### PR TITLE
Move unused rubygem-less, less-rails, commonjs deps to plugins

### DIFF
--- a/comps/comps-foreman-fedora19.xml
+++ b/comps/comps-foreman-fedora19.xml
@@ -36,7 +36,6 @@
       <packagereq type="default">rubygem-bootstrap-sass</packagereq>
       <packagereq type="default">rubygem-bundler_ext</packagereq>
       <packagereq type="default">rubygem-clamp</packagereq>
-      <packagereq type="default">rubygem-commonjs</packagereq>
       <packagereq type="default">rubygem-deep_cloneable</packagereq>
       <packagereq type="default">rubygem-excon</packagereq>
       <packagereq type="default">rubygem-extlib</packagereq>
@@ -71,8 +70,6 @@
       <packagereq type="default">rubygem-kafo_parsers</packagereq>
       <packagereq type="default">rubygem-launchy</packagereq>
       <packagereq type="default">rubygem-ldap_fluff</packagereq>
-      <packagereq type="default">rubygem-less-rails</packagereq>
-      <packagereq type="default">rubygem-less</packagereq>
       <packagereq type="default">rubygem-libv8</packagereq>
       <packagereq type="default">rubygem-multi-select-rails</packagereq>
       <packagereq type="default">rubygem-mysql2</packagereq>
@@ -108,7 +105,6 @@
       <packagereq type="default">rubygem-bootstrap-sass-doc</packagereq>
       <packagereq type="default">rubygem-bundler_ext-doc</packagereq>
       <packagereq type="default">rubygem-clamp-doc</packagereq>
-      <packagereq type="default">rubygem-commonjs-doc</packagereq>
       <packagereq type="default">rubygem-deep_cloneable-doc</packagereq>
       <packagereq type="default">rubygem-excon-doc</packagereq>
       <packagereq type="default">rubygem-extlib-doc</packagereq>
@@ -137,8 +133,6 @@
       <packagereq type="default">rubygem-jwt-doc</packagereq>
       <packagereq type="default">rubygem-launchy-doc</packagereq>
       <packagereq type="default">rubygem-ldap_fluff-doc</packagereq>
-      <packagereq type="default">rubygem-less-doc</packagereq>
-      <packagereq type="default">rubygem-less-rails-doc</packagereq>
       <packagereq type="default">rubygem-multi-select-rails-doc</packagereq>
       <packagereq type="default">rubygem-mysql2-doc</packagereq>
       <packagereq type="default">rubygem-net-scp-doc</packagereq>

--- a/comps/comps-foreman-plugins-fedora19.xml
+++ b/comps/comps-foreman-plugins-fedora19.xml
@@ -42,12 +42,15 @@
       <packagereq type="default">rubygem-algebrick</packagereq>
       <packagereq type="default">rubygem-angular-rails-templates</packagereq>
       <packagereq type="default">rubygem-apipie-params</packagereq>
+      <packagereq type="default">rubygem-commonjs</packagereq>
       <packagereq type="default">rubygem-dalli</packagereq>
       <packagereq type="default">rubygem-deface</packagereq>
       <packagereq type="default">rubygem-diffy</packagereq>
       <packagereq type="default">rubygem-docker-api</packagereq>
       <packagereq type="default">rubygem-dynflow</packagereq>
       <packagereq type="default">rubygem-ftools</packagereq>
+      <packagereq type="default">rubygem-less</packagereq>
+      <packagereq type="default">rubygem-less-rails</packagereq>
       <packagereq type="default">rubygem-open4</packagereq>
       <packagereq type="default">rubygem-opennebula</packagereq>
       <packagereq type="default">rubygem-satyr</packagereq>
@@ -63,6 +66,7 @@
       <packagereq type="default">rubygem-angular-rails-templates-doc</packagereq>
       <packagereq type="default">rubygem-apipie-params-doc</packagereq>
       <packagereq type="default">rubygem-bastion-doc</packagereq>
+      <packagereq type="default">rubygem-commonjs-doc</packagereq>
       <packagereq type="default">rubygem-dalli-doc</packagereq>
       <packagereq type="default">rubygem-deface-doc</packagereq>
       <packagereq type="default">rubygem-diffy-doc</packagereq>
@@ -89,6 +93,8 @@
       <packagereq type="default">rubygem-foreman_templates-doc</packagereq>
       <packagereq type="default">rubygem-foreman_xen-doc</packagereq>
       <packagereq type="default">rubygem-ftools-doc</packagereq>
+      <packagereq type="default">rubygem-less-doc</packagereq>
+      <packagereq type="default">rubygem-less-rails-doc</packagereq>
       <packagereq type="default">rubygem-open4-doc</packagereq>
       <packagereq type="default">rubygem-opennebula-doc</packagereq>
       <packagereq type="default">rubygem-ovirt_provision_plugin-doc</packagereq>

--- a/comps/comps-foreman-plugins-rhel6.xml
+++ b/comps/comps-foreman-plugins-rhel6.xml
@@ -44,6 +44,7 @@
       <packagereq type="default">ruby193-rubygem-angular-rails-templates</packagereq>
       <packagereq type="default">ruby193-rubygem-apipie-params</packagereq>
       <packagereq type="default">ruby193-rubygem-archive-tar-minitar</packagereq>
+      <packagereq type="default">ruby193-rubygem-commonjs</packagereq>
       <packagereq type="default">ruby193-rubygem-dalli</packagereq>
       <packagereq type="default">ruby193-rubygem-deface</packagereq>
       <packagereq type="default">ruby193-rubygem-diffy</packagereq>
@@ -51,6 +52,8 @@
       <packagereq type="default">ruby193-rubygem-dynflow</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman-tasks</packagereq>
       <packagereq type="default">ruby193-rubygem-ftools</packagereq>
+      <packagereq type="default">ruby193-rubygem-less</packagereq>
+      <packagereq type="default">ruby193-rubygem-less-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-little-plugger</packagereq>
       <packagereq type="default">ruby193-rubygem-logging</packagereq>
       <packagereq type="default">ruby193-rubygem-open4</packagereq>
@@ -70,6 +73,7 @@
       <packagereq type="default">ruby193-rubygem-apipie-params-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-archive-tar-minitar-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-bastion-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-commonjs-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-dalli-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-deface-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-diffy-doc</packagereq>
@@ -96,6 +100,8 @@
       <packagereq type="default">ruby193-rubygem-foreman_templates-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_xen-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-ftools-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-less-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-less-rails-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-little-plugger-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-logging-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-open4-doc</packagereq>

--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -44,6 +44,7 @@
       <packagereq type="default">ruby193-rubygem-angular-rails-templates</packagereq>
       <packagereq type="default">ruby193-rubygem-apipie-params</packagereq>
       <packagereq type="default">ruby193-rubygem-archive-tar-minitar</packagereq>
+      <packagereq type="default">ruby193-rubygem-commonjs</packagereq>
       <packagereq type="default">ruby193-rubygem-dalli</packagereq>
       <packagereq type="default">ruby193-rubygem-deface</packagereq>
       <packagereq type="default">ruby193-rubygem-diffy</packagereq>
@@ -51,6 +52,8 @@
       <packagereq type="default">ruby193-rubygem-dynflow</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman-tasks</packagereq>
       <packagereq type="default">ruby193-rubygem-ftools</packagereq>
+      <packagereq type="default">ruby193-rubygem-less</packagereq>
+      <packagereq type="default">ruby193-rubygem-less-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-little-plugger</packagereq>
       <packagereq type="default">ruby193-rubygem-logging</packagereq>
       <packagereq type="default">ruby193-rubygem-open4</packagereq>
@@ -70,6 +73,7 @@
       <packagereq type="default">ruby193-rubygem-apipie-params-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-archive-tar-minitar-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-bastion-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-commonjs-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-dalli-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-deface-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-diffy-doc</packagereq>
@@ -96,6 +100,8 @@
       <packagereq type="default">ruby193-rubygem-foreman_templates-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_xen-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-ftools-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-less-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-less-rails-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-little-plugger-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-logging-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-open4-doc</packagereq>

--- a/comps/comps-foreman-rhel6.xml
+++ b/comps/comps-foreman-rhel6.xml
@@ -44,7 +44,6 @@
       <packagereq type="default">ruby193-rubygem-awesome_print</packagereq>
       <packagereq type="default">ruby193-rubygem-bootstrap-sass</packagereq>
       <packagereq type="default">ruby193-rubygem-bundler_ext</packagereq>
-      <packagereq type="default">ruby193-rubygem-commonjs</packagereq>
       <packagereq type="default">ruby193-rubygem-daemons</packagereq>
       <packagereq type="default">ruby193-rubygem-deep_cloneable</packagereq>
       <packagereq type="default">ruby193-rubygem-eventmachine</packagereq>
@@ -80,8 +79,6 @@
       <packagereq type="default">ruby193-rubygem-jwt</packagereq>
       <packagereq type="default">ruby193-rubygem-launchy</packagereq>
       <packagereq type="default">ruby193-rubygem-ldap_fluff</packagereq>
-      <packagereq type="default">ruby193-rubygem-less</packagereq>
-      <packagereq type="default">ruby193-rubygem-less-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-levenshtein</packagereq>
       <packagereq type="default">ruby193-rubygem-libv8</packagereq>
       <packagereq type="default">ruby193-rubygem-locale</packagereq>
@@ -189,7 +186,6 @@
       <packagereq type="default">ruby193-rubygem-awesome_print-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-bootstrap-sass-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-bundler_ext-doc</packagereq>
-      <packagereq type="default">ruby193-rubygem-commonjs-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-deep_cloneable-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-eventmachine-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-excon-doc</packagereq>
@@ -220,8 +216,6 @@
       <packagereq type="default">ruby193-rubygem-jwt-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-launchy-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-ldap_fluff-doc</packagereq>
-      <packagereq type="default">ruby193-rubygem-less-doc</packagereq>
-      <packagereq type="default">ruby193-rubygem-less-rails-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-multi_json-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-multipart-post-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-multi-select-rails-doc</packagereq>

--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -44,7 +44,6 @@
       <packagereq type="default">ruby193-rubygem-awesome_print</packagereq>
       <packagereq type="default">ruby193-rubygem-bootstrap-sass</packagereq>
       <packagereq type="default">ruby193-rubygem-bundler_ext</packagereq>
-      <packagereq type="default">ruby193-rubygem-commonjs</packagereq>
       <packagereq type="default">ruby193-rubygem-daemons</packagereq>
       <packagereq type="default">ruby193-rubygem-deep_cloneable</packagereq>
       <packagereq type="default">ruby193-rubygem-eventmachine</packagereq>
@@ -80,8 +79,6 @@
       <packagereq type="default">ruby193-rubygem-jwt</packagereq>
       <packagereq type="default">ruby193-rubygem-launchy</packagereq>
       <packagereq type="default">ruby193-rubygem-ldap_fluff</packagereq>
-      <packagereq type="default">ruby193-rubygem-less</packagereq>
-      <packagereq type="default">ruby193-rubygem-less-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-levenshtein</packagereq>
       <packagereq type="default">ruby193-rubygem-libv8</packagereq>
       <packagereq type="default">ruby193-rubygem-locale</packagereq>
@@ -193,7 +190,6 @@
       <packagereq type="default">ruby193-rubygem-awesome_print-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-bootstrap-sass-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-bundler_ext-doc</packagereq>
-      <packagereq type="default">ruby193-rubygem-commonjs-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-deep_cloneable-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-eventmachine-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-excon-doc</packagereq>
@@ -224,8 +220,6 @@
       <packagereq type="default">ruby193-rubygem-jwt-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-launchy-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-ldap_fluff-doc</packagereq>
-      <packagereq type="default">ruby193-rubygem-less-doc</packagereq>
-      <packagereq type="default">ruby193-rubygem-less-rails-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-multi_json-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-multipart-post-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-multi-select-rails-doc</packagereq>

--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -115,7 +115,6 @@ BuildRequires: %{?scl_prefix}rubygem(gettext_i18n_rails_js) >= 0.0.8
 BuildRequires: %{?scl_prefix}rubygem(i18n_data) >= 0.2.6
 BuildRequires: %{?scl_prefix}rubygem(jquery-rails)
 BuildRequires: %{?scl_prefix}rubygem(jquery-ui-rails) < 5.0.0
-BuildRequires: %{?scl_prefix}rubygem(less-rails)
 BuildRequires: %{?scl_prefix}rubygem(net-ldap)
 BuildRequires: %{?scl_prefix}rubygem(oauth)
 BuildRequires: %{?scl_prefix}rubygem(rabl) >= 0.7.5

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -143,7 +143,6 @@ whitelist = foreman
   rubygem-bootstrap-sass
   rubygem-bundler_ext
   rubygem-clamp
-  rubygem-commonjs
   rubygem-deep_cloneable
   rubygem-excon
   rubygem-extlib
@@ -178,8 +177,6 @@ whitelist = foreman
   rubygem-jwt
   rubygem-launchy
   rubygem-ldap_fluff
-  rubygem-less
-  rubygem-less-rails
   rubygem-librarian-puppet
   rubygem-libv8
   rubygem-multi-select-rails
@@ -218,7 +215,7 @@ whitelist = ipxe
   rubygem-apipie-params
   rubygem-archive-tar-minitar
   rubygem-bastion
-  rubygem-ftools
+  rubygem-commonjs
   rubygem-dalli
   rubygem-deface
   rubygem-diffy
@@ -247,8 +244,10 @@ whitelist = ipxe
   rubygem-foreman_simplify
   rubygem-foreman_snapshot
   rubygem-foreman_xen
+  rubygem-ftools
+  rubygem-less
+  rubygem-less-rails
   rubygem-little-plugger
-  rubygem-staypuft
   rubygem-foreman_templates
   rubygem-ovirt_provision_plugin
   rubygem-puppetdb_foreman
@@ -257,6 +256,7 @@ whitelist = ipxe
   rubygem-smart_proxy_pulp
   rubygem-smart_proxy_salt
   rubygem-sprockets-rails
+  rubygem-staypuft
   rubygem-wicked
 
 [foreman-plugins-nightly-rhel7]
@@ -267,7 +267,7 @@ whitelist = rubygem-algebrick
   rubygem-apipie-params
   rubygem-archive-tar-minitar
   rubygem-bastion
-  rubygem-ftools
+  rubygem-commonjs
   rubygem-dalli
   rubygem-deface
   rubygem-diffy
@@ -297,6 +297,9 @@ whitelist = rubygem-algebrick
   rubygem-foreman_snapshot
   rubygem-foreman_xen
   rubygem-foreman_templates
+  rubygem-ftools
+  rubygem-less
+  rubygem-less-rails
   rubygem-little-plugger
   rubygem-ovirt_provision_plugin
   rubygem-puppetdb_foreman
@@ -314,11 +317,11 @@ whitelist = rubygem-algebrick
   rubygem-angular-rails-templates
   rubygem-apipie-params
   rubygem-bastion
+  rubygem-commonjs
   rubygem-dalli
   rubygem-deface
   rubygem-diffy
   rubygem-docker-api
-  rubygem-ftools
   rubygem-open4
   rubygem-opennebula
   rubygem-foreman_abrt
@@ -344,6 +347,9 @@ whitelist = rubygem-algebrick
   rubygem-foreman_snapshot
   rubygem-foreman_templates
   rubygem-foreman_xen
+  rubygem-ftools
+  rubygem-less
+  rubygem-less-rails
   rubygem-ovirt_provision_plugin
   rubygem-puppetdb_foreman
   rubygem-satyr


### PR DESCRIPTION
Looks like this was added back in 1.2 when we went to SCL, but core doesn't use it.  Instead it will be used by rubygem-bastion once it appears in the plugins repo.

Builds of foreman, hopefully proving we don't need it:
http://koji.katello.org/koji/taskinfo?taskID=170857 f19
http://koji.katello.org/koji/taskinfo?taskID=170858 el6
http://koji.katello.org/koji/taskinfo?taskID=170861 el7

Already retagged, so should be good to go.  Once merged, I'll untag it from the old tags.
