### PR TITLE
Fixed some issues with Fedora 17 building

### DIFF
--- a/rpms/fedora-17/.gitignore
+++ b/rpms/fedora-17/.gitignore
@@ -1,0 +1,2 @@
+*.src.rpm
+*.gem

--- a/rpms/fedora-17/SPECS/rubygem-actionmailer.spec
+++ b/rpms/fedora-17/SPECS/rubygem-actionmailer.spec
@@ -10,7 +10,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://www.rubyonrails.org
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Patch0: 0001-rubygem-actionmailer-fix-dep-versions.patch
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems)

--- a/rpms/fedora-17/SPECS/rubygem-actionpack.spec
+++ b/rpms/fedora-17/SPECS/rubygem-actionpack.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://www.rubyonrails.org
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Patch0: 0001-fix-actionpack-dependencies.patch
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 

--- a/rpms/fedora-17/SPECS/rubygem-activemodel.spec
+++ b/rpms/fedora-17/SPECS/rubygem-activemodel.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://www.rubyonrails.org
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 
 Requires: ruby >= 1.8.7

--- a/rpms/fedora-17/SPECS/rubygem-activerecord.spec
+++ b/rpms/fedora-17/SPECS/rubygem-activerecord.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://www.rubyonrails.org
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 
 Requires: ruby >= 1.8.7

--- a/rpms/fedora-17/SPECS/rubygem-activeresource.spec
+++ b/rpms/fedora-17/SPECS/rubygem-activeresource.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://www.rubyonrails.org
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 
 Requires: ruby >= 1.8.7

--- a/rpms/fedora-17/SPECS/rubygem-activesupport.spec
+++ b/rpms/fedora-17/SPECS/rubygem-activesupport.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://www.rubyonrails.org
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 
 Requires: ruby >= 1.8.7

--- a/rpms/fedora-17/SPECS/rubygem-acts_as_audited.spec
+++ b/rpms/fedora-17/SPECS/rubygem-acts_as_audited.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://github.com/collectiveidea/acts_as_audited
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) >= 1.3.6
 Requires: ruby 

--- a/rpms/fedora-17/SPECS/rubygem-ancestry.spec
+++ b/rpms/fedora-17/SPECS/rubygem-ancestry.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://github.com/stefankroes/ancestry
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 
 Requires: ruby 

--- a/rpms/fedora-17/SPECS/rubygem-arel.spec
+++ b/rpms/fedora-17/SPECS/rubygem-arel.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://github.com/rails/arel
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 
 Requires: ruby 

--- a/rpms/fedora-17/SPECS/rubygem-audited-activerecord.spec
+++ b/rpms/fedora-17/SPECS/rubygem-audited-activerecord.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: https://github.com/collectiveidea/audited
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) > 1.3.1
 Requires: ruby 

--- a/rpms/fedora-17/SPECS/rubygem-audited.spec
+++ b/rpms/fedora-17/SPECS/rubygem-audited.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: https://github.com/collectiveidea/audited
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) > 1.3.1
 Requires: ruby 

--- a/rpms/fedora-17/SPECS/rubygem-excon.spec
+++ b/rpms/fedora-17/SPECS/rubygem-excon.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: https://github.com/geemus/excon
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 
 Requires: ruby 

--- a/rpms/fedora-17/SPECS/rubygem-has_many_polymorphs.spec
+++ b/rpms/fedora-17/SPECS/rubygem-has_many_polymorphs.spec
@@ -9,7 +9,7 @@ Release: 3%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://blog.evanweaver.com/files/doc/fauna/has_many_polymorphs/
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) >= 1.3.6
 Requires: ruby 

--- a/rpms/fedora-17/SPECS/rubygem-jquery-rails.spec
+++ b/rpms/fedora-17/SPECS/rubygem-jquery-rails.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://rubygems.org/gems/jquery-rails
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) >= 1.3.6
 Requires: ruby 

--- a/rpms/fedora-17/SPECS/rubygem-multi_json.spec
+++ b/rpms/fedora-17/SPECS/rubygem-multi_json.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://github.com/intridea/multi_json
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) >= 1.3.6
 Requires: ruby 

--- a/rpms/fedora-17/SPECS/rubygem-mysql.spec
+++ b/rpms/fedora-17/SPECS/rubygem-mysql.spec
@@ -13,9 +13,13 @@ Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 
 Requires: ruby >= 1.8.6
+
 BuildRequires: ruby(abi) = %{rubyabi}
 BuildRequires: rubygems-devel 
 BuildRequires: ruby >= 1.8.6
+BuildRequires: ruby-devel
+BuildRequires: mysql-devel
+
 Provides: rubygem(%{gem_name}) = %{version}
 
 %description

--- a/rpms/fedora-17/SPECS/rubygem-net-ssh.spec
+++ b/rpms/fedora-17/SPECS/rubygem-net-ssh.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://github.com/net-ssh/net-ssh
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 
 Requires: ruby 

--- a/rpms/fedora-17/SPECS/rubygem-pg.spec
+++ b/rpms/fedora-17/SPECS/rubygem-pg.spec
@@ -1,11 +1,11 @@
-# Generated from pg-0.13.2.gem by gem2rpm -*- rpm-spec -*-
+# Generated from pg-%{version}.gem by gem2rpm -*- rpm-spec -*-
 %global gem_name pg
 %global rubyabi 1.9.1
 
 Summary: Pg is the Ruby interface to the {PostgreSQL RDBMS}[http://www.postgresql.org/]
 Name: rubygem-%{gem_name}
 Version: 0.13.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Group: Development/Languages
 License: BSD and Ruby and GPL
 URL: https://bitbucket.org/ged/ruby-pg
@@ -13,9 +13,13 @@ Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 
 Requires: ruby >= 1.8.7
+
 BuildRequires: ruby(abi) = %{rubyabi}
 BuildRequires: rubygems-devel 
 BuildRequires: ruby >= 1.8.7
+BuildRequires: ruby-devel
+BuildRequires: postgresql-devel
+
 Provides: rubygem(%{gem_name}) = %{version}
 
 %description
@@ -61,10 +65,6 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 mkdir -p %{buildroot}%{gem_extdir}/lib
-# TODO: move the extensions
-##mv %{buildroot}%{gem_instdir}/lib/shared_object.so %{buildroot}%{gem_extdir}/lib/
-
-
 
 # Remove the binary extension sources and build leftovers.
 rm -rf %{buildroot}%{geminstdir}/ext
@@ -75,7 +75,7 @@ rm -rf %{buildroot}%{geminstdir}/ext
 %{gem_extdir}
 %exclude %{gem_cache}
 %{gem_spec}
-/usr/share/gems/gems/pg-0.13.2/
+/usr/share/gems/gems/pg-%{version}/
 %files doc
 %doc %{gem_docdir}
 %doc %{gem_instdir}/Manifest.txt
@@ -92,5 +92,7 @@ rm -rf %{buildroot}%{geminstdir}/ext
 %doc %{gem_instdir}/ext/pg_result.c
 
 %changelog
+* Tue Apr 3 2013 shk@redhat.com 0.13.2-2
+- Added required packages for building.
 * Thu Jun 14 2012 jason - 0.13.2-1
 - Initial package

--- a/rpms/fedora-17/SPECS/rubygem-rails.spec
+++ b/rpms/fedora-17/SPECS/rubygem-rails.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://www.rubyonrails.org
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) >= 1.3.6
 Requires: ruby >= 1.8.7

--- a/rpms/fedora-17/SPECS/rubygem-railties.spec
+++ b/rpms/fedora-17/SPECS/rubygem-railties.spec
@@ -8,7 +8,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://www.rubyonrails.org
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 
 Requires: ruby >= 1.8.7

--- a/rpms/fedora-17/SPECS/rubygem-rbovirt.spec
+++ b/rpms/fedora-17/SPECS/rubygem-rbovirt.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: MIT
 URL: http://github.com/abenari/rbovirt
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 
 Requires: ruby 

--- a/rpms/fedora-17/SPECS/rubygem-ruby-libvirt.spec
+++ b/rpms/fedora-17/SPECS/rubygem-ruby-libvirt.spec
@@ -13,9 +13,13 @@ Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 
 Requires: ruby >= 1.8.1
+
 BuildRequires: ruby(abi) = %{rubyabi}
 BuildRequires: rubygems-devel 
 BuildRequires: ruby >= 1.8.1
+BuildRequires: ruby-devel
+BuildRequires: libvirt-devel
+
 Provides: rubygem(%{gem_name}) = %{version}
 
 %description

--- a/rpms/fedora-17/SPECS/rubygem-ruby_parser.spec
+++ b/rpms/fedora-17/SPECS/rubygem-ruby_parser.spec
@@ -1,4 +1,3 @@
-# Generated from ruby_parser-2.3.1.gem by gem2rpm -*- rpm-spec -*-
 %global gem_name ruby_parser
 %global rubyabi 1.9.1
 
@@ -13,9 +12,12 @@ Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems)
 Requires: rubygem(sexp_processor) => 4.1.2
+
 BuildRequires: ruby(abi) = %{rubyabi}
 BuildRequires: rubygems-devel
 BuildRequires: ruby
+BuildRequires: ruby-devel
+
 BuildArch: noarch
 Provides: rubygem(%{gem_name}) = %{version}
 
@@ -75,17 +77,18 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 
 # Drop the standalone mode for tests - won't run that way due to missing
 # rubygems require anyway. One instance in lib as well
-find %{buildroot}/usr/share/gems/gems/ruby_parser-2.3.1/{test,lib} -type f | \
+find %{buildroot}/usr/share/gems/gems/ruby_parser-%{version}/{test,lib} -type f | \
   xargs -n 1 sed -i -e '/^#!\/usr\/.*\/ruby.*/d'
 
 %files
 %dir %{gem_instdir}
 %{_bindir}/ruby_parse
+%{_bindir}/ruby_parse_extract_error
 %{gem_instdir}/bin
 %{gem_libdir}
 %exclude %{gem_cache}
 %{gem_spec}
-/usr/share/gems/gems/ruby_parser-2.3.1/
+/usr/share/gems/gems/ruby_parser-%{version}/
 %files doc
 %doc %{gem_docdir}
 %doc %{gem_instdir}/History.txt

--- a/rpms/fedora-17/SPECS/rubygem-scoped_search.spec
+++ b/rpms/fedora-17/SPECS/rubygem-scoped_search.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://github.com/wvanbergen/scoped_search/wiki
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 
 Requires: ruby 

--- a/rpms/fedora-17/SPECS/rubygem-sexp_processor.spec
+++ b/rpms/fedora-17/SPECS/rubygem-sexp_processor.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: https://github.com/seattlerb/sexp_processor
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems)
 BuildRequires: ruby(abi) = %{rubyabi}
@@ -69,7 +69,7 @@ find %{buildroot}/usr/share/gems/gems/sexp_processor-%{version}/ -type f | \
 %doc %{gem_instdir}/README.txt
 
 %changelog
-* Thu Jan 3 2012 shk@redhat.com - 4.1.2-1
+* Thu Jan 3 2013 shk@redhat.com - 4.1.2-1
 - Updated to 4.1.2
 * Thu Jun 14 2012 jason - 3.1.0-1
 - Initial package

--- a/rpms/fedora-17/SPECS/rubygem-tzinfo.spec
+++ b/rpms/fedora-17/SPECS/rubygem-tzinfo.spec
@@ -9,7 +9,7 @@ Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby
 URL: http://tzinfo.rubyforge.org/
-Source0: %{gem_name}-%{version}.gem
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems) 
 Requires: ruby 


### PR DESCRIPTION
This pull request files a few problems with building foreman and dependencies on Fedora 17:
1. Add remote sources for all the gems so `spectool` can be used to do mass rebuilds in an automated fashion.
2. Fixed a dumb changelog typo (2012 vs. 2013)
3. Added a couple `BuildRequires` that were missing for some reason
