### PR TITLE
Fixes #6534 - limit version for rest-client on Ruby 1.8

### DIFF
--- a/rubygem-hammer_cli/rubygem-hammer_cli.spec
+++ b/rubygem-hammer_cli/rubygem-hammer_cli.spec
@@ -20,7 +20,7 @@ Requires: ruby(release)
 # on ruby 1.8.x
 Requires: ruby(rubygems)
 Requires: rubygem(clamp)
-Requires: rubygem(rest-client)
+Requires: rubygem(rest-client) < 1.7.0
 Requires: rubygem(logging)
 Requires: rubygem(awesome_print)
 Requires: rubygem(table_print) >= 1.5.0

--- a/rubygem-hammer_cli_foreman/rubygem-hammer_cli_foreman.spec
+++ b/rubygem-hammer_cli_foreman/rubygem-hammer_cli_foreman.spec
@@ -20,6 +20,7 @@ Requires: ruby(release)
 Requires: ruby(rubygems)
 Requires: rubygem(hammer_cli) >= 0.1.1
 Requires: rubygem(apipie-bindings) >= 0.0.8
+Requires: rubygem(rest-client) < 1.7.0
 Requires: rubygem(rest-client) >= 1.6.5
 BuildRequires: ruby(rubygems)
 BuildRequires: rubygems-devel


### PR DESCRIPTION
latest rest-client 1.7.1 dropped support for Ruby 1.8
