### PR TITLE
Add foreigner + immigrant for foreign key support

### DIFF
--- a/comps/comps-foreman-fedora18.xml
+++ b/comps/comps-foreman-fedora18.xml
@@ -49,6 +49,7 @@
       <packagereq type="default">rubygem-hammer_cli_katello_bridge</packagereq>
       <packagereq type="default">rubygem-hirb-unicode</packagereq>
       <packagereq type="default">rubygem-hirb</packagereq>
+      <packagereq type="default">rubygem-immigrant</packagereq>
       <packagereq type="default">rubygem-jquery-ui-rails</packagereq>
       <packagereq type="default">rubygem-kafo</packagereq>
       <packagereq type="default">rubygem-less-rails</packagereq>

--- a/comps/comps-foreman-fedora19.xml
+++ b/comps/comps-foreman-fedora19.xml
@@ -47,6 +47,7 @@
       <packagereq type="default">rubygem-hammer_cli_katello_bridge</packagereq>
       <packagereq type="default">rubygem-hirb-unicode</packagereq>
       <packagereq type="default">rubygem-hirb</packagereq>
+      <packagereq type="default">rubygem-immigrant</packagereq>
       <packagereq type="default">rubygem-jquery-ui-rails</packagereq>
       <packagereq type="default">rubygem-kafo</packagereq>
       <packagereq type="default">rubygem-less-rails</packagereq>

--- a/comps/comps-foreman-rhel6.xml
+++ b/comps/comps-foreman-rhel6.xml
@@ -74,6 +74,7 @@
       <packagereq type="default">ruby193-rubygem-ffi</packagereq>
       <packagereq type="default">ruby193-rubygem-flot-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-fog</packagereq>
+      <packagereq type="default">ruby193-rubygem-foreigner</packagereq>
       <packagereq type="default">ruby193-rubygem-foremancli</packagereq>
       <packagereq type="default">ruby193-rubygem-formatador</packagereq>
       <packagereq type="default">ruby193-rubygem-gettext</packagereq>


### PR DESCRIPTION
Foreigner is a core dependency, but is provided in Fedora, so only needed on EL6.

Immigrant is a -devel dependency, and since we only ship -devel for non-SCL, it's only needed on Fedora.
