### PR TITLE
add dependency on g++ for foreman-compute

### DIFF
--- a/debian/precise/foreman/control
+++ b/debian/precise/foreman/control
@@ -90,7 +90,7 @@ Priority: extra
 Replaces: foreman-fog
 Provides: foreman-fog
 Conflicts: foreman-fog
-Depends: foreman, libxml2-dev, libxslt1-dev, ${misc:Depends}
+Depends: foreman, libxml2-dev, libxslt1-dev, g++, ${misc:Depends}
 Description: metapackage providing fog dependencies for Foreman (for Amazon EC2 support)
  This package provides fog dependencies for Foreman, a
  flexible systems management web application.

--- a/debian/squeeze/foreman/control
+++ b/debian/squeeze/foreman/control
@@ -90,7 +90,7 @@ Priority: extra
 Replaces: foreman-fog
 Provides: foreman-fog
 Conflicts: foreman-fog
-Depends: foreman, libxml2-dev, libxslt1-dev, ${misc:Depends}
+Depends: foreman, libxml2-dev, libxslt1-dev, g++, ${misc:Depends}
 Description: metapackage providing fog dependencies for Foreman (for Amazon EC2 support)
  This package provides fog dependencies for Foreman, a
  flexible systems management web application.

--- a/debian/wheezy/foreman/control
+++ b/debian/wheezy/foreman/control
@@ -90,7 +90,7 @@ Priority: extra
 Replaces: foreman-fog
 Provides: foreman-fog
 Conflicts: foreman-fog
-Depends: foreman, libxml2-dev, libxslt1-dev, ${misc:Depends}
+Depends: foreman, libxml2-dev, libxslt1-dev, g++, ${misc:Depends}
 Description: metapackage providing fog dependencies for Foreman (for Amazon EC2 support)
  This package provides fog dependencies for Foreman, a
  flexible systems management web application.


### PR DESCRIPTION
otherwise unf_ext can't build it's native extension:

```
Installing unf_ext (0.0.6) with native extensions 
Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

        /usr/bin/ruby1.9.1 extconf.rb 
checking for main() in -lstdc++... no
checking for ruby/encoding.h... yes
creating Makefile

make
compiling unf.cc
make: g++: Command not found
make: *** [unf.o] Error 127
```
