### PR TITLE
add i18n deps to hammer-cli rpm spec and adjust epel 6 comps accordingly

### DIFF
--- a/comps/comps-foreman-rhel6.xml
+++ b/comps/comps-foreman-rhel6.xml
@@ -132,6 +132,7 @@
       <packagereq type="default">rubygem-awesome_print</packagereq>
       <packagereq type="default">rubygem-clamp</packagereq>
       <packagereq type="default">rubygem-daemon_controller</packagereq>
+      <packagereq type="default">rubygem-fast_gettext</packagereq>
       <packagereq type="default">rubygem-foreman_api</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman</packagereq>
       <packagereq type="default">rubygem-hammer_cli_katello_bridge</packagereq>


### PR DESCRIPTION
After the i18n merge hammer-cli requires fast_gettext and locale. These are both available in Fedora 19 and locale is available Fedora for EL6, however fast_gettext needs to be added to the el6 repo, so the comps file has been updated accordingly. 

I went ahead and built fast_gettext as well.
http://koji.katello.org/koji/buildinfo?buildID=8668
