### PR TITLE
installer missing rgen ruby dependency

### DIFF
--- a/debian/trusty/foreman-proxy/control
+++ b/debian/trusty/foreman-proxy/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/ohadlevy/smart-proxy
 
 Package: foreman-proxy
 Architecture: all
-Depends: ruby1.9.1|ruby-interpreter, rake, ruby-sinatra, ruby-rack (>= 1.1.0), ruby-json, ruby-rkerberos (>= 0.1.1), ruby-bundler-ext
+Depends: ruby1.9.1|ruby-interpreter, rake, ruby-sinatra, ruby-rack (>= 1.1.0), ruby-json, ruby-rkerberos (>= 0.1.1), ruby-bundler-ext, ruby-rgen
 Recommends: sudo, wget, ping
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems


### PR DESCRIPTION
added missing ruby-rgen package dependency as that is needed at least on trusty

ISSUE: 8542
http://projects.theforeman.org/issues/8542
