### PR TITLE
Add minitest dep as rubygem-activesupport 3.2.x is missing it

### DIFF
--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -54,6 +54,8 @@ Requires(postun): initscripts
 Requires: %{?scl_prefix}rubygem(json)
 Requires: %{?scl_prefix}rubygem(rails) >= 3.2.8
 Requires: %{?scl_prefix}rubygem(rails) < 3.3.0
+# minitest - workaround as rubygem-activesupport is missing dep
+Requires: %{?scl_prefix}rubygem(minitest)
 Requires: %{?scl_prefix}rubygem(jquery-rails)
 Requires: %{?scl_prefix}rubygem(rest-client)
 Requires: %{?scl_prefix}rubygem(will_paginate) >= 3.0.0
@@ -119,6 +121,8 @@ BuildRequires: %{?scl_prefix}rubygem(uglifier) >= 1.0.3
 BuildRequires: %{?scl_prefix}rubygem(uuidtools)
 BuildRequires: %{?scl_prefix}rubygem(will_paginate) >= 3.0.2
 BuildRequires: %{?scl_prefix}rubygem(rails)
+# minitest - workaround as rubygem-activesupport is missing dep
+BuildRequires: %{?scl_prefix}rubygem(minitest)
 BuildRequires: %{?scl_prefix}rubygem(quiet_assets)
 BuildRequires: %{?scl_prefix}rubygem(spice-html5-rails)
 BuildRequires: %{?scl_prefix}rubygem(flot-rails) = 0.0.3
@@ -271,8 +275,6 @@ Group:  Applications/System
 Requires: %{?scl_prefix}rubygem(awesome_print)
 Requires: %{?scl_prefix}rubygem(hirb-unicode)
 Requires: %{?scl_prefix}rubygem(wirb)
-# minitest - workaround until Rails 4.0 (#2650)
-Requires: %{?scl_prefix}rubygem(minitest)
 Requires: %{name} = %{version}-%{release}
 
 %description console


### PR DESCRIPTION
apipie-rails 0.2.x tries to reference ActionController::TestCase during init
which eventually requires minitest to be loaded.  4.x packages have the
explicit dependency (http://pkgs.fedoraproject.org/cgit/rubygem-activesupport.git/commit/?h=f20&id=26b515ea824c164ed7aa56734309cbc54a01c6cf).

Fixes failed builds (e.g. http://koji.katello.org/koji/taskinfo?taskID=132271) since https://github.com/theforeman/foreman/commit/6592ce8ab995428ead4037b2f4f753863fa5335b.

If you merge this, please click rebuild on this: http://ci.theforeman.org/job/release_nightly_build_rpm/103/

---

Scratch builds green:
- http://koji.katello.org/koji/taskinfo?taskID=132398
- http://koji.katello.org/koji/taskinfo?taskID=132401
- http://koji.katello.org/koji/taskinfo?taskID=132400
