### PR TITLE
Kafo 0.2.2 for 1.3

### DIFF
--- a/dependencies/precise/kafo/changelog
+++ b/dependencies/precise/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (0.2.2-1) stable; urgency=low
+
+  * Fixes #3789 - remove relative parts of the modulepath (shk@redhat.com)
+
+ -- Marek Hulan <mhulan@redhat.com>  Tue, 03 Dec 2013 09:28:57 +0000
+
 ruby-kafo (0.2.1-1) stable; urgency=low
 
   * Fixes #3227 - restore app options names (mhulan@redhat.com)

--- a/dependencies/squeeze/kafo/changelog
+++ b/dependencies/squeeze/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (0.2.2-1) stable; urgency=low
+
+  * Fixes #3789 - remove relative parts of the modulepath (shk@redhat.com)
+
+ -- Marek Hulan <mhulan@redhat.com>  Tue, 03 Dec 2013 09:28:57 +0000
+
 ruby-kafo (0.2.1-1) stable; urgency=low
 
   * Fixes #3227 - restore app options names (mhulan@redhat.com)

--- a/dependencies/wheezy/kafo/changelog
+++ b/dependencies/wheezy/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (0.2.2-1) stable; urgency=low
+
+  * Fixes #3789 - remove relative parts of the modulepath (shk@redhat.com)
+
+ -- Marek Hulan <mhulan@redhat.com>  Tue, 03 Dec 2013 09:28:57 +0000
+
 ruby-kafo (0.2.1-1) stable; urgency=low
 
   * Fixes #3227 - restore app options names (mhulan@redhat.com)


### PR DESCRIPTION
Kafo 0.2.2 has backported fix for #3789 so should get to 1.3 repo. Scratches are built in my repo, I haven't tested the installation but the fix is confirmed working on RHEL. I think debian has different version of puppet so we didn't encounter this issue but it's fix for future updates.
