### PR TITLE
refs #8802 - add *turbolinks dependencies

### DIFF
--- a/comps/comps-foreman-fedora19.xml
+++ b/comps/comps-foreman-fedora19.xml
@@ -86,6 +86,7 @@
       <packagereq type="default">rubygem-spice-html5-rails</packagereq>
       <packagereq type="default">rubygem-table_print</packagereq>
       <packagereq type="default">rubygem-terminal-table</packagereq>
+      <packagereq type="default">rubygem-turbolinks</packagereq>
       <packagereq type="default">rubygem-unicode-display_width</packagereq>
       <packagereq type="default">rubygem-validates_lengths_from_database</packagereq>
 
@@ -147,6 +148,7 @@
       <packagereq type="default">rubygem-signet-doc</packagereq>
       <packagereq type="default">rubygem-spice-html5-rails-doc</packagereq>
       <packagereq type="default">rubygem-table_print-doc</packagereq>
+      <packagereq type="default">rubygem-turbolinks-doc</packagereq>
       <packagereq type="default">rubygem-unicode-display_width-doc</packagereq>
       <packagereq type="default">rubygem-validates_lengths_from_database-doc</packagereq>
       <!--RGD-END-->

--- a/comps/comps-foreman-fedora19.xml
+++ b/comps/comps-foreman-fedora19.xml
@@ -58,6 +58,7 @@
       <packagereq type="default">rubygem-hirb-unicode</packagereq>
       <packagereq type="default">rubygem-hirb</packagereq>
       <packagereq type="default">rubygem-jquery_pwstrength_bootstrap</packagereq>
+      <packagereq type="default">rubygem-jquery-turbolinks</packagereq>
       <packagereq type="default">rubygem-jquery-ui-rails</packagereq>
       <packagereq type="default">rubygem-jwt</packagereq>
       <packagereq type="default">rubygem-kafo</packagereq>
@@ -123,6 +124,7 @@
       <packagereq type="default">rubygem-hirb-doc</packagereq>
       <packagereq type="default">rubygem-hirb-unicode-doc</packagereq>
       <packagereq type="default">rubygem-jquery_pwstrength_bootstrap-doc</packagereq>
+      <packagereq type="default">rubygem-jquery-turbolinks-doc</packagereq>
       <packagereq type="default">rubygem-jquery-ui-rails-doc</packagereq>
       <packagereq type="default">rubygem-jwt-doc</packagereq>
       <packagereq type="default">rubygem-launchy-doc</packagereq>

--- a/comps/comps-foreman-rhel6.xml
+++ b/comps/comps-foreman-rhel6.xml
@@ -67,6 +67,7 @@
       <packagereq type="default">ruby193-rubygem-hirb</packagereq>
       <packagereq type="default">ruby193-rubygem-ipaddress</packagereq>
       <packagereq type="default">ruby193-rubygem-jquery_pwstrength_bootstrap</packagereq>
+      <packagereq type="default">ruby193-rubygem-jquery-turbolinks</packagereq>
       <packagereq type="default">ruby193-rubygem-jquery-ui-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-jwt</packagereq>
       <packagereq type="default">ruby193-rubygem-launchy</packagereq>
@@ -198,6 +199,7 @@
       <packagereq type="default">ruby193-rubygem-hirb-unicode-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-ipaddress-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-jquery_pwstrength_bootstrap-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-jquery-turbolinks-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-jquery-ui-rails-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-jwt-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-launchy-doc</packagereq>

--- a/comps/comps-foreman-rhel6.xml
+++ b/comps/comps-foreman-rhel6.xml
@@ -111,6 +111,7 @@
       <packagereq type="default">ruby193-rubygem-syntax</packagereq>
       <packagereq type="default">ruby193-rubygem-text</packagereq>
       <packagereq type="default">ruby193-rubygem-trollop</packagereq>
+      <packagereq type="default">ruby193-rubygem-turbolinks</packagereq>
       <packagereq type="default">ruby193-rubygem-unf</packagereq>
       <packagereq type="default">ruby193-rubygem-unf_ext</packagereq>
       <packagereq type="default">ruby193-rubygem-unicode-display_width</packagereq>
@@ -235,6 +236,7 @@
       <packagereq type="default">ruby193-rubygem-sprockets-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-sshkey-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-text-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-turbolinks-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-unf-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-unf_ext-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-unicode-display_width-doc</packagereq>

--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -111,6 +111,7 @@
       <packagereq type="default">ruby193-rubygem-syntax</packagereq>
       <packagereq type="default">ruby193-rubygem-text</packagereq>
       <packagereq type="default">ruby193-rubygem-trollop</packagereq>
+      <packagereq type="default">ruby193-rubygem-turbolinks</packagereq>
       <packagereq type="default">ruby193-rubygem-unf</packagereq>
       <packagereq type="default">ruby193-rubygem-unf_ext</packagereq>
       <packagereq type="default">ruby193-rubygem-unicode-display_width</packagereq>
@@ -238,6 +239,7 @@
       <packagereq type="default">ruby193-rubygem-sprockets-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-sshkey-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-text-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-turbolinks-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-unf-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-unf_ext-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-unicode-display_width-doc</packagereq>

--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -67,6 +67,7 @@
       <packagereq type="default">ruby193-rubygem-hirb</packagereq>
       <packagereq type="default">ruby193-rubygem-ipaddress</packagereq>
       <packagereq type="default">ruby193-rubygem-jquery_pwstrength_bootstrap</packagereq>
+      <packagereq type="default">ruby193-rubygem-jquery-turbolinks</packagereq>
       <packagereq type="default">ruby193-rubygem-jquery-ui-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-jwt</packagereq>
       <packagereq type="default">ruby193-rubygem-launchy</packagereq>
@@ -201,6 +202,7 @@
       <packagereq type="default">ruby193-rubygem-hirb-unicode-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-ipaddress-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-jquery_pwstrength_bootstrap-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-jquery-turbolinks-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-jquery-ui-rails-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-jwt-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-launchy-doc</packagereq>

--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -100,6 +100,8 @@ Requires: %{?scl_prefix}rubygem(fast_gettext) >= 0.8
 Requires: %{?scl_prefix}rubygem(fast_gettext) < 1.0
 Requires: %{?scl_prefix}rubygem(gettext_i18n_rails) >= 1.0
 Requires: %{?scl_prefix}rubygem(gettext_i18n_rails) < 2.0
+Requires: %{?scl_prefix}rubygem(turbolinks) >= 2.5
+Requires: %{?scl_prefix}rubygem(turbolinks) < 3.0
 
 # Build dependencies
 BuildRequires: gettext
@@ -150,6 +152,8 @@ BuildRequires: %{?scl_prefix}rubygem(fast_gettext) >= 0.8
 BuildRequires: %{?scl_prefix}rubygem(fast_gettext) < 1.0
 BuildRequires: %{?scl_prefix}rubygem(gettext_i18n_rails) >= 1.0
 BuildRequires: %{?scl_prefix}rubygem(gettext_i18n_rails) < 2.0
+BuildRequires: %{?scl_prefix}rubygem(turbolinks) >= 2.5
+BuildRequires: %{?scl_prefix}rubygem(turbolinks) < 3.0
 # assets
 BuildRequires: %{?scl_prefix}rubygem(sass-rails) >= 3.2
 BuildRequires: %{?scl_prefix}rubygem(sass-rails) < 4.0
@@ -175,6 +179,8 @@ BuildRequires: %{?scl_prefix}rubygem(gridster-rails) >= 0.1
 BuildRequires: %{?scl_prefix}rubygem(gridster-rails) < 1.0
 BuildRequires: %{?scl_prefix}rubygem(jquery_pwstrength_bootstrap) >= 1.2
 BuildRequires: %{?scl_prefix}rubygem(jquery_pwstrength_bootstrap) < 2.0
+BuildRequires: %{?scl_prefix}rubygem(jquery-turbolinks) >= 2.1
+BuildRequires: %{?scl_prefix}rubygem(jquery-turbolinks) < 3.0
 
 %package cli
 Summary: Foreman CLI
@@ -309,6 +315,8 @@ Requires: %{?scl_prefix}rubygem(gridster-rails) >= 0.1
 Requires: %{?scl_prefix}rubygem(gridster-rails) < 1.0
 Requires: %{?scl_prefix}rubygem(jquery_pwstrength_bootstrap) >= 1.2
 Requires: %{?scl_prefix}rubygem(jquery_pwstrength_bootstrap) < 2.0
+Requires: %{?scl_prefix}rubygem(jquery-turbolinks) >= 2.1
+Requires: %{?scl_prefix}rubygem(jquery-turbolinks) < 3.0
 
 %description assets
 Meta package to install asset pipeline support.

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -193,6 +193,7 @@ whitelist = foreman
   rubygem-table_print
   rubygem-terminal-table
   rubygem-therubyracer
+  rubygem-turbolinks
   rubygem-unicode-display_width
   rubygem-validates_lengths_from_database
 

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -163,6 +163,7 @@ whitelist = foreman
   rubygem-hirb
   rubygem-hirb-unicode
   rubygem-jquery_pwstrength_bootstrap
+  rubygem-jquery-turbolinks
   rubygem-jquery-ui-rails
   rubygem-jwt
   rubygem-launchy

--- a/rubygem-jquery-turbolinks/jquery-turbolinks-2.1.0.gem
+++ b/rubygem-jquery-turbolinks/jquery-turbolinks-2.1.0.gem
@@ -1,0 +1,1 @@
+../.git/annex/objects/PV/X4/SHA256E-s11264--0cf68325f00bcc1a79bdc991db9146cd4cd6a3d8de131e7f9a553d3aa8ad43b4.0.gem/SHA256E-s11264--0cf68325f00bcc1a79bdc991db9146cd4cd6a3d8de131e7f9a553d3aa8ad43b4.0.gem

--- a/rubygem-jquery-turbolinks/rubygem-jquery-turbolinks.spec
+++ b/rubygem-jquery-turbolinks/rubygem-jquery-turbolinks.spec
@@ -1,0 +1,95 @@
+%{?scl:%scl_package rubygem-%{gem_name}}
+%{!?scl:%global pkg_name %{name}}
+
+%global gem_name jquery-turbolinks
+
+Summary: jQuery plugin for binded events problem caused by Turbolinks
+Name: %{?scl_prefix}rubygem-%{gem_name}
+Version: 2.1.0
+Release: 1%{?dist}
+Group: Development/Languages
+License: MIT
+URL: https://github.com/kossnocorp/jquery.turbolinks
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
+
+%if 0%{?fedora} > 18
+Requires: %{?scl_prefix}ruby(release)
+%else
+Requires: %{?scl_prefix}ruby(abi)
+%endif
+Requires: %{?scl_prefix}ruby(rubygems)
+Requires: %{?scl_prefix}ruby
+Requires: %{?scl_prefix}rubygem(railties) >= 3.1.0
+Requires: %{?scl_prefix}rubygem(turbolinks)
+
+%if 0%{?fedora} > 18
+BuildRequires: %{?scl_prefix}ruby(release)
+%else
+BuildRequires: %{?scl_prefix}ruby(abi)
+%endif
+BuildRequires: %{?scl_prefix}rubygems-devel
+BuildRequires: %{?scl_prefix}ruby
+BuildArch: noarch
+Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
+
+%description
+Do you like Turbolinks? It's easy and fast way to improve user experience of
+surfing on your website.
+
+But if you have a large codebase with lots of $(el).bind(...) Turbolinks will
+surprise you. Most part of your JavaScripts will stop working in usual way.
+It's because the nodes on which you bind events no longer exist.
+
+I wrote jquery.turbolinks to solve this problem in my project. It's easy to
+use: just require it immediately after jquery.js. Your other scripts should be
+loaded after jquery.turbolinks.js, and turbolinks.js should be after your
+other scripts.
+
+%package doc
+Summary: Documentation for %{pkg_name}
+Group: Documentation
+Requires: %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+BuildArch: noarch
+
+%description doc
+Documentation for %{pkg_name}
+
+%prep
+%setup -n %{pkg_name}-%{version} -q -c -T
+mkdir -p .%{gem_dir}
+%{?scl:scl enable %{scl} "}
+gem install --local --install-dir .%{gem_dir} \
+            --force %{SOURCE0}
+%{?scl:"}
+
+%build
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -a .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+%files
+%dir %{gem_instdir}
+%{gem_libdir}
+%{gem_instdir}/src
+%{gem_instdir}/vendor
+%exclude %{gem_cache}
+%{gem_spec}
+%doc %{gem_instdir}/LICENSE.md
+
+%exclude %{gem_instdir}/.*
+%exclude %{gem_instdir}/Gemfile*
+%exclude %{gem_instdir}/Guardfile
+%exclude %{gem_instdir}/*.gemspec
+%exclude %{gem_instdir}/package.json
+
+%files doc
+%doc %{gem_docdir}
+%doc %{gem_instdir}/CONTRIBUTING.md
+%doc %{gem_instdir}/NOTES.md
+%doc %{gem_instdir}/README.md
+%{gem_instdir}/spec
+%{gem_instdir}/Rakefile
+
+%changelog

--- a/rubygem-turbolinks/rubygem-turbolinks.spec
+++ b/rubygem-turbolinks/rubygem-turbolinks.spec
@@ -1,0 +1,102 @@
+# Generated from turbolinks-0.5.1.gem by gem2rpm -*- rpm-spec -*-
+%{?scl:%scl_package rubygem-%{gem_name}}
+%{!?scl:%global pkg_name %{name}}
+
+%global gem_name turbolinks
+
+Summary:        Turbolinks makes following links in your web application faster
+Name:           %{?scl_prefix}rubygem-%{gem_name}
+Version:        2.5.3
+Release:        1%{?dist}
+Group:          Development/Languages
+License:        MIT
+URL:            http://github.com/rails/turbolinks
+Source0:        http://rubygems.org/gems/%{gem_name}-%{version}.gem
+%if 0%{?fedora} > 18
+Requires:       %{?scl_prefix}ruby(release)
+%else
+Requires:       %{?scl_prefix}ruby(abi)
+%endif
+Requires:       %{?scl_prefix}ruby(rubygems)
+Requires:       %{?scl_prefix}rubygem(coffee-rails)
+%if 0%{?fedora} > 18
+BuildRequires:  %{?scl_prefix}ruby(release)
+%else
+BuildRequires:  %{?scl_prefix}ruby(abi)
+%endif
+BuildRequires:  %{?scl_prefix}rubygems-devel
+BuildArch:      noarch
+Provides:       %{?scl_prefix}rubygem(%{gem_name}) = %{version}
+
+%description
+Turbolinks makes following links in your web application faster. Instead of
+letting the browser recompile the JavaScript and CSS between each page change,
+it keeps the current page instance alive and replaces only the body and
+the title in the head. Think CGI vs persistent process. (Use with Rails Asset
+Pipeline.)
+
+%package doc
+Summary:    Documentation for %{pkg_name}
+Group:      Documentation
+Requires:   %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+BuildArch:  noarch
+
+%description doc
+Documentation for %{pkg_name}
+
+%prep
+%setup -q -c -T
+mkdir -p .%{gem_dir}
+%{?scl:scl enable %{scl} "}
+gem install --local --install-dir .%{gem_dir} \
+            --force %{SOURCE0}
+%{?scl:"}
+
+%build
+%check
+# To test it:
+# run `rackup "test/config.ru"` to run the server and check manually serving assets
+# no idea how to make it automated in koji right now
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -a .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+%files
+%dir %{gem_instdir}
+%{gem_libdir}
+%exclude %{gem_cache}
+%{gem_spec}
+%doc %{gem_instdir}/MIT-LICENSE
+
+%files doc
+%doc %{gem_docdir}
+%doc %{gem_instdir}/README.md
+%{gem_instdir}/test
+
+%changelog
+* Tue Oct 14 2014 Josef Stribny <jstribny@redhat.com> - 2.4.0-1
+- Update to 2.4.0
+
+* Wed Jul 09 2014 Josef Stribny <jstribny@redhat.com> - 2.2.2-1
+- Update to 2.2.2
+
+* Sun Jun 08 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 2.2.1-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_21_Mass_Rebuild
+
+* Fri Mar 07 2014 Josef Stribny <jstribny@redhat.com> - 2.2.1-1
+- Update to 2.2.1
+
+* Wed Oct 23 2013 Josef Stribny <jstribny@redhat.com> - 1.3.0-1
+- Update to 1.3.0
+
+* Sun Aug 04 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.1.1-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_20_Mass_Rebuild
+
+* Mon Apr 22 2013 Josef Stribny <jstribny@redhat.com> - 1.1.1-1
+- Rebuild for https://fedoraproject.org/wiki/Features/Ruby_2.0.0
+- Update to 1.1.1
+
+* Thu Nov 15 2012 Josef Stribny <jstribny@redhat.com> - 0.5.1-1
+- Initial package

--- a/rubygem-turbolinks/turbolinks-2.5.3.gem
+++ b/rubygem-turbolinks/turbolinks-2.5.3.gem
@@ -1,0 +1,1 @@
+../.git/annex/objects/Z0/zk/SHA256E-s20992--5606242743a4c9bb1ef49bc5bb88ebdc2dc1a0ac99a602c9a71defbd8be8b9b5.3.gem/SHA256E-s20992--5606242743a4c9bb1ef49bc5bb88ebdc2dc1a0ac99a602c9a71defbd8be8b9b5.3.gem


### PR DESCRIPTION
Two new packages: turbolinks was imported from Fedora so should already be good, and jquery-turbolinks is new (a build time asset dep).

mock-based scratch builds of all packages for EL7 are at http://people.redhat.com/~dcleal/foreman-8802-turbolinks-el7/  - works fine for me.

Koji-based scratch builds of the two new packages...

jquery-turbolinks:
* http://koji.katello.org/koji/taskinfo?taskID=207712 f19
* http://koji.katello.org/koji/taskinfo?taskID=207713 el6
* http://koji.katello.org/koji/taskinfo?taskID=207714 el7

turbolinks:
* http://koji.katello.org/koji/taskinfo?taskID=207715 f19
* http://koji.katello.org/koji/taskinfo?taskID=207740 el6
* http://koji.katello.org/koji/taskinfo?taskID=207742 el7

Foreman isn't possible as it's a build dep that isn't available in the build roots yet - which is why the PR test fails.