### PR TITLE
Remove db:migrate on snapshot postinst

### DIFF
--- a/plugins/ruby-foreman-snapshot/debian/changelog
+++ b/plugins/ruby-foreman-snapshot/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-snapshot (0.1.0-3) stable; urgency=low
+
+  * Remove db:migrate from postinst.
+
+ -- Daniel Lobato Garcia <elobatocs@gmail.com>  Fri, 31 Oct 2014 10:26:00 +0100
+
 ruby-foreman-snapshot (0.1.0-2) stable; urgency=low
 
   * Prefer foreman-ruby symlink to run bundler if it exists

--- a/plugins/ruby-foreman-snapshot/debian/postinst
+++ b/plugins/ruby-foreman-snapshot/debian/postinst
@@ -37,19 +37,6 @@ else
   fi
 fi
 
-# DB migrate/seed after install
-if [ -f /usr/share/foreman/config/database.yml ]; then
-  if [ ! -z "${DEBUG}" ]; then
-    /usr/sbin/foreman-rake db:migrate || true
-    /usr/sbin/foreman-rake db:seed || true
-    /usr/sbin/foreman-rake apipie:cache || true
-  else
-    /usr/sbin/foreman-rake db:migrate >> $LOGFILE 2>&1 || true
-    /usr/sbin/foreman-rake db:seed >> $LOGFILE 2>&1 || true
-    /usr/sbin/foreman-rake apipie:cache >> $LOGFILE 2>&1 || true
-  fi
-fi
-
 # Own all the core files
 chown -Rf foreman:foreman '/usr/share/foreman'
 


### PR DESCRIPTION
foreman-snapshot does not need to run any migrations
