### PR TITLE
Add newer rbvmomi to Fedora 19

### DIFF
--- a/comps/comps-foreman-fedora19.xml
+++ b/comps/comps-foreman-fedora19.xml
@@ -73,6 +73,7 @@
       <packagereq type="default">rubygem-rack-mini-profiler</packagereq>
       <packagereq type="default">rubygem-rails3_before_render</packagereq>
       <packagereq type="default">rubygem-rbovirt</packagereq>
+      <packagereq type="default">rubygem-rbvmomi</packagereq>
       <packagereq type="default">rubygem-rkerberos</packagereq>
       <packagereq type="default">rubygem-ruby2ruby</packagereq>
       <packagereq type="default">rubygem-rubyipmi</packagereq>


### PR DESCRIPTION
I broke repoclosure yesterday merging https://github.com/theforeman/foreman/commit/de0804f0aa6e9aa61a223fb600a0c97d595695e7: http://ci.theforeman.org/job/packaging_repoclosure/7904/console

https://koji.katello.org/koji/buildinfo?buildID=7806

Also requested a new release in Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=1056942
