### PR TITLE
foreman-proxy needs to depend on ruby-rgen on trusty

### DIFF
--- a/debian/trusty/foreman-proxy/control
+++ b/debian/trusty/foreman-proxy/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/ohadlevy/smart-proxy
 
 Package: foreman-proxy
 Architecture: all
-Depends: ruby1.9.1|ruby-interpreter, rake, ruby-sinatra, ruby-json, ruby-rkerberos (>= 0.1.1)
+Depends: ruby1.9.1|ruby-interpreter, rake, ruby-sinatra, ruby-json, ruby-rgen, ruby-rkerberos (>= 0.1.1)
 Recommends: sudo, wget, ping
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems


### PR DESCRIPTION
otherwise it even won't start:

```
root@tmptst:~# service foreman-proxy start 
/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- rgen/metamodel_builder (LoadError)
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/lib/ruby/vendor_ruby/puppet/pops/model/model.rb:23:in `<top (required)>'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/lib/ruby/vendor_ruby/puppet/pops.rb:20:in `<module:Pops>'
    from /usr/lib/ruby/vendor_ruby/puppet/pops.rb:3:in `<module:Puppet>'
    from /usr/lib/ruby/vendor_ruby/puppet/pops.rb:1:in `<top (required)>'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/share/foreman-proxy/lib/proxy/puppet/class_scanner_eparser.rb:4:in `<top (required)>'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/share/foreman-proxy/lib/proxy/puppet/puppet_class.rb:3:in `<top (required)>'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/share/foreman-proxy/lib/proxy/puppet.rb:6:in `<module:Puppet>'
    from /usr/share/foreman-proxy/lib/proxy/puppet.rb:3:in `<top (required)>'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/share/foreman-proxy/lib/proxy.rb:17:in `<module:Proxy>'
    from /usr/share/foreman-proxy/lib/proxy.rb:1:in `<top (required)>'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/share/foreman-proxy/lib/smart_proxy.rb:5:in `<top (required)>'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/share/foreman-proxy/bin/smart-proxy:5:in `<main>'
```
