### PR TITLE
fixes #7970 - add and prefer /usr/bin/foreman-ruby symlink

### DIFF
--- a/debian/precise/foreman/foreman-assets.postinst
+++ b/debian/precise/foreman/foreman-assets.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/precise/foreman/foreman-compute.postinst
+++ b/debian/precise/foreman/foreman-compute.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/precise/foreman/foreman-console.postinst
+++ b/debian/precise/foreman/foreman-console.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/precise/foreman/foreman-development.postinst
+++ b/debian/precise/foreman/foreman-development.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/precise/foreman/foreman-libvirt.postinst
+++ b/debian/precise/foreman/foreman-libvirt.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/precise/foreman/foreman-mysql2.postinst
+++ b/debian/precise/foreman/foreman-mysql2.postinst
@@ -1,5 +1,5 @@
 #!/bin/sh
-# postinst script for foreman-mysql2
+# postinst script for foreman database
 #
 # see: dh_installdeb(1)
 
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Run a db:migrate and db:seed if the user has created a dbfile

--- a/debian/precise/foreman/foreman-ovirt.postinst
+++ b/debian/precise/foreman/foreman-ovirt.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/precise/foreman/foreman-postgresql.postinst
+++ b/debian/precise/foreman/foreman-postgresql.postinst
@@ -1,5 +1,5 @@
 #!/bin/sh
-# postinst script for foreman-pqsql
+# postinst script for foreman database
 #
 # see: dh_installdeb(1)
 
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Run a db:migrate and db:seed if the user has created a dbfile

--- a/debian/precise/foreman/foreman-test.postinst
+++ b/debian/precise/foreman/foreman-test.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/precise/foreman/foreman-vmware.postinst
+++ b/debian/precise/foreman/foreman-vmware.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/precise/foreman/foreman.postinst
+++ b/debian/precise/foreman/foreman.postinst
@@ -31,12 +31,15 @@ chmod 755 '/var/lib/foreman/public'
 chmod 755 '/var/lib/foreman/public/assets'
 chmod 755 '/var/cache/foreman'
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Test for Gemfile.lock to determine the right action.
 cd /usr/share/foreman
 if [ -f Gemfile.lock ]; then
-  CMD="bundle update --local"
+  CMD="$BUNDLE update --local"
 else
-  CMD="bundle install --path ./vendor/ --local --no-prune"
+  CMD="$BUNDLE install --path ./vendor/ --local --no-prune"
 fi
 
 if [ ! -z "${DEBUG}" ]; then

--- a/debian/precise/foreman/links
+++ b/debian/precise/foreman/links
@@ -6,3 +6,4 @@ var/cache/foreman		usr/share/foreman/tmp
 var/lib/foreman/db		usr/share/foreman/db
 var/log/foreman			usr/share/foreman/log
 var/lib/foreman/public		usr/share/foreman/public
+usr/bin/ruby1.9.1		usr/bin/foreman-ruby

--- a/debian/precise/foreman/rules
+++ b/debian/precise/foreman/rules
@@ -21,3 +21,5 @@ build/foreman::
 	# Somehow blank db sqlite files get added
 	/bin/rm db/production.sqlite3
 	/bin/rm db/development.sqlite3
+	# Use rake1.9.1 explicitly
+	sed -ri 'sX/usr/bin/rake$$X/usr/bin/rake1.9.1X' extras/dbmigrate script/foreman-rake

--- a/debian/trusty/foreman/foreman-assets.postinst
+++ b/debian/trusty/foreman/foreman-assets.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/trusty/foreman/foreman-compute.postinst
+++ b/debian/trusty/foreman/foreman-compute.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/trusty/foreman/foreman-console.postinst
+++ b/debian/trusty/foreman/foreman-console.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/trusty/foreman/foreman-development.postinst
+++ b/debian/trusty/foreman/foreman-development.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/trusty/foreman/foreman-libvirt.postinst
+++ b/debian/trusty/foreman/foreman-libvirt.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/trusty/foreman/foreman-mysql2.postinst
+++ b/debian/trusty/foreman/foreman-mysql2.postinst
@@ -1,5 +1,5 @@
 #!/bin/sh
-# postinst script for foreman-mysql2
+# postinst script for foreman database
 #
 # see: dh_installdeb(1)
 
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Run a db:migrate and db:seed if the user has created a dbfile

--- a/debian/trusty/foreman/foreman-ovirt.postinst
+++ b/debian/trusty/foreman/foreman-ovirt.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/trusty/foreman/foreman-postgresql.postinst
+++ b/debian/trusty/foreman/foreman-postgresql.postinst
@@ -1,5 +1,5 @@
 #!/bin/sh
-# postinst script for foreman-pqsql
+# postinst script for foreman database
 #
 # see: dh_installdeb(1)
 
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Run a db:migrate and db:seed if the user has created a dbfile

--- a/debian/trusty/foreman/foreman-test.postinst
+++ b/debian/trusty/foreman/foreman-test.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/trusty/foreman/foreman-vmware.postinst
+++ b/debian/trusty/foreman/foreman-vmware.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/trusty/foreman/foreman.postinst
+++ b/debian/trusty/foreman/foreman.postinst
@@ -31,12 +31,15 @@ chmod 755 '/var/lib/foreman/public'
 chmod 755 '/var/lib/foreman/public/assets'
 chmod 755 '/var/cache/foreman'
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Test for Gemfile.lock to determine the right action.
 cd /usr/share/foreman
 if [ -f Gemfile.lock ]; then
-  CMD="bundle update --local"
+  CMD="$BUNDLE update --local"
 else
-  CMD="bundle install --path ./vendor/ --local --no-prune"
+  CMD="$BUNDLE install --path ./vendor/ --local --no-prune"
 fi
 
 if [ ! -z "${DEBUG}" ]; then

--- a/debian/trusty/foreman/links
+++ b/debian/trusty/foreman/links
@@ -6,3 +6,4 @@ var/cache/foreman		usr/share/foreman/tmp
 var/lib/foreman/db		usr/share/foreman/db
 var/log/foreman			usr/share/foreman/log
 var/lib/foreman/public		usr/share/foreman/public
+usr/bin/ruby		usr/bin/foreman-ruby

--- a/debian/wheezy/foreman/foreman-assets.postinst
+++ b/debian/wheezy/foreman/foreman-assets.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/wheezy/foreman/foreman-compute.postinst
+++ b/debian/wheezy/foreman/foreman-compute.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/wheezy/foreman/foreman-console.postinst
+++ b/debian/wheezy/foreman/foreman-console.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/wheezy/foreman/foreman-development.postinst
+++ b/debian/wheezy/foreman/foreman-development.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/wheezy/foreman/foreman-libvirt.postinst
+++ b/debian/wheezy/foreman/foreman-libvirt.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/wheezy/foreman/foreman-mysql2.postinst
+++ b/debian/wheezy/foreman/foreman-mysql2.postinst
@@ -1,5 +1,5 @@
 #!/bin/sh
-# postinst script for foreman-mysql2
+# postinst script for foreman database
 #
 # see: dh_installdeb(1)
 
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Run a db:migrate and db:seed if the user has created a dbfile

--- a/debian/wheezy/foreman/foreman-ovirt.postinst
+++ b/debian/wheezy/foreman/foreman-ovirt.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/wheezy/foreman/foreman-postgresql.postinst
+++ b/debian/wheezy/foreman/foreman-postgresql.postinst
@@ -1,5 +1,5 @@
 #!/bin/sh
-# postinst script for foreman-pqsql
+# postinst script for foreman database
 #
 # see: dh_installdeb(1)
 
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Run a db:migrate and db:seed if the user has created a dbfile

--- a/debian/wheezy/foreman/foreman-test.postinst
+++ b/debian/wheezy/foreman/foreman-test.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/wheezy/foreman/foreman-vmware.postinst
+++ b/debian/wheezy/foreman/foreman-vmware.postinst
@@ -17,12 +17,15 @@ LOGFILE='/var/log/foreman-install.log'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  bundle update --local
+  $BUNDLE update --local
 else
-  bundle update --local 2>&1 >> $LOGFILE
+  $BUNDLE update --local 2>&1 >> $LOGFILE
 fi
 
 # Own all the core files

--- a/debian/wheezy/foreman/foreman.postinst
+++ b/debian/wheezy/foreman/foreman.postinst
@@ -31,12 +31,15 @@ chmod 755 '/var/lib/foreman/public'
 chmod 755 '/var/lib/foreman/public/assets'
 chmod 755 '/var/cache/foreman'
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Test for Gemfile.lock to determine the right action.
 cd /usr/share/foreman
 if [ -f Gemfile.lock ]; then
-  CMD="bundle update --local"
+  CMD="$BUNDLE update --local"
 else
-  CMD="bundle install --path ./vendor/ --local --no-prune"
+  CMD="$BUNDLE install --path ./vendor/ --local --no-prune"
 fi
 
 if [ ! -z "${DEBUG}" ]; then

--- a/debian/wheezy/foreman/links
+++ b/debian/wheezy/foreman/links
@@ -6,3 +6,4 @@ var/cache/foreman		usr/share/foreman/tmp
 var/lib/foreman/db		usr/share/foreman/db
 var/log/foreman			usr/share/foreman/log
 var/lib/foreman/public		usr/share/foreman/public
+usr/bin/ruby		usr/bin/foreman-ruby

--- a/plugins/ruby-foreman-bootdisk/debian/changelog
+++ b/plugins/ruby-foreman-bootdisk/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-bootdisk (4.0.0-1) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 16:59:28 +0100
+
 ruby-foreman-bootdisk (4.0.0) stable; urgency=low
 
   * 4.0.0 released

--- a/plugins/ruby-foreman-bootdisk/debian/postinst
+++ b/plugins/ruby-foreman-bootdisk/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='foreman_bootdisk'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-foreman-chef/debian/changelog
+++ b/plugins/ruby-foreman-chef/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-chef (0.0.4-2) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 16:59:31 +0100
+
 ruby-foreman-chef (0.0.4-1) unstable; urgency=low
 
   * Package gems into Foreman's cache dir for local install

--- a/plugins/ruby-foreman-chef/debian/postinst
+++ b/plugins/ruby-foreman-chef/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='foreman_chef'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-foreman-column-view/debian/changelog
+++ b/plugins/ruby-foreman-column-view/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-column-view (0.2.0-3) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 16:59:34 +0100
+
 ruby-foreman-column-view (0.2.0-2) stable; urgency=low
 
   * Package gems into Foreman's cache dir for local install

--- a/plugins/ruby-foreman-column-view/debian/postinst
+++ b/plugins/ruby-foreman-column-view/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='foreman_column_view'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-foreman-deface/debian/changelog
+++ b/plugins/ruby-foreman-deface/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-deface (0.9.1-1) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 16:59:42 +0100
+
 ruby-foreman-deface (0.9.1) unstable; urgency=low
 
   * Initial Release.

--- a/plugins/ruby-foreman-deface/debian/postinst
+++ b/plugins/ruby-foreman-deface/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='deface'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-foreman-default-hostgroup/debian/changelog
+++ b/plugins/ruby-foreman-default-hostgroup/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-default-hostgroup (2.0.1-2) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 16:59:45 +0100
+
 ruby-foreman-default-hostgroup (2.0.1-1) unstable; urgency=low
 
   * Package gems into Foreman's cache dir for local install

--- a/plugins/ruby-foreman-default-hostgroup/debian/postinst
+++ b/plugins/ruby-foreman-default-hostgroup/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='foreman_default_hostgroup'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-foreman-dhcp-browser/debian/changelog
+++ b/plugins/ruby-foreman-dhcp-browser/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-dhcp-browser (0.0.6-1) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Mon, 20 Oct 2014 09:14:40 +0100
+
 ruby-foreman-dhcp-browser (0.0.6) stable; urgency=low
 
   * Update to 0.0.6.

--- a/plugins/ruby-foreman-dhcp-browser/debian/postinst
+++ b/plugins/ruby-foreman-dhcp-browser/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='foreman_dhcp_browser'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-foreman-discovery/debian/changelog
+++ b/plugins/ruby-foreman-discovery/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-discovery (1.4.0~rc4-2) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 16:59:53 +0100
+
 ruby-foreman-discovery (1.4.0~rc4-1) unstable; urgency=medium
 
   * Package RC4 for testing

--- a/plugins/ruby-foreman-discovery/debian/postinst
+++ b/plugins/ruby-foreman-discovery/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='foreman_discovery'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-foreman-hooks/debian/changelog
+++ b/plugins/ruby-foreman-hooks/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-hooks (0.3.4-2) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 16:59:57 +0100
+
 ruby-foreman-hooks (0.3.4-1) unstable; urgency=low
 
   * Package gems into Foreman's cache dir for local install

--- a/plugins/ruby-foreman-hooks/debian/postinst
+++ b/plugins/ruby-foreman-hooks/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='foreman_hooks'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-foreman-host-rundeck/debian/changelog
+++ b/plugins/ruby-foreman-host-rundeck/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-host-rundeck (0.0.2-1) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 16:59:59 +0100
+
 ruby-foreman-host-rundeck (0.0.2) stable; urgency=low
 
   * 0.0.2 released

--- a/plugins/ruby-foreman-host-rundeck/debian/postinst
+++ b/plugins/ruby-foreman-host-rundeck/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='foreman_host_rundeck'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-foreman-memcache/debian/changelog
+++ b/plugins/ruby-foreman-memcache/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-memcache (0.0.3-1) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 17:00:01 +0100
+
 ruby-foreman-memcache (0.0.3) unstable; urgency=low
 
   * Initial Release.

--- a/plugins/ruby-foreman-memcache/debian/postinst
+++ b/plugins/ruby-foreman-memcache/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='foreman_memcache'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-foreman-one/debian/changelog
+++ b/plugins/ruby-foreman-one/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-one (0.2-1) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 17:00:04 +0100
+
 ruby-foreman-one (0.2) unstable; urgency=low
 
   * Initial Release.

--- a/plugins/ruby-foreman-one/debian/postinst
+++ b/plugins/ruby-foreman-one/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='foreman_one'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-foreman-salt/debian/changelog
+++ b/plugins/ruby-foreman-salt/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-salt (0.0.4-1) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 17:00:07 +0100
+
 ruby-foreman-salt (0.0.4) unstable; urgency=low
 
   * Update to 0.0.4

--- a/plugins/ruby-foreman-salt/debian/postinst
+++ b/plugins/ruby-foreman-salt/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='foreman_salt'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-foreman-setup/debian/changelog
+++ b/plugins/ruby-foreman-setup/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-setup (2.1.0-1) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 17:00:09 +0100
+
 ruby-foreman-setup (2.1.0) stable; urgency=low
 
   * 2.1.0 released

--- a/plugins/ruby-foreman-setup/debian/postinst
+++ b/plugins/ruby-foreman-setup/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='foreman_setup'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-foreman-snapshot/debian/changelog
+++ b/plugins/ruby-foreman-snapshot/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-snapshot (0.1.0-2) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 17:00:12 +0100
+
 ruby-foreman-snapshot (0.1.0-1) stable; urgency=low
 
   * Package gems into Foreman's cache dir for local install

--- a/plugins/ruby-foreman-snapshot/debian/postinst
+++ b/plugins/ruby-foreman-snapshot/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='foreman_snapshot'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-foreman-templates/debian/changelog
+++ b/plugins/ruby-foreman-templates/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-templates (1.4.0-3) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 17:00:16 +0100
+
 ruby-foreman-templates (1.4.0-2) unstable; urgency=low
 
   * Package gems into Foreman's cache dir for local install

--- a/plugins/ruby-foreman-templates/debian/postinst
+++ b/plugins/ruby-foreman-templates/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='puppetdb_foreman'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-foreman-xen/debian/changelog
+++ b/plugins/ruby-foreman-xen/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-xen (0.0.3-1) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 17:00:19 +0100
+
 ruby-foreman-xen (0.0.3) unstable; urgency=low
 
   * Initial Release.

--- a/plugins/ruby-foreman-xen/debian/postinst
+++ b/plugins/ruby-foreman-xen/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='foreman_xen'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 

--- a/plugins/ruby-puppetdb-foreman/debian/changelog
+++ b/plugins/ruby-puppetdb-foreman/debian/changelog
@@ -1,3 +1,9 @@
+ruby-puppetdb-foreman (0.1.1-1) stable; urgency=low
+
+  * Prefer foreman-ruby symlink to run bundler if it exists
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 17 Oct 2014 17:00:22 +0100
+
 ruby-puppetdb-foreman (0.1.1) stable; urgency=low
 
   * Release 0.1.1, proxy PuppetDB performance dashboard

--- a/plugins/ruby-puppetdb-foreman/debian/postinst
+++ b/plugins/ruby-puppetdb-foreman/debian/postinst
@@ -18,19 +18,22 @@ PLUGIN='puppetdb_foreman'
 # hang if daemons have been started
 trap db_stop EXIT
 
+BUNDLE=bundle
+[ -h /usr/bin/foreman-ruby ] && BUNDLE="/usr/bin/foreman-ruby /usr/bin/bundle"
+
 # Update gems
 cd /usr/share/foreman
 if [ ! -z "${DEBUG}" ]; then
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local
   else
-    bundle install --local --no-prune
+    $BUNDLE install --local --no-prune
   fi
 else
-  if bundle show $PLUGIN >/dev/null 2>&1; then
-    bundle update $PLUGIN --local 2>&1 >> $LOGFILE
+  if $BUNDLE show $PLUGIN >/dev/null 2>&1; then
+    $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
   else
-    bundle install --local --no-prune 2>&1 >> $LOGFILE
+    $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
   fi
 fi
 


### PR DESCRIPTION
Use foreman-ruby for bundle calls especially, so it allows the default Ruby
to vary separately from Foreman's.  Set foreman-ruby to ruby1.9.1 explicitly
on Ubuntu 12.04.

---

Not finished, I've not copied this to all plugins + OSes, but easy to do so if it looks good.  @mmoll?

Scratch build at http://ci.theforeman.org/job/packaging_build_deb_coreproject/1285/label=debian,os=precise/ which worked well for me.  I was able to install the package, seeing foreman-rake and the bundle installs runs correctly while the default Ruby was 1.8.
