### PR TITLE
Redirect cron output, messages and summaries from tasks to cron.log

### DIFF
--- a/debian/precise/foreman/foreman.cron.d
+++ b/debian/precise/foreman/foreman.cron.d
@@ -5,24 +5,24 @@ RAILS_ENV=production
 FOREMAN_HOME=/usr/share/foreman
 
 # Clean up the session entries in the database
-15 23 * * *     foreman    cd ${FOREMAN_HOME} && bundle exec /usr/bin/rake db:sessions:clear
+15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear >/var/log/foreman/cron.log 2>&1
 
 # Send out daily summary
-0 7 * * *       foreman    cd ${FOREMAN_HOME} && bundle exec /usr/bin/rake reports:summarize
+0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize >/var/log/foreman/cron.log 2>&1
 
 # Expire old reports
-30 7 * * *      foreman    cd ${FOREMAN_HOME} && bundle exec /usr/bin/rake reports:expire
+30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire >/var/log/foreman/cron.log 2>&1
 
 # Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && bundle exec /usr/bin/rake trends:counter
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter >/var/log/foreman/cron.log 2>&1
 
+# Only use the following cronjob if you're not using the ENC or ActiveRecord-based storeconfigs
+# Get the node.rb / ENC script and store at /etc/puppet/node.rb:
+#   https://github.com/theforeman/puppet-foreman/blob/master/templates/external_node.rb.erb
+# Send facts to Foreman, using the ENC script in a fact pushing only mode
+#*/2 * * * *     puppet     /etc/puppet/node.rb --push-facts >/var/log/foreman/cron.log 2>&1
 
-# Only use the following cronjob if you're using stored configs!
-# Populate hosts
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && bundle exec /usr/bin/rake puppet:migrate:populate_hosts
-
-
-# Only uncomment the following cronjob if you're not using stored configs!
-# Send facts to Foreman.
-#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb
-
+# Warning: ActiveRecord-based storeconfigs is deprecated from Foreman 1.1 and Puppet 3.0
+#   see http://projects.theforeman.org/wiki/foreman/ReleaseNotes#11-stable
+# Only use the following cronjob if you're using ActiveRecord storeconfigs!
+#*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts >/var/log/foreman/cron.log 2>&1

--- a/debian/squeeze/foreman/foreman.cron.d
+++ b/debian/squeeze/foreman/foreman.cron.d
@@ -5,24 +5,24 @@ RAILS_ENV=production
 FOREMAN_HOME=/usr/share/foreman
 
 # Clean up the session entries in the database
-15 23 * * *     foreman    cd ${FOREMAN_HOME} && bundle exec /usr/bin/rake db:sessions:clear
+15 23 * * *     foreman    cd ${FOREMAN_HOME} && /usr/bin/rake db:sessions:clear >/var/log/foreman/cron.log 2>&1
 
 # Send out daily summary
-0 7 * * *       foreman    cd ${FOREMAN_HOME} && bundle exec /usr/bin/rake reports:summarize
+0 7 * * *       foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:summarize >/var/log/foreman/cron.log 2>&1
 
 # Expire old reports
-30 7 * * *      foreman    cd ${FOREMAN_HOME} && bundle exec /usr/bin/rake reports:expire
+30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/bin/rake reports:expire >/var/log/foreman/cron.log 2>&1
 
 # Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && bundle exec /usr/bin/rake trends:counter
+*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake trends:counter >/var/log/foreman/cron.log 2>&1
 
+# Only use the following cronjob if you're not using the ENC or ActiveRecord-based storeconfigs
+# Get the node.rb / ENC script and store at /etc/puppet/node.rb:
+#   https://github.com/theforeman/puppet-foreman/blob/master/templates/external_node.rb.erb
+# Send facts to Foreman, using the ENC script in a fact pushing only mode
+#*/2 * * * *     puppet     /etc/puppet/node.rb --push-facts >/var/log/foreman/cron.log 2>&1
 
-# Only use the following cronjob if you're using stored configs!
-# Populate hosts
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && bundle exec /usr/bin/rake puppet:migrate:populate_hosts
-
-
-# Only uncomment the following cronjob if you're not using stored configs!
-# Send facts to Foreman.
-#*/2 * * * *    puppet     ${FOREMAN_HOME}/extras/puppet/foreman/files/push_facts.rb
-
+# Warning: ActiveRecord-based storeconfigs is deprecated from Foreman 1.1 and Puppet 3.0
+#   see http://projects.theforeman.org/wiki/foreman/ReleaseNotes#11-stable
+# Only use the following cronjob if you're using ActiveRecord storeconfigs!
+#*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/bin/rake puppet:migrate:populate_hosts >/var/log/foreman/cron.log 2>&1


### PR DESCRIPTION
Disable storeconfigs cron by default, add deprecation warning

Update push_facts.rb to ENC node.rb --push-facts.

(Debian equivalent of #34)
