### PR TITLE
Add ruby-foreman_api dependency for installer smart proxy registration

### DIFF
--- a/debian/precise/foreman-installer/control
+++ b/debian/precise/foreman-installer/control
@@ -11,6 +11,7 @@ Package: foreman-installer
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
+         ruby-foreman_api,
          ruby-kafo,
          rubygems
 Description: Automated puppet-based installer for The Foreman

--- a/debian/squeeze/foreman-installer/control
+++ b/debian/squeeze/foreman-installer/control
@@ -11,6 +11,7 @@ Package: foreman-installer
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
+         ruby-foreman_api,
          ruby-kafo,
          rubygems
 Description: Automated puppet-based installer for The Foreman


### PR DESCRIPTION
Useful on [pre-2.7.20 versions of Puppet](http://projects.puppetlabs.com/issues/14822) which can't install and pick up the library during the same Puppet run.

I didn't update Wheezy as it ships 2.7.23, so should be immune to this problem.
