### PR TITLE
Remove libkrb5* transitional packages from rkerberos

### DIFF
--- a/dependencies/trusty/rkerberos/changelog
+++ b/dependencies/trusty/rkerberos/changelog
@@ -1,3 +1,9 @@
+ruby-rkerberos (0.1.3-2) stable; urgency=low
+
+  * Remove libkrb5* transitional packages as it installs alongside
+
+ -- Dominic Cleal <dcleal@redhat.com>  Thu, 28 Aug 2014 19:21:00 +0100
+
 ruby-rkerberos (0.1.3-1) stable; urgency=low
 
   * First Trusty release

--- a/dependencies/trusty/rkerberos/control
+++ b/dependencies/trusty/rkerberos/control
@@ -13,47 +13,7 @@ Architecture: any
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter
 Suggests: doc-base
-Replaces: libkrb5-ruby (<< 0.7-3~), libkrb5-ruby1.8 (<< 0.7-3~), libkrb5-ruby1.9.1 (<< 0.7-3~), libkrb5-ruby-doc (<< 0.7-3~), ruby-krb5-auth
-Breaks: libkrb5-ruby (<< 0.7-3~), libkrb5-ruby1.8 (<< 0.7-3~), libkrb5-ruby1.9.1 (<< 0.7-3~), libkrb5-ruby-doc (<< 0.7-3~), ruby-krb5-auth
-Provides: libkrb5-ruby, libkrb5-ruby1.8, libkrb5-ruby1.9.1, libkrb5-ruby-doc, ruby-krb5-auth
 Description: Kerberos binding for Ruby
  Ruby kerberos provides basic Kerberos bindings for ruby which allow
  authentication, password changes, adding principals, and deleting
  principals.
-
-Package: libkrb5-ruby
-Section: oldlibs
-Priority: extra
-Architecture: all
-Depends: ${misc:Depends}, ruby-rkerberos
-Description: Transitional package for ruby-rkerberos
- This is a transitional package to ease upgrades to the ruby-rkerberos
- package. It can safely be removed.
-
-Package: libkrb5-ruby1.8
-Section: oldlibs
-Priority: extra
-Architecture: all
-Depends: ${misc:Depends}, ruby-rkerberos
-Description: Transitional package for ruby-rkerberos
- This is a transitional package to ease upgrades to the ruby-rkerberos
- package. It can safely be removed.
-
-Package: libkrb5-ruby1.9.1
-Section: oldlibs
-Priority: extra
-Architecture: all
-Depends: ${misc:Depends}, ruby-rkerberos
-Description: Transitional package for ruby-rkerberos
- This is a transitional package to ease upgrades to the ruby-rkerberos
- package. It can safely be removed.
-
-Package: libkrb5-ruby-doc
-Section: oldlibs
-Priority: extra
-Architecture: all
-Depends: ${misc:Depends}, ruby-rkerberos
-Description: Transitional package for ruby-rkerberos
- This is a transitional package to ease upgrades to the ruby-rkerberos
- package. It can safely be removed.
-

--- a/dependencies/wheezy/rkerberos/changelog
+++ b/dependencies/wheezy/rkerberos/changelog
@@ -1,3 +1,9 @@
+ruby-rkerberos (0.1.1-2) stable; urgency=low
+
+  * Remove libkrb5* transitional packages as it installs alongside
+
+ -- Dominic Cleal <dcleal@redhat.com>  Thu, 28 Aug 2014 19:21:00 +0100
+
 ruby-rkerberos (0.1.1-1) UNRELEASED; urgency=low
 
   * Non-maintainer upload.

--- a/dependencies/wheezy/rkerberos/control
+++ b/dependencies/wheezy/rkerberos/control
@@ -13,47 +13,7 @@ Architecture: any
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter
 Suggests: doc-base
-Replaces: libkrb5-ruby (<< 0.7-3~), libkrb5-ruby1.8 (<< 0.7-3~), libkrb5-ruby1.9.1 (<< 0.7-3~), libkrb5-ruby-doc (<< 0.7-3~), ruby-krb5-auth
-Breaks: libkrb5-ruby (<< 0.7-3~), libkrb5-ruby1.8 (<< 0.7-3~), libkrb5-ruby1.9.1 (<< 0.7-3~), libkrb5-ruby-doc (<< 0.7-3~), ruby-krb5-auth
-Provides: libkrb5-ruby, libkrb5-ruby1.8, libkrb5-ruby1.9.1, libkrb5-ruby-doc, ruby-krb5-auth
 Description: Kerberos binding for Ruby
  Ruby kerberos provides basic Kerberos bindings for ruby which allow
  authentication, password changes, adding principals, and deleting
  principals.
-
-Package: libkrb5-ruby
-Section: oldlibs
-Priority: extra
-Architecture: all
-Depends: ${misc:Depends}, ruby-rkerberos
-Description: Transitional package for ruby-rkerberos
- This is a transitional package to ease upgrades to the ruby-rkerberos
- package. It can safely be removed.
-
-Package: libkrb5-ruby1.8
-Section: oldlibs
-Priority: extra
-Architecture: all
-Depends: ${misc:Depends}, ruby-rkerberos
-Description: Transitional package for ruby-rkerberos
- This is a transitional package to ease upgrades to the ruby-rkerberos
- package. It can safely be removed.
-
-Package: libkrb5-ruby1.9.1
-Section: oldlibs
-Priority: extra
-Architecture: all
-Depends: ${misc:Depends}, ruby-rkerberos
-Description: Transitional package for ruby-rkerberos
- This is a transitional package to ease upgrades to the ruby-rkerberos
- package. It can safely be removed.
-
-Package: libkrb5-ruby-doc
-Section: oldlibs
-Priority: extra
-Architecture: all
-Depends: ${misc:Depends}, ruby-rkerberos
-Description: Transitional package for ruby-rkerberos
- This is a transitional package to ease upgrades to the ruby-rkerberos
- package. It can safely be removed.
-


### PR DESCRIPTION
libkrb5-ruby\* are part of ruby-krb5-auth in Debian main, and while rkerberos
is the successor to krb5-auth, claiming to replace the packages causes
conflicts as version numbers aren't equivalent.

---

I'm trying to get the archives to pass dose-distcheck tests, this was flagged up.  The builds for squeeze/precise were done by @GregSutcliffe I think though, the files aren't in this repo.  They might need fixing manually...
