### PR TITLE
Standardise logrotate configs

### DIFF
--- a/rpms/epel-5/SOURCES/foreman.logrotate
+++ b/rpms/epel-5/SOURCES/foreman.logrotate
@@ -1,12 +1,10 @@
-/var/log/foreman/*log {
-  missingok
-  notifempty
-  create 0644 foreman foreman
-  sharedscripts
-  rotate 5
-  compress
+# Foreman logs:
+/var/log/foreman/*.log {
   daily
-  postrotate
-    /sbin/service foreman condrestart >/dev/null 2>&1 || true
-  endscript
+  missingok
+  rotate 14
+  compress
+  delaycompress
+  notifempty
+  copytruncate
 }

--- a/rpms/epel-6/SOURCES/foreman.logrotate
+++ b/rpms/epel-6/SOURCES/foreman.logrotate
@@ -1,12 +1,10 @@
-/var/log/foreman/*log {
-  missingok
-  notifempty
-  create 0644 foreman foreman
-  sharedscripts
-  rotate 5
-  compress
+# Foreman logs:
+/var/log/foreman/*.log {
   daily
-  postrotate
-    /sbin/service foreman condrestart >/dev/null 2>&1 || true
-  endscript
+  missingok
+  rotate 14
+  compress
+  delaycompress
+  notifempty
+  copytruncate
 }

--- a/rpms/fedora-16/SOURCES/foreman.logrotate
+++ b/rpms/fedora-16/SOURCES/foreman.logrotate
@@ -1,12 +1,10 @@
-/var/log/foreman/*log {
+# Foreman logs:
+/var/log/foreman/*.log {
+  daily
   missingok
-  notifempty
-  create 0644 foreman foreman
-  sharedscripts
-  rotate 5
+  rotate 14
   compress
-	daily
-  postrotate
-    [ -e /etc/init.d/foreman ] && /etc/init.d/foreman condrestart >/dev/null 2>&1 || true
-  endscript
+  delaycompress
+  notifempty
+  copytruncate
 }

--- a/rpms/fedora-17/SOURCES/foreman.logrotate
+++ b/rpms/fedora-17/SOURCES/foreman.logrotate
@@ -1,12 +1,10 @@
-/var/log/foreman/*log {
+# Foreman logs:
+/var/log/foreman/*.log {
+  daily
   missingok
-  notifempty
-  create 0644 foreman foreman
-  sharedscripts
-  rotate 5
+  rotate 14
   compress
-	daily
-  postrotate
-    [ -e /etc/init.d/foreman ] && /etc/init.d/foreman condrestart >/dev/null 2>&1 || true
-  endscript
+  delaycompress
+  notifempty
+  copytruncate
 }


### PR DESCRIPTION
Includes "copytruncate" so Rails logs can be rotated without needing to
restart the app.

The main driver for this is we don't restart the Foreman if running under Passenger today, so after log rotation, we don't get any logging.

I've simply copied the Debian logrotate configs over all the RPM configs, as it seems to have reasonable settings.
