### PR TITLE
Update rubygem-apipie-bindings to 0.0.10

### DIFF
--- a/rubygem-apipie-bindings/apipie-bindings-0.0.10.gem
+++ b/rubygem-apipie-bindings/apipie-bindings-0.0.10.gem
@@ -1,0 +1,1 @@
+../.git/annex/objects/5F/Vq/SHA256E-s17408--2403c21229fe84bbceb198a6febca2d0193c4becfe2dceb55a6de96dd1860678.10.gem/SHA256E-s17408--2403c21229fe84bbceb198a6febca2d0193c4becfe2dceb55a6de96dd1860678.10.gem

--- a/rubygem-apipie-bindings/apipie-bindings-0.0.9.gem
+++ b/rubygem-apipie-bindings/apipie-bindings-0.0.9.gem
@@ -1,1 +1,0 @@
-../.git/annex/objects/kj/8Q/SHA256E-s16384--dc16dc34fee6bca4a8866e3cb74e0e01ea64233b867d4a1c1bed4ed91262829b.9.gem/SHA256E-s16384--dc16dc34fee6bca4a8866e3cb74e0e01ea64233b867d4a1c1bed4ed91262829b.9.gem

--- a/rubygem-apipie-bindings/rubygem-apipie-bindings.spec
+++ b/rubygem-apipie-bindings/rubygem-apipie-bindings.spec
@@ -5,7 +5,7 @@
 
 Summary: The Ruby bindings for Apipie documented APIs
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 0.0.9
+Version: 0.0.10
 Release: 1%{?dist}
 Group: Development/Libraries
 License: GPLv3


### PR DESCRIPTION
Scratches:
el6: http://koji.katello.org/koji/taskinfo?taskID=158605
el7: http://koji.katello.org/koji/taskinfo?taskID=158615
fedora 19: http://koji.katello.org/koji/taskinfo?taskID=158609
