### PR TITLE
Fixes #4197: Adds 'plugins' directory to /var/log/foreman, /etc/foreman,

### DIFF
--- a/debian/precise/foreman/dirs
+++ b/debian/precise/foreman/dirs
@@ -1,4 +1,7 @@
 etc/foreman
+etc/foreman/plugins
 var/cache/foreman
 var/lib/foreman
+var/lib/foreman/plugins
 var/log/foreman
+var/log/foreman/plugins

--- a/debian/squeeze/foreman/dirs
+++ b/debian/squeeze/foreman/dirs
@@ -1,4 +1,7 @@
 etc/foreman
+etc/foreman/plugins
 var/cache/foreman
 var/lib/foreman
+var/lib/foreman/plugins
 var/log/foreman
+var/log/foreman/plugins

--- a/debian/wheezy/foreman/dirs
+++ b/debian/wheezy/foreman/dirs
@@ -1,4 +1,7 @@
 etc/foreman
+etc/foreman/plugins
 var/cache/foreman
 var/lib/foreman
+var/lib/foreman/plugins
 var/log/foreman
+var/log/foreman/plugins


### PR DESCRIPTION
and /usr/share/foreman to allow plugins to install their own log, config
and other files.
