### PR TITLE
Prevented from missing base policy in foreman-selinux

### DIFF
--- a/foreman-selinux/foreman-selinux.spec
+++ b/foreman-selinux/foreman-selinux.spec
@@ -45,7 +45,7 @@ License:        GPLv3+
 URL:            http://www.theforeman.org
 Source0:        http://downloads.theforeman.org/%{name}/%{name}-%{version}%{?dashalphatag}.tar.bz2
 
-BuildRequires:  checkpolicy, selinux-policy-devel, hardlink
+BuildRequires:  checkpolicy, selinux-policy-devel, hardlink, /usr/sbin/semodule
 BuildRequires:  policycoreutils >= %{selinux_policycoreutils_ver}
 BuildRequires:  /usr/bin/pod2man
 BuildArch:      noarch
@@ -63,6 +63,9 @@ SELinux policy module for Foreman
 %setup -q -n %{name}-%{version}%{?dashalphatag}
 
 %build
+# list available modules (if this fails, we are missing base policy in the buildroot)
+semodule -l
+
 # determine distribution name and version
 %if 0%{?rhel} >= 6
 %define distver rhel%{rhel}


### PR DESCRIPTION
We've hit issue downstream when base policy was not loaded in the buildroot 
causing some optional_blocks to be ignored. We should error out early when 
base policy is not loaded in the build root to prevent that, otherwise we will
likely find this in user reported bugs (allow rule is missing), because 
SELinux will silently ignore those blocks.