### PR TITLE
Depend on ruby1.9.1-dev instead of ruby-dev which could be provided by another version of Ruby

### DIFF
--- a/debian/wheezy/foreman/control
+++ b/debian/wheezy/foreman/control
@@ -13,7 +13,7 @@ Architecture: any
 Section: web
 Priority: extra
 Depends: ruby1.9.1, bundler (>= 1.1),
-         ruby-dev, gcc, make,
+         ruby1.9.1-dev, gcc, make,
          puppet (>=0.24.4), rake (>=0.8.4), ${misc:Depends}
 Recommends: foreman-proxy
 Description: Systems management web interface


### PR DESCRIPTION
Without this installation failed while installing json:

ERROR:  Error installing json:
    ERROR: Failed to build gem native extension.

```
    /usr/bin/ruby1.9.1 extconf.rb
```

/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- mkmf (LoadError)
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in`require'
    from extconf.rb:1:in `<main>'

Gem files will remain installed in /var/lib/gems/1.9.1/gems/json-1.8.0 for inspection.
Results logged to /var/lib/gems/1.9.1/gems/json-1.8.0/ext/json/ext/generator/gem_make.out
