### PR TITLE
Add commented Puppet defaults to proxy configs, ref #1983

### DIFF
--- a/debian/precise/nightly/foreman-proxy/settings.yml
+++ b/debian/precise/nightly/foreman-proxy/settings.yml
@@ -51,9 +51,12 @@
 
 # enable PuppetCA management
 :puppetca: false
+#:ssldir: /var/lib/puppet/ssl
+#:puppetdir: /etc/puppet
 
 # enable Puppet management
 :puppet: false
+#:puppet_conf: /etc/puppet/puppet.conf
 
 # Where our proxy log files are stored
 # filename or STDOUT

--- a/debian/precise/stable/foreman-proxy/settings.yml
+++ b/debian/precise/stable/foreman-proxy/settings.yml
@@ -51,9 +51,12 @@
 
 # enable PuppetCA management
 :puppetca: false
+#:ssldir: /var/lib/puppet/ssl
+#:puppetdir: /etc/puppet
 
 # enable Puppet management
 :puppet: false
+#:puppet_conf: /etc/puppet/puppet.conf
 
 # Where our proxy log files are stored
 # filename or STDOUT

--- a/debian/squeeze/nightly/foreman-proxy/settings.yml
+++ b/debian/squeeze/nightly/foreman-proxy/settings.yml
@@ -51,9 +51,12 @@
 
 # enable PuppetCA management
 :puppetca: false
+#:ssldir: /var/lib/puppet/ssl
+#:puppetdir: /etc/puppet
 
 # enable Puppet management
 :puppet: false
+#:puppet_conf: /etc/puppet/puppet.conf
 
 # Where our proxy log files are stored
 # filename or STDOUT

--- a/debian/squeeze/stable/foreman-proxy/settings.yml
+++ b/debian/squeeze/stable/foreman-proxy/settings.yml
@@ -51,9 +51,12 @@
 
 # enable PuppetCA management
 :puppetca: false
+#:ssldir: /var/lib/puppet/ssl
+#:puppetdir: /etc/puppet
 
 # enable Puppet management
 :puppet: false
+#:puppet_conf: /etc/puppet/puppet.conf
 
 # Where our proxy log files are stored
 # filename or STDOUT


### PR DESCRIPTION
Change configs to match the ones distributed in smart-proxy itself, displaying the defaults the code uses.
