### PR TITLE
Asset precompilation for foreman_docker [deb]

### DIFF
--- a/plugins/ruby-foreman-docker/debian/changelog
+++ b/plugins/ruby-foreman-docker/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-docker (1.0.0-1) stable; urgency=low
+
+  * Update release to 1.0.0
+
+ -- Daniel Lobato Garcia <elobatocs@gmail.com>  Mon, 12 Jan 2015 18:36:00 +0100
+
 ruby-foreman-docker (0.0.3-2) stable; urgency=low
 
   * Set HOME to ~foreman as rb-readline requires it

--- a/plugins/ruby-foreman-docker/debian/control
+++ b/plugins/ruby-foreman-docker/debian/control
@@ -2,12 +2,12 @@ Source: ruby-foreman-docker
 Section: ruby
 Priority: extra
 Maintainer: Pujan Shah <pujan14@gmail.com>
-Build-Depends: debhelper
+Build-Depends: debhelper, foreman-compute (>= 1.7.0), foreman-assets (>= 1.7.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-docker
 
 Package: ruby-foreman-docker
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman-compute (>= 1.7.0)
+Depends: ${misc:Depends}, bundler, foreman-compute (>= 1.7.2)
 Description: Foreman Docker compute resource
  Docker compute resource plugin for Foreman

--- a/plugins/ruby-foreman-docker/debian/control
+++ b/plugins/ruby-foreman-docker/debian/control
@@ -8,6 +8,6 @@ Homepage: https://github.com/theforeman/foreman-docker
 
 Package: ruby-foreman-docker
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman-compute (>= 1.6.0),
+Depends: ${misc:Depends}, bundler, foreman-compute (>= 1.7.0)
 Description: Foreman Docker compute resource
  Docker compute resource plugin for Foreman

--- a/plugins/ruby-foreman-docker/debian/gem.list
+++ b/plugins/ruby-foreman-docker/debian/gem.list
@@ -1,4 +1,5 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_docker-0.0.3.gem"
-GEMS="$GEMS https://rubygems.org/downloads/docker-api-1.8.4.gem"
+GEMS="https://rubygems.org/downloads/foreman_docker-1.0.0.gem"
+GEMS="$GEMS https://rubygems.org/downloads/docker-api-1.13.6.gem"
+GEMS="$GEMS https://rubygems.org/downloads/wicked-1.1.0.gem"
 GEMS="$GEMS https://rubygems.org/downloads/archive-tar-minitar-0.5.2.gem"

--- a/plugins/ruby-foreman-docker/debian/install
+++ b/plugins/ruby-foreman-docker/debian/install
@@ -1,2 +1,3 @@
 foreman_docker.rb      usr/share/foreman/bundler.d
 cache               usr/share/foreman/vendor
+foreman_docker      var/lib/foreman/public/assets

--- a/plugins/ruby-foreman-docker/debian/postinst
+++ b/plugins/ruby-foreman-docker/debian/postinst
@@ -38,6 +38,15 @@ else
   fi
 fi
 
+# DB migrate/seed and precompile assets after install
+if [ -f /usr/share/foreman/config/database.yml ]; then
+  if [ ! -z "${DEBUG}" ]; then
+    /usr/sbin/foreman-rake db:migrate || true
+  else
+    /usr/sbin/foreman-rake db:migrate >> $LOGFILE 2>&1 || true
+  fi
+fi
+
 # Own all the core files
 chown -Rf foreman:foreman '/usr/share/foreman'
 

--- a/plugins/ruby-foreman-docker/debian/rules
+++ b/plugins/ruby-foreman-docker/debian/rules
@@ -9,5 +9,17 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+PLUGIN = foreman_docker
+
+build:
+	cp cache/* /usr/share/foreman/vendor/cache/
+	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
+	cd /usr/share/foreman && ( \
+		bundle install --local && \
+		bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production \
+	)
+	GEM_PATH=$$(cd /usr/share/foreman && bundle show $(PLUGIN)) && \
+		cp -rp $${GEM_PATH}/public/assets/$(PLUGIN) ./
+
 %:
 	dh $@ 

--- a/plugins/ruby-foreman-docker/foreman_docker.rb
+++ b/plugins/ruby-foreman-docker/foreman_docker.rb
@@ -1,1 +1,1 @@
-gem 'foreman_docker', '0.0.3'
+gem 'foreman_docker', '1.0.0'


### PR DESCRIPTION
This combines @eLobato's update PR #423, plus some attempted asset precompilation for the plugin.  Trouble is, it doesn't work yet.  *Edit: oh wait, it does now!*

It does get as far as putting the compiled assets inside the deb:

<pre>
drwxr-xr-x root/root         0 2015-01-13 12:53 ./usr/share/foreman/vendor/
drwxr-xr-x root/root         0 2015-01-13 12:48 ./usr/share/foreman/vendor/ruby/
drwxr-xr-x root/root         0 2015-01-13 12:48 ./usr/share/foreman/vendor/ruby/1.9.1/
drwxr-xr-x root/root         0 2015-01-13 12:48 ./usr/share/foreman/vendor/ruby/1.9.1/gems/
drwxr-xr-x root/root         0 2015-01-13 12:48 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/
drwxr-xr-x root/root         0 2015-01-13 12:48 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/
drwxr-xr-x root/root         0 2015-01-13 12:53 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/assets/
drwxr-xr-x root/root         0 2015-01-13 12:53 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/assets/foreman_docker/
-rw-r--r-- root/root       102 2015-01-13 12:53 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/assets/foreman_docker/autocomplete-1e6e8602603162b4b019d664dd3a9b62.css
-rw-r--r-- root/root       783 2015-01-13 12:53 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/assets/foreman_docker/image_step-073354db2df1279d01aedfd1b4ace3f9.js.gz
-rw-r--r-- root/root       102 2015-01-13 12:53 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/assets/foreman_docker/autocomplete.css
-rw-r--r-- root/root      1522 2015-01-13 12:53 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/assets/foreman_docker/terminal-4367e78f986d885de048a264a18aae90.css
-rw-r--r-- root/root       455 2015-01-13 12:53 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/assets/foreman_docker/terminal.css.gz
-rw-r--r-- root/root       783 2015-01-13 12:53 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/assets/foreman_docker/image_step.js.gz
-rw-r--r-- root/root       110 2015-01-13 12:53 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/assets/foreman_docker/autocomplete.css.gz
-rw-r--r-- root/root      1522 2015-01-13 12:53 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/assets/foreman_docker/terminal.css
-rw-r--r-- root/root       582 2015-01-13 12:53 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/assets/foreman_docker/manifest.yml
-rw-r--r-- root/root       455 2015-01-13 12:53 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/assets/foreman_docker/terminal-4367e78f986d885de048a264a18aae90.css.gz
-rw-r--r-- root/root      2316 2015-01-13 12:53 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/assets/foreman_docker/image_step-073354db2df1279d01aedfd1b4ace3f9.js
-rw-r--r-- root/root      2316 2015-01-13 12:53 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/assets/foreman_docker/image_step.js
-rw-r--r-- root/root       110 2015-01-13 12:53 ./usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0/public/assets/foreman_docker/autocomplete-1e6e8602603162b4b019d664dd3a9b62.css.gz
drwxr-xr-x root/root         0 2015-01-13 10:24 ./usr/share/foreman/vendor/cache/
-rw-r--r-- root/root     39936 2015-01-12 16:39 ./usr/share/foreman/vendor/cache/foreman_docker-1.0.0.gem
-rw-r--r-- root/root     23040 2010-01-09 03:05 ./usr/share/foreman/vendor/cache/archive-tar-minitar-0.5.2.gem
-rw-r--r-- root/root     75776 2014-10-02 17:24 ./usr/share/foreman/vendor/cache/docker-api-1.13.6.gem
-rw-r--r-- root/root     91136 2014-09-15 15:22 ./usr/share/foreman/vendor/cache/wicked-1.1.0.gem
</pre>

However for now I've just stuck them in the same path that the gem gets installed under by Bundler.  What happens of course is that bundler/rubygems just wipes /usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_docker-1.0.0 before installing the .gem before the cache and the packaged assets disappear.

I think a change to core would make this work.  There are two parts to plugin asset serving, a) loading manifests of filenames+checksums (see manifest.yml in the list above) and b) adding the asset dir to the serving path.

We could skip the second and package plugin assets straight into /var/lib/foreman/public/assets/ (aka /usr/share/foreman/public/assets) so they share the same filesystem space as Foreman core (they have a plugin name prefix).

However perhaps then updating core to load manifest.yml files from other directories, e.g. `public/assets/**/manifest.yml` would fix the first issue, so we don't have to put the manifest *inside* the gem installation?

https://github.com/theforeman/foreman/blob/1.7.1/config/environments/production.rb#L125-L147