### PR TITLE
Discard cron output, messages and summaries from tasks

### DIFF
--- a/debian/precise/nightly/foreman/foreman.cron.d
+++ b/debian/precise/nightly/foreman/foreman.cron.d
@@ -5,24 +5,24 @@ RAILS_ENV=production
 FOREMAN_HOME=/usr/share/foreman
 
 # Clean up the session entries in the database
-15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear
+15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear >/var/log/foreman/cron.log 2>&1
 
 # Send out daily summary
-0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize
+0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize >/var/log/foreman/cron.log 2>&1
 
 # Expire old reports
-30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire
+30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire >/var/log/foreman/cron.log 2>&1
 
 # Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter >/var/log/foreman/cron.log 2>&1
 
 
 # Only use the following cronjob if you're using stored configs!
 # Populate hosts
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts >/var/log/foreman/cron.log 2>&1
 
 
 # Only uncomment the following cronjob if you're not using stored configs!
 # Send facts to Foreman.
-#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb
+#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb >/var/log/foreman/cron.log 2>&1
 

--- a/debian/precise/rc/foreman/foreman.cron.d
+++ b/debian/precise/rc/foreman/foreman.cron.d
@@ -5,24 +5,24 @@ RAILS_ENV=production
 FOREMAN_HOME=/usr/share/foreman
 
 # Clean up the session entries in the database
-15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear
+15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear >/var/log/foreman/cron.log 2>&1
 
 # Send out daily summary
-0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize
+0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize >/var/log/foreman/cron.log 2>&1
 
 # Expire old reports
-30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire
+30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire >/var/log/foreman/cron.log 2>&1
 
 # Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter >/var/log/foreman/cron.log 2>&1
 
 
 # Only use the following cronjob if you're using stored configs!
 # Populate hosts
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts >/var/log/foreman/cron.log 2>&1
 
 
 # Only uncomment the following cronjob if you're not using stored configs!
 # Send facts to Foreman.
-#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb
+#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb >/var/log/foreman/cron.log 2>&1
 

--- a/debian/precise/stable/foreman/foreman.cron.d
+++ b/debian/precise/stable/foreman/foreman.cron.d
@@ -5,24 +5,24 @@ RAILS_ENV=production
 FOREMAN_HOME=/usr/share/foreman
 
 # Clean up the session entries in the database
-15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear
+15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear >/var/log/foreman/cron.log 2>&1
 
 # Send out daily summary
-0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize
+0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize >/var/log/foreman/cron.log 2>&1
 
 # Expire old reports
-30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire
+30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire >/var/log/foreman/cron.log 2>&1
 
 # Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter >/var/log/foreman/cron.log 2>&1
 
 
 # Only use the following cronjob if you're using stored configs!
 # Populate hosts
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts >/var/log/foreman/cron.log 2>&1
 
 
 # Only uncomment the following cronjob if you're not using stored configs!
 # Send facts to Foreman.
-#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb
+#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb >/var/log/foreman/cron.log 2>&1
 

--- a/debian/squeeze/nightly/foreman/foreman.cron.d
+++ b/debian/squeeze/nightly/foreman/foreman.cron.d
@@ -5,24 +5,24 @@ RAILS_ENV=production
 FOREMAN_HOME=/usr/share/foreman
 
 # Clean up the session entries in the database
-15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear
+15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear >/var/log/foreman/cron.log 2>&1
 
 # Send out daily summary
-0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize
+0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize >/var/log/foreman/cron.log 2>&1
 
 # Expire old reports
-30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire
+30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire >/var/log/foreman/cron.log 2>&1
 
 # Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter >/var/log/foreman/cron.log 2>&1
 
 
 # Only use the following cronjob if you're using stored configs!
 # Populate hosts
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts >/var/log/foreman/cron.log 2>&1
 
 
 # Only uncomment the following cronjob if you're not using stored configs!
 # Send facts to Foreman.
-#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb
+#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb >/var/log/foreman/cron.log 2>&1
 

--- a/debian/squeeze/rc/foreman/foreman.cron.d
+++ b/debian/squeeze/rc/foreman/foreman.cron.d
@@ -5,24 +5,24 @@ RAILS_ENV=production
 FOREMAN_HOME=/usr/share/foreman
 
 # Clean up the session entries in the database
-15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear
+15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear >/var/log/foreman/cron.log 2>&1
 
 # Send out daily summary
-0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize
+0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize >/var/log/foreman/cron.log 2>&1
 
 # Expire old reports
-30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire
+30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire >/var/log/foreman/cron.log 2>&1
 
 # Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter >/var/log/foreman/cron.log 2>&1
 
 
 # Only use the following cronjob if you're using stored configs!
 # Populate hosts
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts >/var/log/foreman/cron.log 2>&1
 
 
 # Only uncomment the following cronjob if you're not using stored configs!
 # Send facts to Foreman.
-#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb
+#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb >/var/log/foreman/cron.log 2>&1
 

--- a/debian/squeeze/stable/foreman/foreman.cron.d
+++ b/debian/squeeze/stable/foreman/foreman.cron.d
@@ -5,24 +5,24 @@ RAILS_ENV=production
 FOREMAN_HOME=/usr/share/foreman
 
 # Clean up the session entries in the database
-15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear
+15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear >/var/log/foreman/cron.log 2>&1
 
 # Send out daily summary
-0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize
+0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize >/var/log/foreman/cron.log 2>&1
 
 # Expire old reports
-30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire
+30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire >/var/log/foreman/cron.log 2>&1
 
 # Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter >/var/log/foreman/cron.log 2>&1
 
 
 # Only use the following cronjob if you're using stored configs!
 # Populate hosts
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts >/var/log/foreman/cron.log 2>&1
 
 
 # Only uncomment the following cronjob if you're not using stored configs!
 # Send facts to Foreman.
-#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb
+#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb >/var/log/foreman/cron.log 2>&1
 

--- a/rpms/epel-5/SOURCES/foreman.cron.d
+++ b/rpms/epel-5/SOURCES/foreman.cron.d
@@ -5,24 +5,24 @@ RAILS_ENV=production
 FOREMAN_HOME=/usr/share/foreman
 
 # Clean up the session entries in the database
-15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear
+15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear >/var/log/foreman/cron.log 2>&1
 
 # Send out daily summary
-0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize
+0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize >/var/log/foreman/cron.log 2>&1
 
 # Expire old reports
-30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire
+30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire >/var/log/foreman/cron.log 2>&1
 
 # Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter >/var/log/foreman/cron.log 2>&1
 
 
 # Only use the following cronjob if you're using stored configs!
 # Populate hosts
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts >/var/log/foreman/cron.log 2>&1
 
 
 # Only uncomment the following cronjob if you're not using stored configs!
 # Send facts to Foreman.
-#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb
+#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb >/var/log/foreman/cron.log 2>&1
 

--- a/rpms/epel-6/SOURCES/foreman.cron.d
+++ b/rpms/epel-6/SOURCES/foreman.cron.d
@@ -5,24 +5,24 @@ RAILS_ENV=production
 FOREMAN_HOME=/usr/share/foreman
 
 # Clean up the session entries in the database
-15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear
+15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear >/var/log/foreman/cron.log 2>&1
 
 # Send out daily summary
-0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize
+0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize >/var/log/foreman/cron.log 2>&1
 
 # Expire old reports
-30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire
+30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire >/var/log/foreman/cron.log 2>&1
 
 # Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter >/var/log/foreman/cron.log 2>&1
 
 
 # Only use the following cronjob if you're using stored configs!
 # Populate hosts
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts >/var/log/foreman/cron.log 2>&1
 
 
 # Only uncomment the following cronjob if you're not using stored configs!
 # Send facts to Foreman.
-#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb
+#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb >/var/log/foreman/cron.log 2>&1
 

--- a/rpms/fedora-16/SOURCES/foreman.cron.d
+++ b/rpms/fedora-16/SOURCES/foreman.cron.d
@@ -5,24 +5,24 @@ RAILS_ENV=production
 FOREMAN_HOME=/usr/share/foreman
 
 # Clean up the session entries in the database
-15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear
+15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear >/var/log/foreman/cron.log 2>&1
 
 # Send out daily summary
-0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize
+0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize >/var/log/foreman/cron.log 2>&1
 
 # Expire old reports
-30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire
+30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire >/var/log/foreman/cron.log 2>&1
 
 # Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter >/var/log/foreman/cron.log 2>&1
 
 
 # Only use the following cronjob if you're using stored configs!
 # Populate hosts
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts >/var/log/foreman/cron.log 2>&1
 
 
 # Only uncomment the following cronjob if you're not using stored configs!
 # Send facts to Foreman.
-#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb
+#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb >/var/log/foreman/cron.log 2>&1
 

--- a/rpms/fedora-17/SOURCES/foreman.cron.d
+++ b/rpms/fedora-17/SOURCES/foreman.cron.d
@@ -5,24 +5,24 @@ RAILS_ENV=production
 FOREMAN_HOME=/usr/share/foreman
 
 # Clean up the session entries in the database
-15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear
+15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear >/var/log/foreman/cron.log 2>&1
 
 # Send out daily summary
-0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize
+0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize >/var/log/foreman/cron.log 2>&1
 
 # Expire old reports
-30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire
+30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire >/var/log/foreman/cron.log 2>&1
 
 # Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter >/var/log/foreman/cron.log 2>&1
 
 
 # Only use the following cronjob if you're using stored configs!
 # Populate hosts
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts >/var/log/foreman/cron.log 2>&1
 
 
 # Only uncomment the following cronjob if you're not using stored configs!
 # Send facts to Foreman.
-#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb
+#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb >/var/log/foreman/cron.log 2>&1
 


### PR DESCRIPTION
@lzap found it's filling up the foreman user's mailbox.  In particular the warning from Foreman that libvirt bindings aren't installed and `puppet:migrate:populate_hosts` which prints a summary after executing.
