### PR TITLE
Fix patch since change to installer config in 8f20e89

### DIFF
--- a/debian/precise/foreman-installer/patches/patch_config_file.diff
+++ b/debian/precise/foreman-installer/patches/patch_config_file.diff
@@ -9,7 +9,7 @@
 +:answer_file: /usr/share/foreman-installer/config/answers.yaml
 +:installer_dir: /usr/share/foreman-installer
  # Uncomment if you want to load puppet modules from a specific path, $pwd/modules is used by default
--:modules_dir: .
+-:modules_dir: ./modules
 +:modules_dir: /usr/share/foreman-installer/modules
  
  ## Kafo tuning, customization of core functionality

--- a/debian/squeeze/foreman-installer/patches/patch_config_file.diff
+++ b/debian/squeeze/foreman-installer/patches/patch_config_file.diff
@@ -9,7 +9,7 @@
 +:answer_file: /usr/share/foreman-installer/config/answers.yaml
 +:installer_dir: /usr/share/foreman-installer
  # Uncomment if you want to load puppet modules from a specific path, $pwd/modules is used by default
--:modules_dir: .
+-:modules_dir: ./modules
 +:modules_dir: /usr/share/foreman-installer/modules
  
  ## Kafo tuning, customization of core functionality

--- a/debian/wheezy/foreman-installer/patches/patch_config_file.diff
+++ b/debian/wheezy/foreman-installer/patches/patch_config_file.diff
@@ -9,7 +9,7 @@
 +:answer_file: /usr/share/foreman-installer/config/answers.yaml
 +:installer_dir: /usr/share/foreman-installer
  # Uncomment if you want to load puppet modules from a specific path, $pwd/modules is used by default
--:modules_dir: .
+-:modules_dir: ./modules
 +:modules_dir: /usr/share/foreman-installer/modules
  
  ## Kafo tuning, customization of core functionality


### PR DESCRIPTION
Apologies, I broke this in https://github.com/theforeman/foreman-installer/commit/8f20e89c69bf2127ee6821abc9c5b1fde68e58e9 which fixed the use of kafo-export-params within the Rakefile/rpmbuild since kafo 0.3.6.

scratch builds: http://ci.theforeman.org/view/Packaging/job/packaging_build_deb_coreproject/308/
