### PR TITLE
Remove rubygem-ansi, now in EPEL

### DIFF
--- a/comps/comps-foreman-rhel6.xml
+++ b/comps/comps-foreman-rhel6.xml
@@ -135,7 +135,6 @@
       <packagereq type="default">foreman-installer</packagereq>
 
       <packagereq type="default">mod_passenger</packagereq>
-      <packagereq type="default">rubygem-ansi</packagereq>
       <packagereq type="default">rubygem-apipie-bindings</packagereq>
       <packagereq type="default">rubygem-awesome_print</packagereq>
       <packagereq type="default">rubygem-bundler</packagereq>

--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -135,7 +135,6 @@
       <packagereq type="default">foreman-installer</packagereq>
 
       <packagereq type="default">mod_passenger</packagereq>
-      <packagereq type="default">rubygem-ansi</packagereq>
       <packagereq type="default">rubygem-apipie-bindings</packagereq>
       <packagereq type="default">rubygem-awesome_print</packagereq>
       <packagereq type="default">rubygem-bundler_ext</packagereq>

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -66,7 +66,6 @@ disttag = .el6
 whitelist = foreman-installer
   foreman-proxy
   foreman-selinux
-  rubygem-ansi
   rubygem-apipie-bindings
   rubygem-awesome_print
   rubygem-bundler_ext
@@ -100,7 +99,6 @@ disttag = .el7
 whitelist = foreman-installer
   foreman-proxy
   foreman-selinux
-  rubygem-ansi
   rubygem-apipie-bindings
   rubygem-awesome_print
   rubygem-bundler_ext


### PR DESCRIPTION
Pending https://admin.fedoraproject.org/updates/rubygem-ansi-1.4.3-2.el6 being pushed to stable.

Thanks to @traylenator!
