### PR TITLE
update clamp to 0.6.3 (DEB only)

### DIFF
--- a/dependencies/precise/clamp/changelog
+++ b/dependencies/precise/clamp/changelog
@@ -1,3 +1,10 @@
+ruby-clamp (0.6.3-2foreman1) stable; urgency=low
+
+  * Update to 0.6.3 (licensing only change)
+  * Prepare versioning for Debian/jessie
+
+ -- Michael Moll <mmoll@mmoll.at>  Tue, 13 Jan 2014 00:31:24 +0100
+
 ruby-clamp (0.6.2-2) stable; urgency=low
 
   * Patch for i18n support

--- a/dependencies/precise/clamp/copyright
+++ b/dependencies/precise/clamp/copyright
@@ -1,33 +1,48 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: clamp
-Source: FIXME <http://example.com/>
+Source: https://github.com/mdub/clamp
 
 Files: *
-Copyright: <years> <put author's name and email here>
-           <years> <likewise for another author>
-License: GPL-2+ (FIXME)
- This program is free software; you can redistribute it
- and/or modify it under the terms of the GNU General Public
- License as published by the Free Software Foundation; either
- version 2 of the License, or (at your option) any later
- version.
- .
- This program is distributed in the hope that it will be
- useful, but WITHOUT ANY WARRANTY; without even the implied
- warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
- PURPOSE.  See the GNU General Public License for more
- details.
- .
- You should have received a copy of the GNU General Public
- License along with this package; if not, write to the Free
- Software Foundation, Inc., 51 Franklin St, Fifth Floor,
- Boston, MA  02110-1301 USA
- .
- On Debian systems, the full text of the GNU General Public
- License version 2 can be found in the file
- `/usr/share/common-licenses/GPL-2'.
+Copyright: 2010 Mike Williams <mdub@dogbiscuit.org>
+License: MIT
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Files: debian/*
-Copyright: 2013  <>
-License:
- [LICENSE TEXT]
+Copyright: 2013-2015 Foreman developers <foreman-dev@googlegroups.com>
+Comment: the Debian packaging is licensed under the same terms as the original package.
+License: MIT
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/dependencies/precise/clamp/ruby-clamp.docs
+++ b/dependencies/precise/clamp/ruby-clamp.docs
@@ -1,2 +1,2 @@
-# FIXME: READMEs found
-# README.md
+CHANGES.md
+README.md

--- a/dependencies/precise/clamp/ruby-clamp.examples
+++ b/dependencies/precise/clamp/ruby-clamp.examples
@@ -1,3 +1,1 @@
-# FIXME: examples/ dir found in source. Consider installing the examples.
-# Examples:
-# examples/*
+examples/*

--- a/dependencies/precise/clamp/watch
+++ b/dependencies/precise/clamp/watch
@@ -1,2 +1,0 @@
-version=3
-http://pkg-ruby-extras.alioth.debian.org/cgi-bin/gemwatch/clamp .*/clamp-(.*).tar.gz

--- a/dependencies/trusty/clamp/changelog
+++ b/dependencies/trusty/clamp/changelog
@@ -1,3 +1,10 @@
+ruby-clamp (0.6.3-2foreman1) stable; urgency=low
+
+  * Update to 0.6.3 (licensing only change)
+  * Prepare versioning for Debian/jessie
+
+ -- Michael Moll <mmoll@mmoll.at>  Tue, 13 Jan 2014 00:31:24 +0100
+
 ruby-clamp (0.6.2-2) stable; urgency=low
 
   * Patch for i18n support

--- a/dependencies/trusty/clamp/copyright
+++ b/dependencies/trusty/clamp/copyright
@@ -1,33 +1,48 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: clamp
-Source: FIXME <http://example.com/>
+Source: https://github.com/mdub/clamp
 
 Files: *
-Copyright: <years> <put author's name and email here>
-           <years> <likewise for another author>
-License: GPL-2+ (FIXME)
- This program is free software; you can redistribute it
- and/or modify it under the terms of the GNU General Public
- License as published by the Free Software Foundation; either
- version 2 of the License, or (at your option) any later
- version.
- .
- This program is distributed in the hope that it will be
- useful, but WITHOUT ANY WARRANTY; without even the implied
- warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
- PURPOSE.  See the GNU General Public License for more
- details.
- .
- You should have received a copy of the GNU General Public
- License along with this package; if not, write to the Free
- Software Foundation, Inc., 51 Franklin St, Fifth Floor,
- Boston, MA  02110-1301 USA
- .
- On Debian systems, the full text of the GNU General Public
- License version 2 can be found in the file
- `/usr/share/common-licenses/GPL-2'.
+Copyright: 2010 Mike Williams <mdub@dogbiscuit.org>
+License: MIT
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Files: debian/*
-Copyright: 2013  <>
-License:
- [LICENSE TEXT]
+Copyright: 2013-2015 Foreman developers <foreman-dev@googlegroups.com>
+Comment: the Debian packaging is licensed under the same terms as the original package.
+License: MIT
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/dependencies/trusty/clamp/ruby-clamp.docs
+++ b/dependencies/trusty/clamp/ruby-clamp.docs
@@ -1,2 +1,2 @@
-# FIXME: READMEs found
-# README.md
+CHANGES.md
+README.md

--- a/dependencies/trusty/clamp/ruby-clamp.examples
+++ b/dependencies/trusty/clamp/ruby-clamp.examples
@@ -1,3 +1,1 @@
-# FIXME: examples/ dir found in source. Consider installing the examples.
-# Examples:
-# examples/*
+examples/*

--- a/dependencies/trusty/clamp/watch
+++ b/dependencies/trusty/clamp/watch
@@ -1,2 +1,0 @@
-version=3
-http://pkg-ruby-extras.alioth.debian.org/cgi-bin/gemwatch/clamp .*/clamp-(.*).tar.gz

--- a/dependencies/wheezy/clamp/changelog
+++ b/dependencies/wheezy/clamp/changelog
@@ -1,3 +1,10 @@
+ruby-clamp (0.6.3-2foreman1) stable; urgency=low
+
+  * Update to 0.6.3 (licensing only change)
+  * Prepare versioning for Debian/jessie
+
+ -- Michael Moll <mmoll@mmoll.at>  Tue, 13 Jan 2014 00:31:24 +0100
+
 ruby-clamp (0.6.2-2) stable; urgency=low
 
   * Patch for i18n support

--- a/dependencies/wheezy/clamp/copyright
+++ b/dependencies/wheezy/clamp/copyright
@@ -1,33 +1,48 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: clamp
-Source: FIXME <http://example.com/>
+Source: https://github.com/mdub/clamp
 
 Files: *
-Copyright: <years> <put author's name and email here>
-           <years> <likewise for another author>
-License: GPL-2+ (FIXME)
- This program is free software; you can redistribute it
- and/or modify it under the terms of the GNU General Public
- License as published by the Free Software Foundation; either
- version 2 of the License, or (at your option) any later
- version.
- .
- This program is distributed in the hope that it will be
- useful, but WITHOUT ANY WARRANTY; without even the implied
- warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
- PURPOSE.  See the GNU General Public License for more
- details.
- .
- You should have received a copy of the GNU General Public
- License along with this package; if not, write to the Free
- Software Foundation, Inc., 51 Franklin St, Fifth Floor,
- Boston, MA  02110-1301 USA
- .
- On Debian systems, the full text of the GNU General Public
- License version 2 can be found in the file
- `/usr/share/common-licenses/GPL-2'.
+Copyright: 2010 Mike Williams <mdub@dogbiscuit.org>
+License: MIT
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Files: debian/*
-Copyright: 2013  <>
-License:
- [LICENSE TEXT]
+Copyright: 2013-2015 Foreman developers <foreman-dev@googlegroups.com>
+Comment: the Debian packaging is licensed under the same terms as the original package.
+License: MIT
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/dependencies/wheezy/clamp/ruby-clamp.docs
+++ b/dependencies/wheezy/clamp/ruby-clamp.docs
@@ -1,2 +1,2 @@
-# FIXME: READMEs found
-# README.md
+CHANGES.md
+README.md

--- a/dependencies/wheezy/clamp/ruby-clamp.examples
+++ b/dependencies/wheezy/clamp/ruby-clamp.examples
@@ -1,3 +1,1 @@
-# FIXME: examples/ dir found in source. Consider installing the examples.
-# Examples:
-# examples/*
+examples/*

--- a/dependencies/wheezy/clamp/watch
+++ b/dependencies/wheezy/clamp/watch
@@ -1,2 +1,0 @@
-version=3
-http://pkg-ruby-extras.alioth.debian.org/cgi-bin/gemwatch/clamp .*/clamp-(.*).tar.gz


### PR DESCRIPTION
Debian/jessie has 0.6.3-1, but without the i18n patch from mdub/clamp#43, so I'd like to introduce a higher version for Debian/Ubuntu in our repos (without bumping epoch).

Scratchbuild is :green_heart:: http://ci.theforeman.org/job/packaging_build_deb_dependency/621/

The upstream change from 0.6.2 to 0.6.3 was only to add the MIT license.

For the packaging files to be also licensed under the MIT license, I'd like to collect the ACKs from all people in the changelog:
- [x] @ares
- [x] @GregSutcliffe
- [x] @tstrachota
