### PR TITLE
refs #2972 - jsonp support [rpm]

### DIFF
--- a/comps/comps-foreman-fedora19.xml
+++ b/comps/comps-foreman-fedora19.xml
@@ -73,6 +73,7 @@
       <packagereq type="default">rubygem-powerbar</packagereq>
       <packagereq type="default">rubygem-quiet_assets</packagereq>
       <packagereq type="default">rubygem-rabl</packagereq>
+      <packagereq type="default">rubygem-rack-jsonp</packagereq>
       <packagereq type="default">rubygem-rb-readline</packagereq>
       <packagereq type="default">rubygem-rbovirt</packagereq>
       <packagereq type="default">rubygem-rbvmomi</packagereq>
@@ -137,6 +138,7 @@
       <packagereq type="default">rubygem-powerbar-doc</packagereq>
       <packagereq type="default">rubygem-quiet_assets-doc</packagereq>
       <packagereq type="default">rubygem-rabl-doc</packagereq>
+      <packagereq type="default">rubygem-rack-jsonp-doc</packagereq>
       <packagereq type="default">rubygem-rbovirt-doc</packagereq>
       <packagereq type="default">rubygem-rb-readline-doc</packagereq>
       <packagereq type="default">rubygem-rbvmomi-doc</packagereq>

--- a/comps/comps-foreman-rhel6.xml
+++ b/comps/comps-foreman-rhel6.xml
@@ -91,6 +91,7 @@
       <packagereq type="default">ruby193-rubygem-po_to_json</packagereq>
       <packagereq type="default">ruby193-rubygem-quiet_assets</packagereq>
       <packagereq type="default">ruby193-rubygem-rabl</packagereq>
+      <packagereq type="default">ruby193-rubygem-rack-jsonp</packagereq>
       <packagereq type="default">ruby193-rubygem-rbovirt</packagereq>
       <packagereq type="default">ruby193-rubygem-rbvmomi</packagereq>
       <packagereq type="default">ruby193-rubygem-rest-client</packagereq>
@@ -220,6 +221,7 @@
       <packagereq type="default">ruby193-rubygem-po_to_json-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-quiet_assets-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-rabl-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-rack-jsonp-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-rbovirt-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-rbvmomi-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-retriable-doc</packagereq>

--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -91,6 +91,7 @@
       <packagereq type="default">ruby193-rubygem-po_to_json</packagereq>
       <packagereq type="default">ruby193-rubygem-quiet_assets</packagereq>
       <packagereq type="default">ruby193-rubygem-rabl</packagereq>
+      <packagereq type="default">ruby193-rubygem-rack-jsonp</packagereq>
       <packagereq type="default">ruby193-rubygem-rbovirt</packagereq>
       <packagereq type="default">ruby193-rubygem-rbvmomi</packagereq>
       <packagereq type="default">ruby193-rubygem-rest-client</packagereq>
@@ -223,6 +224,7 @@
       <packagereq type="default">ruby193-rubygem-po_to_json-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-quiet_assets-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-rabl-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-rack-jsonp-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-rbovirt-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-rbvmomi-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-retriable-doc</packagereq>

--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -102,6 +102,8 @@ Requires: %{?scl_prefix}rubygem(gettext_i18n_rails) >= 1.0
 Requires: %{?scl_prefix}rubygem(gettext_i18n_rails) < 2.0
 Requires: %{?scl_prefix}rubygem(turbolinks) >= 2.5
 Requires: %{?scl_prefix}rubygem(turbolinks) < 3.0
+# jsonp
+Requires: %{?scl_prefix}rubygem(rack-jsonp)
 
 # Build dependencies
 BuildRequires: gettext
@@ -557,14 +559,32 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,0755)
-%doc README.md
-%doc VERSION
-%doc LICENSE
-%exclude %{_datadir}/%{name}/bundler.d/*
-%{_datadir}/%{name}
-%attr(700,%{name},%{name}) %{_datadir}/%{name}/.ssh
-%{_datadir}/%{name}/plugins
+%doc CHANGELOG Contributors LICENSE README.md VERSION
+%dir %{_datadir}/%{name}
+%{_datadir}/%{name}/app
 %exclude %{_datadir}/%{name}/app/assets
+%dir %{_datadir}/%{name}/bundler.d
+%exclude %{_datadir}/%{name}/bundler.d/development.rb
+%{_datadir}/%{name}/bundler.d/facter.rb
+%{_datadir}/%{name}/bundler.d/jsonp.rb
+%exclude %{_datadir}/%{name}/bundler.d/openid.rb
+%exclude %{_datadir}/%{name}/bundler.d/test.rb
+%{_datadir}/%{name}/config*
+%{_datadir}/%{name}/db
+%{_datadir}/%{name}/extras
+%{_datadir}/%{name}/Gemfile.in
+%{_datadir}/%{name}/lib
+%{_datadir}/%{name}/locale
+%{_datadir}/%{name}/log
+%{_datadir}/%{name}/migrate
+%{_datadir}/%{name}/plugins
+%{_datadir}/%{name}/public
+%{_datadir}/%{name}/Rakefile
+%{_datadir}/%{name}/script
+%{_datadir}/%{name}/seeds.*
+%attr(700,%{name},%{name}) %{_datadir}/%{name}/.ssh
+%{_datadir}/%{name}/tmp
+%{_datadir}/%{name}/VERSION
 %{_initrddir}/%{name}
 %{_sbindir}/%{name}-debug
 %{_sbindir}/%{name}-rake

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -178,6 +178,7 @@ whitelist = foreman
   rubygem-powerbar
   rubygem-quiet_assets
   rubygem-rabl
+  rubygem-rack-jsonp
   rubygem-rb-readline
   rubygem-rbvmomi
   rubygem-rbovirt

--- a/rubygem-rack-jsonp/rack-jsonp-1.3.1.gem
+++ b/rubygem-rack-jsonp/rack-jsonp-1.3.1.gem
@@ -1,0 +1,1 @@
+../.git/annex/objects/7g/5M/SHA256E-s7168--2d4187fc96122fab629dddfdf3e8c462059c70daf1999d85c88e59bfa51a197c.1.gem/SHA256E-s7168--2d4187fc96122fab629dddfdf3e8c462059c70daf1999d85c88e59bfa51a197c.1.gem

--- a/rubygem-rack-jsonp/rubygem-rack-jsonp.spec
+++ b/rubygem-rack-jsonp/rubygem-rack-jsonp.spec
@@ -1,0 +1,76 @@
+%{?scl:%scl_package rubygem-%{gem_name}}
+%{!?scl:%global pkg_name %{name}}
+
+%global gem_name rack-jsonp
+%global rubyabi 1.9.1
+
+Summary: A Rack middleware for providing JSON-P support
+Name: %{?scl_prefix}rubygem-%{gem_name}
+Version: 1.3.1
+Release: 1%{?dist}
+Group: Development/Languages
+License: MIT
+URL: https://github.com/crohr/rack-jsonp
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
+
+%if 0%{?fedora} > 18
+Requires: %{?scl_prefix}ruby(release)
+%else
+Requires: %{?scl_prefix}ruby(abi) = %{rubyabi}
+%endif
+Requires: %{?scl_prefix}ruby(rubygems)
+Requires: %{?scl_prefix}ruby
+Requires: %{?scl_prefix}rubygem(rack)
+
+%if 0%{?fedora} > 18
+BuildRequires: %{?scl_prefix}ruby(release)
+%else
+BuildRequires: %{?scl_prefix}ruby(abi) = %{rubyabi}
+%endif
+BuildRequires: %{?scl_prefix}rubygems-devel
+BuildRequires: %{?scl_prefix}ruby
+BuildArch: noarch
+Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
+
+%description
+A Rack middleware for providing JSON-P support. Most of it is taken from the
+original Rack::JSONP middleware present in rack-contrib.
+
+%package doc
+Summary: Documentation for %{pkg_name}
+Group: Documentation
+Requires: %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+BuildArch: noarch
+
+%description doc
+Documentation for %{pkg_name}
+
+%prep
+%setup -n %{pkg_name}-%{version} -q -c -T
+mkdir -p .%{gem_dir}
+%{?scl:scl enable %{scl} "}
+gem install --local --install-dir .%{gem_dir} \
+            --force %{SOURCE0}
+%{?scl:"}
+
+%build
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -a .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+%files
+%dir %{gem_instdir}
+%{gem_libdir}
+%doc %{gem_instdir}/LICENSE
+%exclude %{gem_instdir}/spec
+%exclude %{gem_cache}
+%{gem_spec}
+
+%files doc
+%doc %{gem_docdir}
+%doc %{gem_instdir}/README.rdoc
+%{gem_instdir}/Rakefile
+
+%changelog


### PR DESCRIPTION
The PR test might fail on the foreman change, I'm not sure it's working right now for core packages.

foreman scratch builds:
http://koji.katello.org/koji/taskinfo?taskID=199932 f19
http://koji.katello.org/koji/taskinfo?taskID=199934 el6
http://koji.katello.org/koji/taskinfo?taskID=199935 el7

rack-jsonp scratch builds:
http://koji.katello.org/koji/taskinfo?taskID=199920
http://koji.katello.org/koji/taskinfo?taskID=199921
http://koji.katello.org/koji/taskinfo?taskID=199922

More explanation in the commit message as to why I had to change so much just to add jsonp.rb.