### PR TITLE
Dropping foreman_api rubygem

### DIFF
--- a/comps/comps-foreman-fedora19.xml
+++ b/comps/comps-foreman-fedora19.xml
@@ -27,7 +27,6 @@
       <packagereq type="default">foreman-vmware</packagereq>
 
       <packagereq type="default">foreman-installer</packagereq>
-      <packagereq type="default">rubygem-foreman_api</packagereq>
 
       <packagereq type="default">rubygem-ansi</packagereq>
       <packagereq type="default">rubygem-apipie-bindings</packagereq>

--- a/comps/comps-foreman-rhel6.xml
+++ b/comps/comps-foreman-rhel6.xml
@@ -135,7 +135,6 @@
       <packagereq type="default">rubygem-awesome_print</packagereq>
       <packagereq type="default">rubygem-clamp</packagereq>
       <packagereq type="default">rubygem-fast_gettext</packagereq>
-      <packagereq type="default">rubygem-foreman_api</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman</packagereq>
       <packagereq type="default">rubygem-hammer_cli_katello_bridge</packagereq>
       <packagereq type="default">rubygem-hammer_cli_katello</packagereq>


### PR DESCRIPTION
Once https://github.com/theforeman/puppet-foreman/pull/181 is merged and built.
