### PR TITLE
Fix hooks version number to reflect packaged gem

### DIFF
--- a/plugins/ruby-foreman-hooks/debian/changelog
+++ b/plugins/ruby-foreman-hooks/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-hooks (0.3.7-1) stable; urgency=low
+
+  * Fix version number to reflect packaged gem
+
+ -- Dominic Cleal <dcleal@redhat.com>  Tue, 27 Jan 2015 12:21:29 +0000
+
 ruby-foreman-hooks (0.3.4-3) stable; urgency=low
 
   * Set HOME to ~foreman as rb-readline requires it


### PR DESCRIPTION
I guess adding a new entry is the correct thing to do here, rather than editing historical entries.

For deb/develop & 1.7 I think.