### PR TITLE
Add rubygem-ovirt_provision_plugin package

### DIFF
--- a/comps/comps-foreman-plugins-fedora19.xml
+++ b/comps/comps-foreman-plugins-fedora19.xml
@@ -45,6 +45,8 @@
       <packagereq type="default">rubygem-foreman_templates-doc</packagereq>
       <packagereq type="default">rubygem-foreman_xen</packagereq>
       <packagereq type="default">rubygem-foreman_xen-doc</packagereq>
+      <packagereq type="default">rubygem-ovirt_provision_plugin</packagereq>
+      <packagereq type="default">rubygem-ovirt_provision_plugin-doc</packagereq>
       <packagereq type="default">rubygem-puppetdb_foreman</packagereq>
 
       <packagereq type="default">rubygem-algebrick</packagereq>

--- a/comps/comps-foreman-plugins-rhel6.xml
+++ b/comps/comps-foreman-plugins-rhel6.xml
@@ -43,6 +43,8 @@
       <packagereq type="default">ruby193-rubygem-foreman_templates-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_xen</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_xen-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-ovirt_provision_plugin</packagereq>
+      <packagereq type="default">ruby193-rubygem-ovirt_provision_plugin-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-puppetdb_foreman</packagereq>
       <packagereq type="default">ruby193-rubygem-staypuft</packagereq>
       <packagereq type="default">ruby193-rubygem-staypuft-doc</packagereq>

--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -43,6 +43,8 @@
       <packagereq type="default">ruby193-rubygem-foreman_templates-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_xen</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_xen-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-ovirt_provision_plugin</packagereq>
+      <packagereq type="default">ruby193-rubygem-ovirt_provision_plugin-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-puppetdb_foreman</packagereq>
       <packagereq type="default">ruby193-rubygem-staypuft</packagereq>
       <packagereq type="default">ruby193-rubygem-staypuft-doc</packagereq>

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -229,6 +229,7 @@ whitelist = ipxe
   rubygem-foreman_xen
   rubygem-staypuft
   rubygem-foreman_templates
+  rubygem-ovirt_provision_plugin
   rubygem-puppetdb_foreman
   rubygem-wicked
 
@@ -263,9 +264,10 @@ whitelist = rubygem-algebrick
   rubygem-foreman_simplify
   rubygem-foreman_snapshot
   rubygem-foreman_xen
-  rubygem-staypuft
   rubygem-foreman_templates
+  rubygem-ovirt_provision_plugin
   rubygem-puppetdb_foreman
+  rubygem-staypuft
   rubygem-wicked
 
 [foreman-plugins-nightly-fedora19]
@@ -298,6 +300,7 @@ whitelist = rubygem-algebrick
   rubygem-foreman_snapshot
   rubygem-foreman_templates
   rubygem-foreman_xen
+  rubygem-ovirt_provision_plugin
   rubygem-puppetdb_foreman
 
 [requirements]

--- a/rubygem-ovirt_provision_plugin/ovirt_provision_plugin-0.0.1.gem
+++ b/rubygem-ovirt_provision_plugin/ovirt_provision_plugin-0.0.1.gem
@@ -1,0 +1,1 @@
+../.git/annex/objects/kp/Jq/SHA256E-s19456--4adce63286ae55878a39f7b073c7a01bdbf4cb19fb056475a9d335de19be1f33.1.gem/SHA256E-s19456--4adce63286ae55878a39f7b073c7a01bdbf4cb19fb056475a9d335de19be1f33.1.gem

--- a/rubygem-ovirt_provision_plugin/rubygem-ovirt_provision_plugin.spec
+++ b/rubygem-ovirt_provision_plugin/rubygem-ovirt_provision_plugin.spec
@@ -1,0 +1,103 @@
+# This package contains macros that provide functionality relating to
+# Software Collections. These macros are not used in default
+# Fedora builds, and should not be blindly copied or enabled.
+# Specifically, the "scl" macro must not be defined in official Fedora
+# builds. For more information, see:
+# http://docs.fedoraproject.org/en-US/Fedora_Contributor_Documentation
+# /1/html/Software_Collections_Guide/index.html
+
+%{?scl:%scl_package rubygem-%{gem_name}}
+%{!?scl:%global pkg_name %{name}}
+
+%global gem_name ovirt_provision_plugin
+
+%define rubyabi 1.9.1
+%global foreman_dir /usr/share/foreman
+%global foreman_bundlerd_dir %{foreman_dir}/bundler.d
+%global foreman_pluginconf_dir %{foreman_dir}/config/settings.plugins.d
+
+Summary:    Foreman plugin to provision new hosts and integrate to oVirt Engine
+Name:       %{?scl_prefix}rubygem-%{gem_name}
+Version:    0.0.1
+Release:    1%{?dist}
+Group:      Applications/System
+License:    GPLv3
+URL:        http://github.com/theforeman/ovirt_provision_plugin
+Source0:    http://rubygems.org/downloads/%{gem_name}-%{version}.gem
+
+Requires:   foreman >= 1.5.0
+Requires:   %{?scl_prefix}rubygem(deface)
+
+%if 0%{?fedora} > 18
+Requires: %{?scl_prefix}ruby(release)
+%else
+Requires: %{?scl_prefix}ruby(abi) >= %{rubyabi}
+%endif
+Requires: %{?scl_prefix}rubygems
+
+%if 0%{?fedora} > 18
+BuildRequires: %{?scl_prefix}ruby(release)
+%else
+BuildRequires: %{?scl_prefix}ruby(abi) >= %{rubyabi}
+%endif
+BuildRequires: %{?scl_prefix}rubygems-devel
+BuildRequires: %{?scl_prefix}rubygems
+
+BuildArch: noarch
+
+Requires: %{?scl_prefix}rubygem(rbovirt) >= 0.0.27
+
+Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
+Provides: foreman-plugin-ovirt-provision
+
+%description
+This plugin monitors oVirt provision for new host and perform related API calls
+to ovirt-engine.
+
+%package doc
+BuildArch:  noarch
+Requires:   %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+Summary:    Documentation for rubygem-%{gem_name}
+
+%description doc
+This package contains documentation for rubygem-%{gem_name}.
+
+%prep
+%setup -n %{pkg_name}-%{version} -q -c -T
+mkdir -p .%{gem_dir}
+%{?scl:scl enable %{scl} "}
+gem install --local --install-dir .%{gem_dir} \
+            --force %{SOURCE0} --no-rdoc --no-ri
+%{?scl:"}
+
+%build
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -a .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+mkdir -p %{buildroot}%{foreman_bundlerd_dir}
+cat <<GEMFILE > %{buildroot}%{foreman_bundlerd_dir}/%{gem_name}.rb
+gem '%{gem_name}'
+GEMFILE
+
+%files
+%dir %{gem_instdir}
+%{gem_instdir}/app
+%{gem_instdir}/config
+%{gem_instdir}/lib
+%exclude %{gem_cache}
+%exclude %{gem_instdir}/Rakefile
+%exclude %{gem_instdir}/test
+%{gem_spec}
+%{foreman_bundlerd_dir}/%{gem_name}.rb
+%doc %{gem_instdir}/LICENSE
+
+%exclude %{gem_cache}
+
+%files doc
+%doc %{gem_instdir}/LICENSE
+%doc %{gem_instdir}/README.md
+
+%changelog


### PR DESCRIPTION
Scratch builds:
http://koji.katello.org/koji/taskinfo?taskID=122698 (el6)
http://koji.katello.org/koji/taskinfo?taskID=122699 (el7)
http://koji.katello.org/koji/taskinfo?taskID=122702 (f19)

@bronhaim's the author of the plugin.

Will be built for nightlies only, due to rbovirt dependency.
