### PR TITLE
Fixed path in SCL statement

### DIFF
--- a/foreman-proxy/foreman-proxy.spec
+++ b/foreman-proxy/foreman-proxy.spec
@@ -74,7 +74,7 @@ Mainly used by the foreman project (http://theforeman.org)
   for f in bin/smart-proxy extra/query.rb extra/changelog extra/migrate_settings.rb; do
     sed -ri '1sX(/usr/bin/ruby|/usr/bin/env ruby)X%{scl_ruby}X' $f
   done
-  sed -ri '1,$sX/usr/bin/rubyX%{scl_ruby}X' extra/spec/foreman-proxy.init
+  sed -ri '1,$sX/usr/bin/rubyX%{scl_ruby}X' %{SOURCE2}
 %endif
 
 #replace default location of 'settings.d'


### PR DESCRIPTION
Or we can completely remove that. I always hit this when I forget to build into
nonscl tag :-) What you think?