### PR TITLE
update rubyipmi to 0.8.1 (DEB)

### DIFF
--- a/dependencies/precise/rubyipmi/changelog
+++ b/dependencies/precise/rubyipmi/changelog
@@ -1,3 +1,10 @@
+ruby-rubyipmi (0.8.1-1) unstable; urgency=low
+
+  * Update to 0.8.1
+  * License was changed to LGPLv2.1
+
+ -- Michael Moll <mmoll@mmoll.at>  Tue, 28 Oct 2014 23:56:25 +0100
+
 ruby-rubyipmi (0.7.0-1) unstable; urgency=low
 
   * Update to 0.7.0

--- a/dependencies/precise/rubyipmi/copyright
+++ b/dependencies/precise/rubyipmi/copyright
@@ -4,12 +4,9 @@ Source: https://github.com/logicminds/rubyipmi
 
 Files: *
 Copyright: 2013, Corey Osman <corey@logicminds.biz>
-License: GPL-3+
+License: LGPL-2.1
 
 Files: debian/*
 Copyright: 2013, Michael Moll <mmoll@mmoll.at>
-License: GPL-3+
+License: LGPL-2.1
 Comment: the Debian packaging is licensed under the same terms as the original package.
-
-On Debian systems, you can find the full text of the GNU General Public
-License v3 in `/usr/share/common-licenses/GPL-3'.

--- a/dependencies/precise/rubyipmi/watch
+++ b/dependencies/precise/rubyipmi/watch
@@ -1,2 +1,0 @@
-version=3
-http://pkg-ruby-extras.alioth.debian.org/cgi-bin/gemwatch/rubyipmi .*/rubyipmi-(.*).tar.gz

--- a/dependencies/squeeze/rubyipmi/changelog
+++ b/dependencies/squeeze/rubyipmi/changelog
@@ -1,3 +1,10 @@
+ruby-rubyipmi (0.8.1-1) unstable; urgency=low
+
+  * Update to 0.8.1
+  * License was changed to LGPLv2.1
+
+ -- Michael Moll <mmoll@mmoll.at>  Tue, 28 Oct 2014 23:56:25 +0100
+
 ruby-rubyipmi (0.7.0-1) unstable; urgency=low
 
   * Update to 0.7.0

--- a/dependencies/squeeze/rubyipmi/copyright
+++ b/dependencies/squeeze/rubyipmi/copyright
@@ -4,12 +4,9 @@ Source: https://github.com/logicminds/rubyipmi
 
 Files: *
 Copyright: 2013, Corey Osman <corey@logicminds.biz>
-License: GPL-3+
+License: LGPL-2.1
 
 Files: debian/*
 Copyright: 2013, Michael Moll <mmoll@mmoll.at>
-License: GPL-3+
+License: LGPL-2.1
 Comment: the Debian packaging is licensed under the same terms as the original package.
-
-On Debian systems, you can find the full text of the GNU General Public
-License v3 in `/usr/share/common-licenses/GPL-3'.

--- a/dependencies/squeeze/rubyipmi/watch
+++ b/dependencies/squeeze/rubyipmi/watch
@@ -1,2 +1,0 @@
-version=3
-http://pkg-ruby-extras.alioth.debian.org/cgi-bin/gemwatch/rubyipmi .*/rubyipmi-(.*).tar.gz

--- a/dependencies/trusty/rubyipmi/changelog
+++ b/dependencies/trusty/rubyipmi/changelog
@@ -1,3 +1,10 @@
+ruby-rubyipmi (0.8.1-1) unstable; urgency=low
+
+  * Update to 0.8.1
+  * License was changed to LGPLv2.1
+
+ -- Michael Moll <mmoll@mmoll.at>  Tue, 28 Oct 2014 23:56:25 +0100
+
 ruby-rubyipmi (0.7.0-1) unstable; urgency=low
 
   * Update to 0.7.0

--- a/dependencies/trusty/rubyipmi/copyright
+++ b/dependencies/trusty/rubyipmi/copyright
@@ -4,12 +4,9 @@ Source: https://github.com/logicminds/rubyipmi
 
 Files: *
 Copyright: 2013, Corey Osman <corey@logicminds.biz>
-License: GPL-3+
+License: LGPL-2.1
 
 Files: debian/*
 Copyright: 2013, Michael Moll <mmoll@mmoll.at>
-License: GPL-3+
+License: LGPL-2.1
 Comment: the Debian packaging is licensed under the same terms as the original package.
-
-On Debian systems, you can find the full text of the GNU General Public
-License v3 in `/usr/share/common-licenses/GPL-3'.

--- a/dependencies/trusty/rubyipmi/watch
+++ b/dependencies/trusty/rubyipmi/watch
@@ -1,2 +1,0 @@
-version=3
-http://pkg-ruby-extras.alioth.debian.org/cgi-bin/gemwatch/rubyipmi .*/rubyipmi-(.*).tar.gz

--- a/dependencies/wheezy/rubyipmi/changelog
+++ b/dependencies/wheezy/rubyipmi/changelog
@@ -1,3 +1,10 @@
+ruby-rubyipmi (0.8.1-1) unstable; urgency=low
+
+  * Update to 0.8.1
+  * License was changed to LGPLv2.1
+
+ -- Michael Moll <mmoll@mmoll.at>  Tue, 28 Oct 2014 23:56:25 +0100
+
 ruby-rubyipmi (0.7.0-1) unstable; urgency=low
 
   * Update to 0.7.0

--- a/dependencies/wheezy/rubyipmi/copyright
+++ b/dependencies/wheezy/rubyipmi/copyright
@@ -4,12 +4,9 @@ Source: https://github.com/logicminds/rubyipmi
 
 Files: *
 Copyright: 2013, Corey Osman <corey@logicminds.biz>
-License: GPL-3+
+License: LGPL-2.1
 
 Files: debian/*
 Copyright: 2013, Michael Moll <mmoll@mmoll.at>
-License: GPL-3+
+License: LGPL-2.1
 Comment: the Debian packaging is licensed under the same terms as the original package.
-
-On Debian systems, you can find the full text of the GNU General Public
-License v3 in `/usr/share/common-licenses/GPL-3'.

--- a/dependencies/wheezy/rubyipmi/watch
+++ b/dependencies/wheezy/rubyipmi/watch
@@ -1,2 +1,0 @@
-version=3
-http://pkg-ruby-extras.alioth.debian.org/cgi-bin/gemwatch/rubyipmi .*/rubyipmi-(.*).tar.gz


### PR DESCRIPTION
http://ci.theforeman.org/job/packaging_build_deb_dependency/592/
waiting for tests with IPMI hardware (#416 for RPMs)
