### PR TITLE
update hammer_cli_foreman_salt to 0.0.4 (DEB)

### DIFF
--- a/dependencies/precise/hammer_cli_foreman_salt/changelog
+++ b/dependencies/precise/hammer_cli_foreman_salt/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-salt (0.0.4-1) stable; urgency=low
+
+  * Update to 0.0.4
+
+ -- Michael Moll <mmoll@mmoll.at>  Thu, 03 Mar 2015 20:50:09 +0100
+
 ruby-hammer-cli-foreman-salt (0.0.2-1) stable; urgency=low
 
   * Initial release

--- a/dependencies/trusty/hammer_cli_foreman_salt/changelog
+++ b/dependencies/trusty/hammer_cli_foreman_salt/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-salt (0.0.4-1) stable; urgency=low
+
+  * Update to 0.0.4
+
+ -- Michael Moll <mmoll@mmoll.at>  Thu, 03 Mar 2015 20:50:09 +0100
+
 ruby-hammer-cli-foreman-salt (0.0.2-1) stable; urgency=low
 
   * Initial release

--- a/dependencies/wheezy/hammer_cli_foreman_salt/changelog
+++ b/dependencies/wheezy/hammer_cli_foreman_salt/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-salt (0.0.4-1) stable; urgency=low
+
+  * Update to 0.0.4
+
+ -- Michael Moll <mmoll@mmoll.at>  Thu, 03 Mar 2015 20:50:09 +0100
+
 ruby-hammer-cli-foreman-salt (0.0.2-1) stable; urgency=low
 
   * Initial release


### PR DESCRIPTION
http://ci.theforeman.org/job/packaging_build_deb_dependency/640/ is :green_heart: and the resulting package is working for me on Debian/wheezy.

Should also go into deb/1.8