### PR TITLE
Remove thin support

### DIFF
--- a/comps/comps-foreman-rhel6.xml
+++ b/comps/comps-foreman-rhel6.xml
@@ -112,7 +112,6 @@
       <packagereq type="default">ruby193-rubygem-spice-html5-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-sshkey</packagereq>
       <packagereq type="default">ruby193-rubygem-syntax</packagereq>
-      <packagereq type="default">ruby193-rubygem-thin</packagereq>
       <packagereq type="default">ruby193-rubygem-trollop</packagereq>
       <packagereq type="default">ruby193-rubygem-unf</packagereq>
       <packagereq type="default">ruby193-rubygem-unf_ext</packagereq>

--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -112,7 +112,6 @@
       <packagereq type="default">ruby193-rubygem-spice-html5-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-sshkey</packagereq>
       <packagereq type="default">ruby193-rubygem-syntax</packagereq>
-      <packagereq type="default">ruby193-rubygem-thin</packagereq>
       <packagereq type="default">ruby193-rubygem-trollop</packagereq>
       <packagereq type="default">ruby193-rubygem-unf</packagereq>
       <packagereq type="default">ruby193-rubygem-unf_ext</packagereq>

--- a/foreman/foreman.init
+++ b/foreman/foreman.init
@@ -12,12 +12,7 @@ if [ -f /etc/sysconfig/foreman ]; then
     . /etc/sysconfig/foreman
 fi
 
-function run_in_scl() {
-   scl enable ruby193 "thin $*"
-}
-
 prog=foreman
-THIN=/usr/bin/thin
 RETVAL=0
 FOREMAN_PORT=${FOREMAN_PORT:-3000}
 FOREMAN_USER=${FOREMAN_USER:-foreman}
@@ -25,31 +20,16 @@ FOREMAN_HOME=${FOREMAN_HOME:-/usr/share/foreman}
 export HOME=$FOREMAN_HOME
 FOREMAN_ENV=${FOREMAN_ENV:-production}
 FOREMAN_USE_PASSENGER=${FOREMAN_USE_PASSENGER:-0}
-FOREMAN_USE_THIN=${FOREMAN_USE_THIN:-0}
 
 if [[ -z $FOREMAN_PID ]]
 then
-    if [[ $FOREMAN_USE_THIN = 1 ]]
-    then
-        FOREMAN_PID=${FOREMAN_HOME}/tmp/pids/thin.*.pid
-    else
-        FOREMAN_PID=${FOREMAN_HOME}/tmp/pids/server.pid
-    fi
+    FOREMAN_PID=${FOREMAN_HOME}/tmp/pids/server.pid
 fi
 
 start() {
     echo -n $"Starting $prog: "
-    if [[ $FOREMAN_USE_THIN = 1 ]]
-    then
-        $THIN start --user ${FOREMAN_USER} \
-            --environment $FOREMAN_ENV \
-            --group ${FOREMAN_USER} \
-            --config /etc/foreman/thin.yml \
-            --rackup "${FOREMAN_HOME}/config.ru"
-    else
-        cd ${FOREMAN_HOME}
-        daemon --user ${FOREMAN_USER} /usr/bin/ruby ${FOREMAN_HOME}/script/rails s -p ${FOREMAN_PORT} -e ${FOREMAN_ENV} -d ${FOREMAN_EXTRA_ARGS} > /dev/null
-    fi
+    cd ${FOREMAN_HOME}
+    daemon --user ${FOREMAN_USER} /usr/bin/ruby ${FOREMAN_HOME}/script/rails s -p ${FOREMAN_PORT} -e ${FOREMAN_ENV} -d ${FOREMAN_EXTRA_ARGS} > /dev/null
     RETVAL=$?
     if [ $RETVAL = 0 ]
     then

--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -74,7 +74,6 @@ Requires: %{?scl_prefix}rubygem(audited-activerecord) >= 3.0.0
 Requires: %{?scl_prefix}rubygem(apipie-rails) >= 0.1.1
 Requires: %{?scl_prefix}rubygem(apipie-rails) < 0.2.0
 Requires: %{?scl_prefix}rubygem(bundler_ext)
-Requires: %{?scl_prefix}rubygem(thin)
 Requires: %{?scl_prefix}rubygem(fast_gettext) >= 0.8.0
 Requires: %{?scl_prefix}rubygem(gettext_i18n_rails) >= 0.10.0
 Requires: %{?scl_prefix}rubygem(gettext_i18n_rails) < 1.0.0
@@ -390,7 +389,6 @@ plugins required for Foreman to work.
     sed -ri '1sX(/usr/bin/ruby|/usr/bin/env ruby)X%{scl_ruby}X' $f
   done
   sed -ri '1,$sX/usr/bin/rubyX%{scl_ruby}X' %{SOURCE1}
-  sed -ri '1,$s|THIN=/usr/bin/thin|THIN="run_in_scl"|' %{SOURCE1}
   # script content
   sed -ri 'sX/usr/bin/rakeX%{scl_rake}X' extras/dbmigrate script/foreman-rake
 %endif

--- a/foreman/foreman.sysconfig
+++ b/foreman/foreman.sysconfig
@@ -16,6 +16,3 @@
 # 'start' and 'stop' completely and remind the operator that passenger is in
 # use.
 #FOREMAN_USE_PASSENGER=0
-
-# set to 1 if you're using thin as a server
-#FOREMAN_USE_THIN=0


### PR DESCRIPTION
Katello no longer uses it and I've never seen a user with it, so it'll save me the effort of building the chain of build deps required for thin on EL7.

el6: http://koji.katello.org/koji/taskinfo?taskID=114943
f19: http://koji.katello.org/koji/taskinfo?taskID=114942
