### PR TITLE
fixes #7234 - add foreman-release-scl meta-package

### DIFF
--- a/comps/comps-foreman-rhel6.xml
+++ b/comps/comps-foreman-rhel6.xml
@@ -21,10 +21,14 @@
       <packagereq type="default">foreman-postgresql</packagereq>
       <packagereq type="default">foreman-proxy</packagereq>
       <packagereq type="default">foreman-release</packagereq>
+      <packagereq type="default">foreman-release-scl</packagereq>
       <packagereq type="default">foreman-selinux</packagereq>
       <packagereq type="default">foreman-sqlite</packagereq>
       <packagereq type="default">foreman-test</packagereq>
       <packagereq type="default">foreman-vmware</packagereq>
+
+      <packagereq type="default">rhscl-ruby193-epel-6-x86_64</packagereq>
+      <packagereq type="default">rhscl-v8314-epel-6-x86_64</packagereq>
 
       <packagereq type="default">ruby193-facter</packagereq>
       <packagereq type="default">ruby193-mod_passenger</packagereq>

--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -21,10 +21,14 @@
       <packagereq type="default">foreman-postgresql</packagereq>
       <packagereq type="default">foreman-proxy</packagereq>
       <packagereq type="default">foreman-release</packagereq>
+      <packagereq type="default">foreman-release-scl</packagereq>
       <packagereq type="default">foreman-selinux</packagereq>
       <packagereq type="default">foreman-sqlite</packagereq>
       <packagereq type="default">foreman-test</packagereq>
       <packagereq type="default">foreman-vmware</packagereq>
+
+      <packagereq type="default">rhscl-ruby193-epel-7-x86_64</packagereq>
+      <packagereq type="default">rhscl-v8314-epel-7-x86_64</packagereq>
 
       <packagereq type="default">ruby193-facter</packagereq>
       <packagereq type="default">ruby193-mod_passenger</packagereq>

--- a/extras/extras-foreman-rhel6-x86_64
+++ b/extras/extras-foreman-rhel6-x86_64
@@ -1,0 +1,2 @@
+https://www.softwarecollections.org/en/scls/rhscl/ruby193/epel-6-x86_64/download/rhscl-ruby193-epel-6-x86_64.noarch.rpm
+https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-6-x86_64/download/rhscl-v8314-epel-6-x86_64.noarch.rpm

--- a/extras/extras-foreman-rhel7-x86_64
+++ b/extras/extras-foreman-rhel7-x86_64
@@ -1,0 +1,2 @@
+https://www.softwarecollections.org/en/scls/rhscl/ruby193/epel-7-x86_64/download/rhscl-ruby193-epel-7-x86_64.noarch.rpm
+https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-7-x86_64/download/rhscl-v8314-epel-7-x86_64.noarch.rpm

--- a/foreman-release-scl/foreman-release-scl.spec
+++ b/foreman-release-scl/foreman-release-scl.spec
@@ -1,0 +1,23 @@
+Name:     foreman-release-scl
+Version:  1
+Release:  1%{?dist}
+
+Summary:  Foreman Software Collections repositories meta-package
+Group:    Applications/System
+License:  GPLv3+
+URL:      http://theforeman.org
+
+Requires: rhscl-ruby193-epel-%{rhel}-%{_arch}
+Requires: rhscl-v8314-epel-%{rhel}-%{_arch}
+
+%description
+Software Collection repositories provide additional sets of software packages,
+typically newer versions than those available in an OS distribution.
+
+This meta-package depends on those packages that contain the Yum repository
+configuration files required for Foreman.  It's designed for use on Red Hat
+Enterprise Linux rebuilds, such as CentOS.
+
+%files
+
+%changelog

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -17,6 +17,7 @@ fetch_strategy = custom.JenkinsSourceStrategy
 disttag = .el6
 blacklist = foreman-installer
   foreman-proxy
+  foreman-release-scl
   foreman-selinux
   rubygem-clamp
   rubygem-ffi
@@ -39,6 +40,7 @@ scl = ruby193
 disttag = .el7
 blacklist = foreman-installer
   foreman-proxy
+  foreman-release-scl
   foreman-selinux
   rubygem-clamp
   rubygem-ffi
@@ -65,6 +67,7 @@ scl = ruby193
 disttag = .el6
 whitelist = foreman-installer
   foreman-proxy
+  foreman-release-scl
   foreman-selinux
   rubygem-apipie-bindings
   rubygem-awesome_print
@@ -98,6 +101,7 @@ whitelist = foreman-installer
 disttag = .el7
 whitelist = foreman-installer
   foreman-proxy
+  foreman-release-scl
   foreman-selinux
   rubygem-apipie-bindings
   rubygem-awesome_print


### PR DESCRIPTION
Depends on the release RPMs from softwarecollections.org, for RHEL clone users
to get the repositories that provide RHSCL rebuilds.

extras/ will be consumed by the mash split script when we build repos, much
like comps/.  These files will be fetched and included into the finished repo.

---

I've created an updated mash split script which seems to do the job, I created a test repo with the rhscl-\* release packages inside from my packaging branch.

http://koji.katello.org/koji/taskinfo?taskID=163534 el6
http://koji.katello.org/koji/taskinfo?taskID=163535 el7
