### PR TITLE
default_hostgroup: bump to 2.0.1 and include example config

### DIFF
--- a/plugins/ruby-foreman-default-hostgroup/debian/changelog
+++ b/plugins/ruby-foreman-default-hostgroup/debian/changelog
@@ -1,3 +1,10 @@
+ruby-foreman-default-hostgroup (2.0.1) unstable; urgency=low
+
+  * Release 2.0.1
+  * Add example config file
+
+ -- Greg Sutcliffe <gsutclif@redhat.com>  Tue, 29 Apr 2014 13:27:00 +0000
+
 ruby-foreman-default-hostgroup (2.0.0) unstable; urgency=low
 
   * Release 2.0.0

--- a/plugins/ruby-foreman-default-hostgroup/debian/install
+++ b/plugins/ruby-foreman-default-hostgroup/debian/install
@@ -1,1 +1,2 @@
 foreman_default_hostgroup.rb usr/share/foreman/bundler.d
+default_hostgroup.yaml.example etc/foreman/plugins

--- a/plugins/ruby-foreman-default-hostgroup/default_hostgroup.yaml.example
+++ b/plugins/ruby-foreman-default-hostgroup/default_hostgroup.yaml.example
@@ -1,0 +1,21 @@
+# Example default_hostgroup settings
+#
+# Must be placed in ~foreman/config/settings.plugins.d/
+#
+# :map:
+#   <hostgroup>:    <regex>
+#
+# The regex can be written either with or without the enclosing slashes:
+#   ^test$      - valid
+#   /^test$/    - also valid
+#
+#
+---
+:default_hostgroup:
+    :map:
+        "Internal":         \.local$
+        "Core Services":    \.core.my-company.net$
+        "Customers/Foobar"  \.foobar.customers.my-company.net$
+        "Webserver":        ^www\d*\.
+        "Mailserver":       ^mx\d*\.
+        "Default":          .*

--- a/plugins/ruby-foreman-default-hostgroup/foreman_default_hostgroup.rb
+++ b/plugins/ruby-foreman-default-hostgroup/foreman_default_hostgroup.rb
@@ -1,1 +1,1 @@
-gem 'foreman_default_hostgroup', '2.0.0'
+gem 'foreman_default_hostgroup', '2.0.1'


### PR DESCRIPTION
```
Setting up ruby-foreman-default-hostgroup (9999-plugin+scratchbuild+201404291721) ...
root@wheezy335:~# ls /etc/foreman/plugins/
default_hostgroup.yaml.example
root@wheezy335:~# ls ~foreman/config/settings.plugins.d/
default_hostgroup.yaml.example
```

I'll merge to deb/develop as well
