### PR TITLE
Fix status exit code to return non-zero when stopped

### DIFF
--- a/rpms/el5/SOURCES/foreman.init
+++ b/rpms/el5/SOURCES/foreman.init
@@ -123,13 +123,13 @@ case "$1" in
             echo
             RETVAL=1
         else
+            RETVAL=1
             for PID in $FOREMAN_PID
             do
-                RETVAL=${RETVAL:-0}
                 status -p $PID
+                RETURN=$? && [ "$RETVAL" != 0 ] && RETVAL=$RETURN
             done
         fi
-        RETVAL=${RETVAL:-1}
     ;;
     condrestart)
         if [ -f ${FOREMAN_HOME}/tmp/pids/server.pid ]; then

--- a/rpms/el6/SOURCES/foreman.init
+++ b/rpms/el6/SOURCES/foreman.init
@@ -123,13 +123,13 @@ case "$1" in
             echo
             RETVAL=1
         else
+            RETVAL=1
             for PID in $FOREMAN_PID
             do
-                RETVAL=${RETVAL:-0}
                 status -p $PID
+                RETURN=$? && [ "$RETVAL" != 0 ] && RETVAL=$RETURN
             done
         fi
-        RETVAL=${RETVAL:-1}
     ;;
     condrestart)
         if [ -f ${FOREMAN_HOME}/tmp/pids/server.pid ]; then

--- a/rpms/f16/SOURCES/foreman.init
+++ b/rpms/f16/SOURCES/foreman.init
@@ -123,13 +123,13 @@ case "$1" in
             echo
             RETVAL=1
         else
+            RETVAL=1
             for PID in $FOREMAN_PID
             do
-                RETVAL=${RETVAL:-0}
                 status -p $PID
+                RETURN=$? && [ "$RETVAL" != 0 ] && RETVAL=$RETURN
             done
         fi
-        RETVAL=${RETVAL:-1}
     ;;
     condrestart)
         if [ -f ${FOREMAN_HOME}/tmp/pids/server.pid ]; then

--- a/rpms/f17/SOURCES/foreman.init
+++ b/rpms/f17/SOURCES/foreman.init
@@ -123,13 +123,13 @@ case "$1" in
             echo
             RETVAL=1
         else
+            RETVAL=1
             for PID in $FOREMAN_PID
             do
-                RETVAL=${RETVAL:-0}
                 status -p $PID
+                RETURN=$? && [ "$RETVAL" != 0 ] && RETVAL=$RETURN
             done
         fi
-        RETVAL=${RETVAL:-1}
     ;;
     condrestart)
         if [ -f ${FOREMAN_HOME}/tmp/pids/server.pid ]; then


### PR DESCRIPTION
init script's status action wasn't LSB compliant, so broke foreman-installer which checks it via puppet
