### PR TITLE
README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ dependencies.
 RPM packaging branches
 ======================
 The rpm/\* branches contain the spec files for Foreman, related projects and its
-dependencies.  Pull requests gladly accepted for these.  rpm/develop is the first
+dependencies.  Pull requests gladly accepted for these.  `rpm/develop` is the first
 and best place to make changes, as it's branched for each release.
 
 Koji's repos are built using the files under comps/, new packages and
@@ -18,11 +18,11 @@ Debian packaging branches
 
 The deb/\* branches contain the Debian packaging files for Foreman and its
 dependencies. The repo mirrors [Foreman Core](https://github.com/theforeman/foreman),
-i.e. deb/develop is for packaging branch 'develop', deb/1.3 is for packaging release
+i.e. `deb/develop` is for packaging branch 'develop', `deb/1.3` is for packaging release
 1.3.x and so on
 
 Contributing
 ============
 
-It's generally best to contribute to `rpm/develop` or 'deb/develop' unless something
+It's generally best to contribute to `rpm/develop` or `deb/develop` unless something
 is specifically broken for an older release. Please fork and send a PR.


### PR DESCRIPTION
Dump PR, I know, but since rpm/develop was monospaced and deb/develop was just in between quotes I figured it was a mistake..