### PR TITLE
bumping smart_proxy_pulp version to 1.0.1

### DIFF
--- a/rubygem-smart_proxy_pulp/rubygem-smart_proxy_pulp.spec
+++ b/rubygem-smart_proxy_pulp/rubygem-smart_proxy_pulp.spec
@@ -6,7 +6,7 @@
 
 Summary: Basic Pulp support for Foreman Smart-Proxy
 Name: rubygem-%{gem_name}
-Version: 1.0.0
+Version: 1.0.1
 Release: 2%{?dist}
 Group: Applications/System
 License: GPLv3


### PR DESCRIPTION
in support of https://github.com/theforeman/smart-proxy-pulp/pull/1
