### PR TITLE
Remove therubyracer runtime dependency

### DIFF
--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -85,7 +85,6 @@ Requires: %{?scl_prefix}rubygem(gettext_i18n_rails) >= 0.10.0
 Requires: %{?scl_prefix}rubygem(gettext_i18n_rails) < 1.0.0
 Requires: %{?scl_prefix}rubygem(gettext_i18n_rails_js) >= 0.0.8
 Requires: %{?scl_prefix}rubygem(i18n_data) >= 0.2.6
-Requires: %{?scl_prefix}rubygem(therubyracer)
 Requires: %{?scl_prefix}rubygem(foreigner) >= 1.4.2
 Requires: %{?scl_prefix}rubygem(deep_cloneable) >= 2.0.0
 Requires: %{?scl_prefix}rubygem(deep_cloneable) < 3.0.0


### PR DESCRIPTION
I don't think this has any runtime usage, I can remove it and v8\* here with no apparent consequences.  It remains a build time dependency of course, and is required by foreman-assets still, enabling its use for asset precompilation.  I don't think there's any other use of a JavaScript engine.

http://koji.katello.org/koji/taskinfo?taskID=188942 f19
http://koji.katello.org/koji/taskinfo?taskID=188944 el6
http://koji.katello.org/koji/taskinfo?taskID=188948 el7

Just putting this up to check I'm not going mad.
