### PR TITLE
Fixes #4197: Adds 'plugins' directory to /var/log/foreman, /etc/foreman,

### DIFF
--- a/debian/precise/foreman/dirs
+++ b/debian/precise/foreman/dirs
@@ -1,4 +1,7 @@
 etc/foreman
+etc/foreman/plugins
 var/cache/foreman
 var/lib/foreman
+var/lib/foreman/plugins
 var/log/foreman
+var/log/foreman/plugins

--- a/debian/precise/foreman/links
+++ b/debian/precise/foreman/links
@@ -1,6 +1,7 @@
 etc/foreman/database.yml	usr/share/foreman/config/database.yml
 etc/foreman/email.yaml		usr/share/foreman/config/email.yaml
 etc/foreman/settings.yaml	usr/share/foreman/config/settings.yaml
+etc/foreman/plugins		usr/share/foreman/config/settings.plugins.d
 var/cache/foreman		usr/share/foreman/tmp
 var/lib/foreman/db		usr/share/foreman/db
 var/log/foreman			usr/share/foreman/log

--- a/debian/squeeze/foreman/dirs
+++ b/debian/squeeze/foreman/dirs
@@ -1,4 +1,7 @@
 etc/foreman
+etc/foreman/plugins
 var/cache/foreman
 var/lib/foreman
+var/lib/foreman/plugins
 var/log/foreman
+var/log/foreman/plugins

--- a/debian/squeeze/foreman/links
+++ b/debian/squeeze/foreman/links
@@ -1,6 +1,7 @@
 etc/foreman/database.yml	usr/share/foreman/config/database.yml
 etc/foreman/email.yaml		usr/share/foreman/config/email.yaml
 etc/foreman/settings.yaml	usr/share/foreman/config/settings.yaml
+etc/foreman/plugins		usr/share/foreman/config/settings.plugins.d
 var/cache/foreman		usr/share/foreman/tmp
 var/lib/foreman/db		usr/share/foreman/db
 var/log/foreman			usr/share/foreman/log

--- a/debian/wheezy/foreman/dirs
+++ b/debian/wheezy/foreman/dirs
@@ -1,4 +1,7 @@
 etc/foreman
+etc/foreman/plugins
 var/cache/foreman
 var/lib/foreman
+var/lib/foreman/plugins
 var/log/foreman
+var/log/foreman/plugins

--- a/debian/wheezy/foreman/links
+++ b/debian/wheezy/foreman/links
@@ -1,6 +1,7 @@
 etc/foreman/database.yml	usr/share/foreman/config/database.yml
 etc/foreman/email.yaml		usr/share/foreman/config/email.yaml
 etc/foreman/settings.yaml	usr/share/foreman/config/settings.yaml
+etc/foreman/plugins		usr/share/foreman/config/settings.plugins.d
 var/cache/foreman		usr/share/foreman/tmp
 var/lib/foreman/db		usr/share/foreman/db
 var/log/foreman			usr/share/foreman/log


### PR DESCRIPTION
and /usr/share/foreman to allow plugins to install their own log, config
and other files.
