### PR TITLE
Execute smart-proxy binary directly in sysvinit script

### DIFF
--- a/foreman-proxy/foreman-proxy.init
+++ b/foreman-proxy/foreman-proxy.init
@@ -29,7 +29,7 @@ start() {
         return 6
     fi
 
-    daemon --user ${FOREMAN_PROXY_USER} /usr/bin/ruby ${FOREMAN_PROXY_HOME}/bin/smart-proxy > /dev/null
+    daemon --user ${FOREMAN_PROXY_USER} ${FOREMAN_PROXY_HOME}/bin/smart-proxy > /dev/null
     RETVAL=$?
     if [ $RETVAL = 0 ]
     then


### PR DESCRIPTION
We need this for our upcoming proxy policy. Systemd is correct, this aligns
with it. The shebang is okay (I am fine with `env` although this is against
Fedora standards).
