### PR TITLE
 Fix nightly builds not being recognised as such in setup_build 

### DIFF
--- a/debian/buildscripts/build.sh
+++ b/debian/buildscripts/build.sh
@@ -44,7 +44,7 @@ $GIT submodule update
 mv "${BUILD_DIR}/debian" "${TARGET}/"
 
 # Cleanup source
-setup_build
+setup_build $*
 rm -rf $(/usr/bin/find "${TARGET}" -name '.git*')
 
 if [ "$PBUILDER" != "local" ] ; then


### PR DESCRIPTION
It appears that nightly builds aren't getting published:
http://deb.theforeman.org/pool/wheezy/nightly/f/foreman/ (just stable releases)

I see in the logs that setup_build doesn't think they're nightly builds:
http://ci.theforeman.org/job/packaging_build_foreman_individual-DEB/1825/console

<pre>
+ ../../buildscripts/build.sh wheezy64 nightly
Cloning into /var/lib/workspace/workspace/packaging_build_foreman_individual-DEB/debian/wheezy/wheezy64/foreman...
Already on 'develop'
not nightly: skipped setup_build
</pre>


Hopefully this'll do the trick.
