### PR TITLE
fixes #4739 - add dependency on libaugeas-ruby

### DIFF
--- a/debian/wheezy/foreman-proxy/control
+++ b/debian/wheezy/foreman-proxy/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/ohadlevy/smart-proxy
 
 Package: foreman-proxy
 Architecture: all
-Depends: ruby1.9.1|ruby-interpreter, rake, ruby-sinatra (>= 1.3.3), ruby-json, ruby-rkerberos (>= 0.1.1)
+Depends: ruby1.9.1|ruby-interpreter, rake, ruby-sinatra (>= 1.3.3), ruby-json, ruby-rkerberos (>= 0.1.1), libaugeas-ruby
 Recommends: sudo, wget, ping
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems


### PR DESCRIPTION
The problem on Debian/wheezy is, that foreman-proxy is running under
Ruby 1.9 (system default), but puppet is on version 2.7.x, which has no
support for ruby >1.8, so the dependency on puppet does pull in only
libaugeas-ruby1.8.
