### PR TITLE
Add staypuft-installer package

### DIFF
--- a/comps/comps-foreman-plugins-fedora19.xml
+++ b/comps/comps-foreman-plugins-fedora19.xml
@@ -63,6 +63,8 @@
       <packagereq type="default">rubygem-ftools-doc</packagereq>
       <packagereq type="default">rubygem-open4</packagereq>
       <packagereq type="default">rubygem-open4-doc</packagereq>
+
+      <packagereq type="default">foreman-installer-staypuft</packagereq>
     </packagelist>
   </group>
 </comps>

--- a/comps/comps-foreman-plugins-rhel6.xml
+++ b/comps/comps-foreman-plugins-rhel6.xml
@@ -74,6 +74,8 @@
       <packagereq type="default">ruby193-rubygem-open4-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-wicked</packagereq>
       <packagereq type="default">ruby193-rubygem-wicked-doc</packagereq>
+
+      <packagereq type="default">foreman-installer-staypuft</packagereq>
     </packagelist>
   </group>
 </comps>


### PR DESCRIPTION
package is built in koji
EL6 http://koji.katello.org/koji/buildinfo?buildID=10031
F19 http://koji.katello.org/koji/buildinfo?buildID=10032
