### PR TITLE
fixes #6660 - create rpm-state if missing

### DIFF
--- a/foreman-proxy/foreman-proxy.spec
+++ b/foreman-proxy/foreman-proxy.spec
@@ -159,7 +159,7 @@ getent passwd foreman-proxy >/dev/null || \
 
 # Keep monolithic config in case it's replaced with the new default
 if [ $1 == 2 -a ! -e %{_sysconfdir}/%{name}/settings.d ]; then
-  test -e %{_localstatedir}/lib/rpm-state/%{name} || mkdir %{_localstatedir}/lib/rpm-state/%{name}
+  test -e %{_localstatedir}/lib/rpm-state/%{name} || mkdir -p %{_localstatedir}/lib/rpm-state/%{name}
   cp %{_sysconfdir}/%{name}/settings.yml %{_localstatedir}/lib/rpm-state/%{name}/settings.yml.orig
 fi
 


### PR DESCRIPTION
Scratch builds (green)
http://koji.katello.org/koji/taskinfo?taskID=135899
http://koji.katello.org/koji/taskinfo?taskID=135900
http://koji.katello.org/koji/taskinfo?taskID=135902

Works OK on upgrade from 1.5.2 for me.
