### PR TITLE
hammer_cli - fixed rest-client library for squeeze

### DIFF
--- a/dependencies/squeeze/hammer_cli/control
+++ b/dependencies/squeeze/hammer_cli/control
@@ -12,7 +12,7 @@ Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-clamp,
-         ruby-rest-client,
+         librestclient-ruby,
          ruby-logging,
          ruby-table-print,
          ruby-awesome-print,


### PR DESCRIPTION
Provides correct dependency on rest client library.
http://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=librestclient
