### PR TITLE
Do not fail when foreman-selinux-enable returns nonzero

### DIFF
--- a/foreman-selinux/foreman-selinux.spec
+++ b/foreman-selinux/foreman-selinux.spec
@@ -111,7 +111,7 @@ install -m 0644 foreman-selinux-relabel.man8 %{buildroot}%{_mandir}/man8/foreman
 
 %post
 if /usr/sbin/selinuxenabled ; then
-    %{_sbindir}/%{name}-enable
+    %{_sbindir}/%{name}-enable || true
 fi
 
 %posttrans


### PR DESCRIPTION
I will file selinux PR that will add elastic search port to the selinux enable
transaction. Since the code gets complicated and we've seen several
selinux-enable failures on Satellite 6 recently, I'd like not to end yum
transaction when this fails. It can be easily fixed by rerunning the script or
manual command.
