### PR TITLE
apipie-bindings updated to 0.0.8

### DIFF
--- a/dependencies/precise/apipie-bindings/changelog
+++ b/dependencies/precise/apipie-bindings/changelog
@@ -1,3 +1,9 @@
+ruby-apipie-bindings (0.0.8-1) stable; urgency=low
+
+  * Update to 0.0.8
+
+ -- Tomas Strachota <tstrachota@redhat.com>  Thu, 7 May 2014 14:50:32 -0500
+
 ruby-apipie-bindings (0.0.6-1) stable; urgency=low
 
   * Initial release

--- a/dependencies/squeeze/apipie-bindings/changelog
+++ b/dependencies/squeeze/apipie-bindings/changelog
@@ -1,3 +1,9 @@
+ruby-apipie-bindings (0.0.8-1) stable; urgency=low
+
+  * Update to 0.0.8
+
+ -- Tomas Strachota <tstrachota@redhat.com>  Thu, 7 May 2014 14:50:32 -0500
+
 ruby-apipie-bindings (0.0.6-1) stable; urgency=low
 
   * Initial release

--- a/dependencies/wheezy/apipie-bindings/changelog
+++ b/dependencies/wheezy/apipie-bindings/changelog
@@ -1,3 +1,9 @@
+ruby-apipie-bindings (0.0.8-1) stable; urgency=low
+
+  * Update to 0.0.8
+
+ -- Tomas Strachota <tstrachota@redhat.com>  Thu, 7 May 2014 14:50:32 -0500
+
 ruby-apipie-bindings (0.0.6-1) stable; urgency=low
 
   * Initial release


### PR DESCRIPTION
Scratch builds:
- squeeze http://ci.theforeman.org/view/Packaging/job/packaging_build_deb_dependency/493/label=debian,os=squeeze/console
- precise http://ci.theforeman.org/view/Packaging/job/packaging_build_deb_dependency/493/label=debian,os=precise/console
- wheezy http://ci.theforeman.org/view/Packaging/job/packaging_build_deb_dependency/493/label=debian,os=wheezy/console
