### PR TITLE
Update nokogiri gem when installing deface-based plugins

### DIFF
--- a/plugins/ruby-foreman-column-view/debian/changelog
+++ b/plugins/ruby-foreman-column-view/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-column-view (0.2.0-1) stable; urgency=low
+
+  * Update nokogiri on install
+
+ -- Greg Sutcliffe <gsutclif@redhat.com>  Tue, 20 May 2014 21:23:00 +0000
+
 ruby-foreman-column-view (0.2.0) unstable; urgency=low
 
   * Release 0.2.0

--- a/plugins/ruby-foreman-column-view/debian/postinst
+++ b/plugins/ruby-foreman-column-view/debian/postinst
@@ -19,9 +19,14 @@ trap db_stop EXIT
 
 # Update gems
 cd /usr/share/foreman
+# Nokogiri causes us pain due to tight dependencies within deface
+# so update it first. We rescue it as trusty will return non-zero if
+# nokogiri isn't in the Gemfile.
 if [ ! -z "${DEBUG}" ]; then
+  bundle update nokogiri || true
   bundle update foreman_column_view
 else
+  bundle update nokogiri 2>&1 >> $LOGFILE || true
   bundle update foreman_column_view 2>&1 >> $LOGFILE
 fi
 

--- a/plugins/ruby-foreman-dhcp-browser/debian/changelog
+++ b/plugins/ruby-foreman-dhcp-browser/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-dhcp-browser (0.0.4-1) stable; urgency=low
+
+  * Update nokogiri on install
+
+ -- Greg Sutcliffe <gsutclif@redhat.com>  Tue, 20 May 2014 21:23:00 +0000
+
 ruby-foreman-dhcp-browser (0.0.4) stable; urgency=low
 
   * Initial Release.

--- a/plugins/ruby-foreman-dhcp-browser/debian/postinst
+++ b/plugins/ruby-foreman-dhcp-browser/debian/postinst
@@ -19,9 +19,14 @@ trap db_stop EXIT
 
 # Update gems
 cd /usr/share/foreman
+# Nokogiri causes us pain due to tight dependencies within deface
+# so update it first. We rescue it as trusty will return non-zero if
+# nokogiri isn't in the Gemfile.
 if [ ! -z "${DEBUG}" ]; then
+  bundle update nokogiri || true
   bundle update foreman_dhcp_browser
 else
+  bundle update nokogiri 2>&1 >> $LOGFILE || true
   bundle update foreman_dhcp_browser 2>&1 >> $LOGFILE
 fi
 

--- a/plugins/ruby-foreman-discovery/debian/changelog
+++ b/plugins/ruby-foreman-discovery/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-discovery (1.3.0~rc2-1) stable; urgency=low
+
+  * Update nokogiri on install
+
+ -- Greg Sutcliffe <gsutclif@redhat.com>  Tue, 20 May 2014 21:23:00 +0000
+
 ruby-foreman-discovery (1.3.0~rc2) unstable; urgency=low
 
   * Update to 1.3.0 rc2

--- a/plugins/ruby-foreman-discovery/debian/postinst
+++ b/plugins/ruby-foreman-discovery/debian/postinst
@@ -19,9 +19,14 @@ trap db_stop EXIT
 
 # Update gems
 cd /usr/share/foreman
+# Nokogiri causes us pain due to tight dependencies within deface
+# so update it first. We rescue it as trusty will return non-zero if
+# nokogiri isn't in the Gemfile.
 if [ ! -z "${DEBUG}" ]; then
+  bundle update nokogiri || true
   bundle update foreman_discovery
 else
+  bundle update nokogiri 2>&1 >> $LOGFILE || true
   bundle update foreman_discovery 2>&1 >> $LOGFILE
 fi
 

--- a/plugins/ruby-foreman-setup/debian/changelog
+++ b/plugins/ruby-foreman-setup/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-setup (2.0.4-1) stable; urgency=low
+
+  * Update nokogiri on install
+
+ -- Greg Sutcliffe <gsutclif@redhat.com>  Tue, 20 May 2014 21:23:00 +0000
+
 ruby-foreman-setup (2.0.4) stable; urgency=low
 
   * Release 2.0.4

--- a/plugins/ruby-foreman-setup/debian/postinst
+++ b/plugins/ruby-foreman-setup/debian/postinst
@@ -20,13 +20,18 @@ trap db_stop EXIT
 
 # Update gems
 cd /usr/share/foreman
+# Nokogiri causes us pain due to tight dependencies within deface
+# so update it first. We rescue it as trusty will return non-zero if
+# nokogiri isn't in the Gemfile.
 if [ ! -z "${DEBUG}" ]; then
+  bundle update nokogiri || true
   if bundle show $PLUGIN >/dev/null 2>&1; then
     bundle update $PLUGIN
   else
     bundle install
   fi
 else
+  bundle update nokogiri 2>&1 >> $LOGFILE || true
   if bundle show $PLUGIN >/dev/null 2>&1; then
     bundle update $PLUGIN 2>&1 >> $LOGFILE
   else


### PR DESCRIPTION
deface < 1.0 has a dependency on ~> 1.5.0 which conflicts
with the 1.6.x gem installed by default in core.
