### PR TITLE
Foreman - generate apipie cache on postinstall

### DIFF
--- a/debian/precise/foreman/foreman.postinst
+++ b/debian/precise/foreman/foreman.postinst
@@ -75,6 +75,13 @@ if [ -f /usr/share/foreman/config/database.yml ]; then
   fi
 fi
 
+# Generate apipie cache
+if [ ! -z "${DEBUG}" ]; then
+  /usr/sbin/foreman-rake apipie:cache || true
+else
+  /usr/sbin/foreman-rake apipie:cache >> $LOGFILE 2>&1 || true
+fi
+
 # Generate a static session token for signing cookies
 if [ ! -f config/initializers/local_secret_token.rb ]; then
   touch config/initializers/local_secret_token.rb

--- a/debian/squeeze/foreman/foreman.postinst
+++ b/debian/squeeze/foreman/foreman.postinst
@@ -75,6 +75,13 @@ if [ -f /usr/share/foreman/config/database.yml ]; then
   fi
 fi
 
+# Generate apipie cache
+if [ ! -z "${DEBUG}" ]; then
+  /usr/sbin/foreman-rake apipie:cache || true
+else
+  /usr/sbin/foreman-rake apipie:cache >> $LOGFILE 2>&1 || true
+fi
+
 # Generate a static session token for signing cookies
 if [ ! -f config/initializers/local_secret_token.rb ]; then
   touch config/initializers/local_secret_token.rb

--- a/debian/wheezy/foreman/foreman.postinst
+++ b/debian/wheezy/foreman/foreman.postinst
@@ -75,6 +75,13 @@ if [ -f /usr/share/foreman/config/database.yml ]; then
   fi
 fi
 
+# Generate apipie cache
+if [ ! -z "${DEBUG}" ]; then
+  /usr/sbin/foreman-rake apipie:cache || true
+else
+  /usr/sbin/foreman-rake apipie:cache >> $LOGFILE 2>&1 || true
+fi
+
 # Generate a static session token for signing cookies
 if [ ! -f config/initializers/local_secret_token.rb ]; then
   touch config/initializers/local_secret_token.rb


### PR DESCRIPTION
Generating cache for dynamic bindings. See https://github.com/theforeman/foreman/pull/1265 for details.

Scratchbuilds for testing:
- wheezy: http://ci.theforeman.org/view/Packaging/job/packaging_build_deb_coreproject/507/label=debian,os=wheezy/
- squeeze: http://ci.theforeman.org/view/Packaging/job/packaging_build_deb_coreproject/label=debian,os=squeeze/506/
- precise: http://ci.theforeman.org/view/Packaging/job/packaging_build_deb_coreproject/label=debian,os=precise/506/
