### PR TITLE
Update rubygem_hammer-cli-foreman to 0.1.2

### DIFF
--- a/rubygem-hammer_cli_foreman/hammer_cli_foreman-0.1.1.gem
+++ b/rubygem-hammer_cli_foreman/hammer_cli_foreman-0.1.1.gem
@@ -1,1 +1,0 @@
-../.git/annex/objects/QF/v6/SHA256E-s114688--e97c7ec12eb60c088a47bb8a3b37bb91f9daba087a66c6bf778eadd12a9f97d5.1.gem/SHA256E-s114688--e97c7ec12eb60c088a47bb8a3b37bb91f9daba087a66c6bf778eadd12a9f97d5.1.gem

--- a/rubygem-hammer_cli_foreman/hammer_cli_foreman-0.1.2.gem
+++ b/rubygem-hammer_cli_foreman/hammer_cli_foreman-0.1.2.gem
@@ -1,0 +1,1 @@
+../.git/annex/objects/kG/vK/SHA256E-s199168--d7905d84291e3aa38841284bbde53f63bfd5e83dee56ed84f9f19bedd45afeec.2.gem/SHA256E-s199168--d7905d84291e3aa38841284bbde53f63bfd5e83dee56ed84f9f19bedd45afeec.2.gem

--- a/rubygem-hammer_cli_foreman/rubygem-hammer_cli_foreman.spec
+++ b/rubygem-hammer_cli_foreman/rubygem-hammer_cli_foreman.spec
@@ -3,7 +3,7 @@
 
 Summary: Universal command-line interface for Foreman
 Name: rubygem-%{gem_name}
-Version: 0.1.1
+Version: 0.1.2
 Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv3


### PR DESCRIPTION
NonSCL el6: http://koji.katello.org/koji/taskinfo?taskID=140103
Fedora 19: http://koji.katello.org/koji/taskinfo?taskID=140101
