### PR TITLE
Add sshkey dep for GCE support

### DIFF
--- a/comps/comps-foreman-fedora19.xml
+++ b/comps/comps-foreman-fedora19.xml
@@ -14,6 +14,7 @@
       <packagereq type="default">foreman-compute</packagereq>
       <packagereq type="default">foreman-console</packagereq>
       <packagereq type="default">foreman-devel</packagereq>
+      <packagereq type="default">foreman-gce</packagereq>
       <packagereq type="default">foreman-libvirt</packagereq>
       <packagereq type="default">foreman-mysql2</packagereq>
       <packagereq type="default">foreman-mysql</packagereq>

--- a/comps/comps-foreman-rhel6.xml
+++ b/comps/comps-foreman-rhel6.xml
@@ -14,6 +14,7 @@
       <packagereq type="default">foreman-compute</packagereq>
       <packagereq type="default">foreman-console</packagereq>
       <packagereq type="default">foreman-devel</packagereq>
+      <packagereq type="default">foreman-gce</packagereq>
       <packagereq type="default">foreman-libvirt</packagereq>
       <packagereq type="default">foreman-mysql2</packagereq>
       <packagereq type="default">foreman-mysql</packagereq>


### PR DESCRIPTION
Missed this one from the bundler group..

https://koji.katello.org/koji/buildinfo?buildID=7267 (el6)
https://apps.fedoraproject.org/packages/rubygem-sshkey (f19)
