### PR TITLE
refs #5793 - distribute VERSION

### DIFF
--- a/debian/precise/foreman-proxy/install
+++ b/debian/precise/foreman-proxy/install
@@ -5,5 +5,6 @@ lib usr/share/foreman-proxy
 public usr/share/foreman-proxy
 Rakefile usr/share/foreman-proxy
 tasks usr/share/foreman-proxy
+VERSION usr/share/foreman-proxy
 views usr/share/foreman-proxy
 debian/settings.yml etc/foreman-proxy

--- a/debian/squeeze/foreman-proxy/install
+++ b/debian/squeeze/foreman-proxy/install
@@ -5,5 +5,6 @@ lib usr/share/foreman-proxy
 public usr/share/foreman-proxy
 Rakefile usr/share/foreman-proxy
 tasks usr/share/foreman-proxy
+VERSION usr/share/foreman-proxy
 views usr/share/foreman-proxy
 debian/settings.yml etc/foreman-proxy

--- a/debian/trusty/foreman-proxy/install
+++ b/debian/trusty/foreman-proxy/install
@@ -5,5 +5,6 @@ lib usr/share/foreman-proxy
 public usr/share/foreman-proxy
 Rakefile usr/share/foreman-proxy
 tasks usr/share/foreman-proxy
+VERSION usr/share/foreman-proxy
 views usr/share/foreman-proxy
 debian/settings.yml etc/foreman-proxy

--- a/debian/wheezy/foreman-proxy/install
+++ b/debian/wheezy/foreman-proxy/install
@@ -5,5 +5,6 @@ lib usr/share/foreman-proxy
 public usr/share/foreman-proxy
 Rakefile usr/share/foreman-proxy
 tasks usr/share/foreman-proxy
+VERSION usr/share/foreman-proxy
 views usr/share/foreman-proxy
 debian/settings.yml etc/foreman-proxy


### PR DESCRIPTION
https://github.com/theforeman/smart-proxy/commit/9f019d1e3ba033d892ffe4e29b871d3f1dc74437 introduces a dependency on this file.

Scratches: http://ci.theforeman.org/job/packaging_build_deb_coreproject/727/ seem to contain the /usr/share/foreman-proxy/VERSION file

Please kick http://ci.theforeman.org/job/test_proxy_develop/ when merged, which'll build new RPMs and debs.
