### PR TITLE
update smart_proxy_salt to 2.0.0 (DEB)

### DIFF
--- a/plugins/smart_proxy_salt/changelog
+++ b/plugins/smart_proxy_salt/changelog
@@ -1,10 +1,16 @@
+ruby-smart-proxy-salt (2.0.0-1) unstable; urgency=low
+
+  * Update to 2.0.0
+
+ -- Michael Moll <mmoll@mmoll.at>  Thu, 03 Mar 2015 20:38:12 +0100
+
 ruby-smart-proxy-salt (1.0.0-1) unstable; urgency=low
 
   * Updated to 1.0.0
 
  -- Stephen Benjamin <stephen@redhat.com>  Thu, 20 Nov 2014 09:20:00 +0200
 
- ruby-smart-proxy-salt (0.0.2-1) unstable; urgency=low
+ruby-smart-proxy-salt (0.0.2-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/smart_proxy_salt/control
+++ b/plugins/smart_proxy_salt/control
@@ -10,6 +10,6 @@ XS-Ruby-Versions: all
 Package: ruby-smart-proxy-salt
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.6.0~rc1), salt-master, python
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.8.0~rc1), salt-master, python
 Description: SaltStack Plug-In for Foreman's Smart Proxy
  SaltStack Plug-In for Foreman's Smart Proxy

--- a/plugins/smart_proxy_salt/files
+++ b/plugins/smart_proxy_salt/files
@@ -1,1 +1,0 @@
-ruby-smart-proxy-salt_1.0.0-1_all.deb ruby optional

--- a/plugins/smart_proxy_salt/salt.rb
+++ b/plugins/smart_proxy_salt/salt.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_salt', '1.0.0'
+gem 'smart_proxy_salt', '2.0.0'


### PR DESCRIPTION
http://ci.theforeman.org/job/packaging_build_deb_proxy_plugin/27/ is :rotating_light:, seems like an error in the Jenkins job, if anybody could check that... :sleepy:

Should also go into deb/1.8