### PR TITLE
[do not merge] Remove runtime dependency on bootstrap-sass, asset precompilation only

### DIFF
--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -88,8 +88,6 @@ Requires: %{?scl_prefix}rubygem(gettext_i18n_rails_js) >= 0.0.8
 Requires: %{?scl_prefix}rubygem(i18n_data) >= 0.2.6
 Requires: %{?scl_prefix}rubygem(therubyracer)
 Requires: %{?scl_prefix}rubygem(jquery-ui-rails) < 5.0.0
-Requires: %{?scl_prefix}rubygem(bootstrap-sass) >= 3.0.3.0
-Requires: %{?scl_prefix}rubygem(bootstrap-sass) < 3.0.4
 Requires: %{?scl_prefix}rubygem(foreigner) >= 1.4.2
 Requires: %{?scl_prefix}rubygem(deep_cloneable) >= 2.0.0
 Requires: %{?scl_prefix}rubygem(deep_cloneable) < 3.0.0
@@ -123,6 +121,7 @@ BuildRequires: %{?scl_prefix}rubygem(rest-client)
 BuildRequires: %{?scl_prefix}rubygem(ruby_parser) >= 3.0.0
 BuildRequires: %{?scl_prefix}rubygem(safemode) >= 1.2.1
 BuildRequires: %{?scl_prefix}rubygem(sass-rails) => 3.2.3
+BuildRequires: %{?scl_prefix}rubygem(sass-rails) < 3.3
 BuildRequires: %{?scl_prefix}rubygem(scoped_search) >= 2.7.0
 BuildRequires: %{?scl_prefix}rubygem(scoped_search) < 3.0.0
 BuildRequires: %{?scl_prefix}rubygem(sqlite3)


### PR DESCRIPTION
Two more RPMs removed from the default install.  They're already in the foreman-assets deps, but are unneeded at runtime when we ship precompiled stylesheets.

http://koji.katello.org/koji/taskinfo?taskID=175198 f19
http://koji.katello.org/koji/taskinfo?taskID=175200 el6
http://koji.katello.org/koji/taskinfo?taskID=175202 el7
