### PR TITLE
Add build-essential to foreman-core deps

### DIFF
--- a/debian/precise/foreman/control
+++ b/debian/precise/foreman/control
@@ -5,7 +5,7 @@ Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 7), cdbs, bundler (>= 1.2), ruby, ruby1.8-dev, git | git-core,
                libxml2-dev, libxslt1-dev, libmysqlclient-dev, libpq-dev, pkg-config,
-               libvirt-dev, libsqlite3-dev, facter
+               libvirt-dev, libsqlite3-dev, facter, build-essential
 Homepage: http://www.theforeman.org/
 
 Package: foreman
@@ -13,7 +13,7 @@ Architecture: any
 Section: web
 Priority: extra
 Depends: rubygems1.8 | ruby1.9.1, bundler (>= 1.2),
-         libxml2-dev, libxslt1-dev, facter,
+         libxml2-dev, libxslt1-dev, facter, build-essential
          rake (>=0.8.4), ${misc:Depends}
 Recommends: foreman-proxy
 Description: Systems management web interface

--- a/debian/squeeze/foreman/control
+++ b/debian/squeeze/foreman/control
@@ -5,7 +5,7 @@ Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 7), cdbs, bundler (>= 1.2), ruby, ruby1.8-dev, git | git-core,
                libxml2-dev, libxslt1-dev, libmysqlclient-dev, libpq-dev, pkg-config,
-               libvirt-dev, libsqlite3-dev, facter
+               libvirt-dev, libsqlite3-dev, facter, build-essential
 Homepage: http://www.theforeman.org/
 
 Package: foreman
@@ -13,7 +13,7 @@ Architecture: any
 Section: web
 Priority: extra
 Depends: rubygems1.8 | ruby1.9.1, bundler (>= 1.2),
-         libxml2-dev, libxslt1-dev, facter,
+         libxml2-dev, libxslt1-dev, facter, build-essential
          rake (>=0.8.4), ${misc:Depends}
 Recommends: foreman-proxy
 Description: Systems management web interface

--- a/debian/wheezy/foreman/control
+++ b/debian/wheezy/foreman/control
@@ -5,7 +5,7 @@ Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 7), cdbs, bundler (>= 1.1), ruby1.9.1-dev, git | git-core,
                libxml2-dev, libxslt1-dev, libmysqlclient-dev, libpq-dev, pkg-config,
-               libvirt-dev, libsqlite3-dev, facter
+               libvirt-dev, libsqlite3-dev, facter, build-essential
 Homepage: http://www.theforeman.org/
 
 Package: foreman
@@ -13,7 +13,7 @@ Architecture: any
 Section: web
 Priority: extra
 Depends: ruby1.9.1, bundler (>= 1.1),
-         ruby1.9.1-dev, gcc, make, facter,
+         ruby1.9.1-dev, facter, build-essential
          rake (>=0.8.4), ${misc:Depends}
 Recommends: foreman-proxy
 Description: Systems management web interface


### PR DESCRIPTION
This was causing a problem on precise but I'm adding it to all OSes to be safe.
