### PR TITLE
Add google-api-client + deps

### DIFF
--- a/comps/comps-foreman-fedora19.xml
+++ b/comps/comps-foreman-fedora19.xml
@@ -31,16 +31,20 @@
 
       <packagereq type="default">rubygem-ansi</packagereq>
       <packagereq type="default">rubygem-apipie-rails</packagereq>
+      <packagereq type="default">rubygem-autoparse</packagereq>
       <packagereq type="default">rubygem-bundler_ext</packagereq>
       <packagereq type="default">rubygem-clamp</packagereq>
       <packagereq type="default">rubygem-commonjs</packagereq>
       <packagereq type="default">rubygem-excon</packagereq>
+      <packagereq type="default">rubygem-extlib</packagereq>
+      <packagereq type="default">rubygem-faraday</packagereq>
       <packagereq type="default">rubygem-fast_gettext</packagereq>
       <packagereq type="default">rubygem-flot-rails</packagereq>
       <packagereq type="default">rubygem-fog</packagereq>
       <packagereq type="default">rubygem-foremancli</packagereq>
       <packagereq type="default">rubygem-gettext_i18n_rails</packagereq>
       <packagereq type="default">rubygem-gettext_i18n_rails_js</packagereq>
+      <packagereq type="default">rubygem-google-api-client</packagereq>
       <packagereq type="default">rubygem-hammer_cli</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman</packagereq>
       <packagereq type="default">rubygem-hammer_cli_katello</packagereq>
@@ -49,7 +53,9 @@
       <packagereq type="default">rubygem-hirb</packagereq>
       <packagereq type="default">rubygem-immigrant</packagereq>
       <packagereq type="default">rubygem-jquery-ui-rails</packagereq>
+      <packagereq type="default">rubygem-jwt</packagereq>
       <packagereq type="default">rubygem-kafo</packagereq>
+      <packagereq type="default">rubygem-launchy</packagereq>
       <packagereq type="default">rubygem-less-rails</packagereq>
       <packagereq type="default">rubygem-less</packagereq>
       <packagereq type="default">rubygem-libv8</packagereq>
@@ -66,6 +72,7 @@
       <packagereq type="default">rubygem-ruby2ruby</packagereq>
       <packagereq type="default">rubygem-rubyipmi</packagereq>
       <packagereq type="default">rubygem-safemode</packagereq>
+      <packagereq type="default">rubygem-signet</packagereq>
       <packagereq type="default">rubygem-single_test</packagereq>
       <packagereq type="default">rubygem-spice-html5-rails</packagereq>
       <packagereq type="default">rubygem-table_print</packagereq>

--- a/comps/comps-foreman-rhel6.xml
+++ b/comps/comps-foreman-rhel6.xml
@@ -44,12 +44,14 @@
       <packagereq type="default">ruby193-rubygem-activerecord</packagereq>
       <packagereq type="default">ruby193-rubygem-activeresource</packagereq>
       <packagereq type="default">ruby193-rubygem-activesupport</packagereq>
+      <packagereq type="default">ruby193-rubygem-addressable</packagereq>
       <packagereq type="default">ruby193-rubygem-ancestry</packagereq>
       <packagereq type="default">ruby193-rubygem-apipie-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-arel</packagereq>
       <packagereq type="default">ruby193-rubygem-audited-activerecord</packagereq>
       <packagereq type="default">ruby193-rubygem-audited</packagereq>
       <packagereq type="default">ruby193-rubygem-augeas</packagereq>
+      <packagereq type="default">ruby193-rubygem-autoparse</packagereq>
       <packagereq type="default">ruby193-rubygem-awesome_print</packagereq>
       <packagereq type="default">ruby193-rubygem-bigdecimal</packagereq>
       <packagereq type="default">ruby193-rubygem-builder</packagereq>
@@ -66,6 +68,8 @@
       <packagereq type="default">ruby193-rubygem-eventmachine</packagereq>
       <packagereq type="default">ruby193-rubygem-excon</packagereq>
       <packagereq type="default">ruby193-rubygem-execjs</packagereq>
+      <packagereq type="default">ruby193-rubygem-extlib</packagereq>
+      <packagereq type="default">ruby193-rubygem-faraday</packagereq>
       <packagereq type="default">ruby193-rubygem-fast_gettext</packagereq>
       <packagereq type="default">ruby193-rubygem-ffi</packagereq>
       <packagereq type="default">ruby193-rubygem-flot-rails</packagereq>
@@ -76,6 +80,7 @@
       <packagereq type="default">ruby193-rubygem-gettext</packagereq>
       <packagereq type="default">ruby193-rubygem-gettext_i18n_rails</packagereq>
       <packagereq type="default">ruby193-rubygem-gettext_i18n_rails_js</packagereq>
+      <packagereq type="default">ruby193-rubygem-google-api-client</packagereq>
       <packagereq type="default">ruby193-rubygem-hike</packagereq>
       <packagereq type="default">ruby193-rubygem-hirb-unicode</packagereq>
       <packagereq type="default">ruby193-rubygem-hirb</packagereq>
@@ -86,6 +91,8 @@
       <packagereq type="default">ruby193-rubygem-jquery-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-jquery-ui-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-json</packagereq>
+      <packagereq type="default">ruby193-rubygem-jwt</packagereq>
+      <packagereq type="default">ruby193-rubygem-launchy</packagereq>
       <packagereq type="default">ruby193-rubygem-less</packagereq>
       <packagereq type="default">ruby193-rubygem-less-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-levenshtein</packagereq>
@@ -98,6 +105,7 @@
       <packagereq type="default">ruby193-rubygem-minitest</packagereq>
       <packagereq type="default">ruby193-rubygem-mocha</packagereq>
       <packagereq type="default">ruby193-rubygem-multi_json</packagereq>
+      <packagereq type="default">ruby193-rubygem-multipart-post</packagereq>
       <packagereq type="default">ruby193-rubygem-mysql2</packagereq>
       <packagereq type="default">ruby193-rubygem-mysql</packagereq>
       <packagereq type="default">ruby193-rubygem-net-http-persistent</packagereq>
@@ -141,6 +149,7 @@
       <packagereq type="default">ruby193-rubygem-sexp_processor</packagereq>
       <packagereq type="default">ruby193-rubygem-shadow</packagereq>
       <packagereq type="default">ruby193-rubygem-shoulda</packagereq>
+      <packagereq type="default">ruby193-rubygem-signet</packagereq>
       <packagereq type="default">ruby193-rubygem-single_test</packagereq>
       <packagereq type="default">ruby193-rubygem-spice-html5-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-sprockets</packagereq>


### PR DESCRIPTION
https://rubygems.org/gems/google-api-client/versions/0.6.4

http://koji.katello.org/koji/buildinfo?buildID=7263 (el6)
http://koji.katello.org/koji/buildinfo?buildID=7264 (f19)

addressable:
http://koji.katello.org/koji/buildinfo?buildID=7249
https://apps.fedoraproject.org/packages/rubygem-addressable

autoparse:
http://koji.katello.org/koji/buildinfo?buildID=7252
http://koji.katello.org/koji/buildinfo?buildID=7253

extlib:
http://koji.katello.org/koji/buildinfo?buildID=7250
http://koji.katello.org/koji/buildinfo?buildID=7251

faraday:
http://koji.katello.org/koji/buildinfo?buildID=7255
http://koji.katello.org/koji/buildinfo?buildID=7256

jwt:
http://koji.katello.org/koji/buildinfo?buildID=7257
http://koji.katello.org/koji/buildinfo?buildID=7258

launchy:
http://koji.katello.org/koji/buildinfo?buildID=7259
http://koji.katello.org/koji/buildinfo?buildID=7260 (newer build than f19)

multipart-post:
http://koji.katello.org/koji/buildinfo?buildID=7254
https://apps.fedoraproject.org/packages/rubygem-multipart-post

signet:
http://koji.katello.org/koji/buildinfo?buildID=7261
http://koji.katello.org/koji/buildinfo?buildID=7262
