### PR TITLE
Do not list the assets directory twice.

### DIFF
--- a/rubygem-foreman_docker/rubygem-foreman_docker.spec
+++ b/rubygem-foreman_docker/rubygem-foreman_docker.spec
@@ -99,7 +99,6 @@ cp -a .%{gem_dir}/* \
 %{gem_spec}
 %{foreman_bundlerd_plugin}
 %{foreman_assets_plugin}
-%{gem_instdir}/public/assets/%{gem_name}
 %doc %{gem_instdir}/LICENSE
 
 %exclude %{gem_instdir}/.*


### PR DESCRIPTION
Addressing rpmbuild warning: File listed twice.