### PR TITLE
Update foreman_discovery debs to 1.3.0 rc2

### DIFF
--- a/plugins/ruby-foreman-discovery/debian/changelog
+++ b/plugins/ruby-foreman-discovery/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-discovery (1.3.0~rc2) unstable; urgency=low
+
+  * Update to 1.3.0 rc2
+
+ -- Michael Moll <mmoll@mmoll.at>  Mon, 12 May 2014 02:20:43 +0200
+
 ruby-foreman-discovery (1.2.0) unstable; urgency=low
 
   * Release 1.2.0

--- a/plugins/ruby-foreman-discovery/foreman_discovery.rb
+++ b/plugins/ruby-foreman-discovery/foreman_discovery.rb
@@ -1,1 +1,1 @@
-gem 'foreman_discovery', '1.2.0'
+gem 'foreman_discovery', '1.3.0.rc2'


### PR DESCRIPTION
Because of the new permissions model, I think foreman_discovery 1.2.0 does not play nice with foreman 1.5 and a new deb is needed.
