### PR TITLE
add rubygem-apipie-bindings to Fedora 19 and EL6 comps

### DIFF
--- a/comps/comps-foreman-fedora19.xml
+++ b/comps/comps-foreman-fedora19.xml
@@ -30,6 +30,7 @@
       <packagereq type="default">rubygem-foreman_api</packagereq>
 
       <packagereq type="default">rubygem-ansi</packagereq>
+      <packagereq type="default">rubygem-apipie-bindings</packagereq>
       <packagereq type="default">rubygem-apipie-rails</packagereq>
       <packagereq type="default">rubygem-autoparse</packagereq>
       <packagereq type="default">rubygem-bootstrap-sass</packagereq>

--- a/comps/comps-foreman-rhel6.xml
+++ b/comps/comps-foreman-rhel6.xml
@@ -129,6 +129,7 @@
 
       <packagereq type="default">mod_passenger</packagereq>
       <packagereq type="default">rubygem-ansi</packagereq>
+      <packagereq type="default">rubygem-apipie-bindings</packagereq>
       <packagereq type="default">rubygem-awesome_print</packagereq>
       <packagereq type="default">rubygem-clamp</packagereq>
       <packagereq type="default">rubygem-daemon_controller</packagereq>


### PR DESCRIPTION
It looks like rubygem-apipie-bindings is not available for el6 or Fedora 19 outside of the Foreman repo and it is a new dependency for Hammer. You may wish to hold off on this unil mbacovsk pushes the new version of apipie-bindings that no longer requires rubygem-18n though, so that it does not introduce a (albeit temporary) broken dependency.
