### PR TITLE
refs #4478 - precompile API docs [deb]

### DIFF
--- a/debian/precise/foreman/foreman.postinst
+++ b/debian/precise/foreman/foreman.postinst
@@ -80,9 +80,9 @@ fi
 
 # Generate apipie cache
 if [ ! -z "${DEBUG}" ]; then
-  /usr/sbin/foreman-rake apipie:cache || true
+  /usr/sbin/foreman-rake apipie:cache:index || true
 else
-  /usr/sbin/foreman-rake apipie:cache >> $LOGFILE 2>&1 || true
+  /usr/sbin/foreman-rake apipie:cache:index >> $LOGFILE 2>&1 || true
 fi
 
 # Generate a static session token for signing cookies

--- a/debian/precise/foreman/rules
+++ b/debian/precise/foreman/rules
@@ -16,9 +16,10 @@ build/foreman::
 	/bin/cp config/database.yml.example config/database.yml
 	/usr/bin/bundle pack --all
 	/usr/bin/bundle exec rake locale:pack assets:precompile
+	/usr/bin/bundle exec rake db:migrate --trace RAILS_ENV=production
+	/usr/bin/bundle exec rake apipie:cache cache_part=resources --trace RAILS_ENV=production
 	/bin/rm config/settings.yaml
 	/bin/rm config/database.yml
-	# Somehow blank db sqlite files get added
 	/bin/rm db/production.sqlite3
 	/bin/rm db/development.sqlite3
 	# Use rake1.9.1 explicitly

--- a/debian/trusty/foreman/foreman.postinst
+++ b/debian/trusty/foreman/foreman.postinst
@@ -80,9 +80,9 @@ fi
 
 # Generate apipie cache
 if [ ! -z "${DEBUG}" ]; then
-  /usr/sbin/foreman-rake apipie:cache || true
+  /usr/sbin/foreman-rake apipie:cache:index || true
 else
-  /usr/sbin/foreman-rake apipie:cache >> $LOGFILE 2>&1 || true
+  /usr/sbin/foreman-rake apipie:cache:index >> $LOGFILE 2>&1 || true
 fi
 
 # Generate a static session token for signing cookies

--- a/debian/trusty/foreman/rules
+++ b/debian/trusty/foreman/rules
@@ -16,9 +16,10 @@ build/foreman::
 	/bin/cp config/database.yml.example config/database.yml
 	/usr/bin/bundle pack --all
 	/usr/bin/bundle exec rake locale:pack assets:precompile
+	/usr/bin/bundle exec rake db:migrate --trace RAILS_ENV=production
+	/usr/bin/bundle exec rake apipie:cache cache_part=resources --trace RAILS_ENV=production
 	/bin/rm config/settings.yaml
 	/bin/rm config/database.yml
-	# Somehow blank db sqlite files get added
 	/bin/rm db/production.sqlite3
 	/bin/rm db/development.sqlite3
 	/bin/mkdir -p .ssh

--- a/debian/wheezy/foreman/foreman.postinst
+++ b/debian/wheezy/foreman/foreman.postinst
@@ -80,9 +80,9 @@ fi
 
 # Generate apipie cache
 if [ ! -z "${DEBUG}" ]; then
-  /usr/sbin/foreman-rake apipie:cache || true
+  /usr/sbin/foreman-rake apipie:cache:index || true
 else
-  /usr/sbin/foreman-rake apipie:cache >> $LOGFILE 2>&1 || true
+  /usr/sbin/foreman-rake apipie:cache:index >> $LOGFILE 2>&1 || true
 fi
 
 # Generate a static session token for signing cookies

--- a/debian/wheezy/foreman/rules
+++ b/debian/wheezy/foreman/rules
@@ -16,9 +16,10 @@ build/foreman::
 	/bin/cp config/database.yml.example config/database.yml
 	/usr/bin/bundle pack
 	/usr/bin/bundle exec rake locale:pack assets:precompile
+	/usr/bin/bundle exec rake db:migrate --trace RAILS_ENV=production
+	/usr/bin/bundle exec rake apipie:cache cache_part=resources --trace RAILS_ENV=production
 	/bin/rm config/settings.yaml
 	/bin/rm config/database.yml
-	# Somehow blank db sqlite files get added
 	/bin/rm db/production.sqlite3
 	/bin/rm db/development.sqlite3
 	/bin/mkdir -p .ssh

--- a/plugins/ruby-foreman-bootdisk/debian/changelog
+++ b/plugins/ruby-foreman-bootdisk/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-bootdisk (5.0.0) stable; urgency=low
+
+  * 5.0.0 released
+
+ -- Dominic Cleal <dcleal@redhat.com>  Tue, 03 Mar 2015 14:45:17 +0000
+
 ruby-foreman-bootdisk (4.0.2-1) stable; urgency=low
 
   * Set HOME to ~foreman as rb-readline requires it

--- a/plugins/ruby-foreman-bootdisk/debian/control
+++ b/plugins/ruby-foreman-bootdisk/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/theforeman/foreman_bootdisk
 
 Package: ruby-foreman-bootdisk
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.6.0~rc1),
+Depends: ${misc:Depends}, bundler, foreman (>= 1.8.0~rc1),
   syslinux, genisoimage, ipxe
 Description: Foreman Bootdisk Plugin
  Plugin for Foreman that creates iPXE-based boot disks to provision hosts

--- a/plugins/ruby-foreman-bootdisk/debian/control
+++ b/plugins/ruby-foreman-bootdisk/debian/control
@@ -2,7 +2,7 @@ Source: ruby-foreman-bootdisk
 Section: ruby
 Priority: extra
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
-Build-Depends: debhelper (>= 8.0.0)
+Build-Depends: debhelper (>= 8.0.0), foreman (>= 1.8.0~rc1), foreman-sqlite3 (>= 1.8.0~rc1)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_bootdisk
 

--- a/plugins/ruby-foreman-bootdisk/debian/gem.list
+++ b/plugins/ruby-foreman-bootdisk/debian/gem.list
@@ -1,2 +1,2 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_bootdisk-4.0.2.gem"
+GEMS="https://rubygems.org/downloads/foreman_bootdisk-5.0.0.gem"

--- a/plugins/ruby-foreman-bootdisk/debian/install
+++ b/plugins/ruby-foreman-bootdisk/debian/install
@@ -1,2 +1,3 @@
 foreman_bootdisk.rb usr/share/foreman/bundler.d
 cache               usr/share/foreman/vendor
+apipie-cache/foreman_bootdisk    var/lib/foreman/public/apipie-cache/plugin

--- a/plugins/ruby-foreman-bootdisk/debian/postinst
+++ b/plugins/ruby-foreman-bootdisk/debian/postinst
@@ -43,11 +43,11 @@ if [ -f /usr/share/foreman/config/database.yml ]; then
   if [ ! -z "${DEBUG}" ]; then
     /usr/sbin/foreman-rake db:migrate || true
     /usr/sbin/foreman-rake db:seed || true
-    /usr/sbin/foreman-rake apipie:cache || true
+    /usr/sbin/foreman-rake apipie:cache:index || true
   else
     /usr/sbin/foreman-rake db:migrate >> $LOGFILE 2>&1 || true
     /usr/sbin/foreman-rake db:seed >> $LOGFILE 2>&1 || true
-    /usr/sbin/foreman-rake apipie:cache >> $LOGFILE 2>&1 || true
+    /usr/sbin/foreman-rake apipie:cache:index >> $LOGFILE 2>&1 || true
   fi
 fi
 

--- a/plugins/ruby-foreman-bootdisk/debian/rules
+++ b/plugins/ruby-foreman-bootdisk/debian/rules
@@ -9,5 +9,19 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+PLUGIN = foreman_bootdisk
+
+build:
+	cp cache/* /usr/share/foreman/vendor/cache/
+	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
+	cd /usr/share/foreman && ( \
+		bundle install --local && \
+		bundle exec rake db:migrate RAILS_ENV=development && \
+		bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
+			OUT=/var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) RAILS_ENV=development \
+	)
+	[ -e apipie-cache ] || mkdir apipie-cache/
+	cp -rp /var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) ./apipie-cache/
+
 %:
 	dh $@ 

--- a/plugins/ruby-foreman-bootdisk/foreman_bootdisk.rb
+++ b/plugins/ruby-foreman-bootdisk/foreman_bootdisk.rb
@@ -1,1 +1,1 @@
-gem 'foreman_bootdisk', '4.0.2'
+gem 'foreman_bootdisk', '5.0.0'

--- a/plugins/ruby-foreman-docker/debian/control
+++ b/plugins/ruby-foreman-docker/debian/control
@@ -2,7 +2,7 @@ Source: ruby-foreman-docker
 Section: ruby
 Priority: extra
 Maintainer: Pujan Shah <pujan14@gmail.com>
-Build-Depends: debhelper, foreman-compute (>= 1.7.0), foreman-assets (>= 1.7.0)
+Build-Depends: debhelper, foreman-compute (>= 1.8.0~rc1), foreman-assets (>= 1.7.0), foreman-sqlite3 (>= 1.8.0~rc1)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-docker
 

--- a/plugins/ruby-foreman-docker/debian/install
+++ b/plugins/ruby-foreman-docker/debian/install
@@ -1,3 +1,4 @@
-foreman_docker.rb      usr/share/foreman/bundler.d
-cache               usr/share/foreman/vendor
-foreman_docker      var/lib/foreman/public/assets
+foreman_docker.rb              usr/share/foreman/bundler.d
+cache                          usr/share/foreman/vendor
+foreman_docker                 var/lib/foreman/public/assets
+apipie-cache/foreman_docker    var/lib/foreman/public/apipie-cache/plugin

--- a/plugins/ruby-foreman-docker/debian/postinst
+++ b/plugins/ruby-foreman-docker/debian/postinst
@@ -42,8 +42,10 @@ fi
 if [ -f /usr/share/foreman/config/database.yml ]; then
   if [ ! -z "${DEBUG}" ]; then
     /usr/sbin/foreman-rake db:migrate || true
+    /usr/sbin/foreman-rake apipie:cache:index || true
   else
     /usr/sbin/foreman-rake db:migrate >> $LOGFILE 2>&1 || true
+    /usr/sbin/foreman-rake apipie:cache:index >> $LOGFILE 2>&1 || true
   fi
 fi
 

--- a/plugins/ruby-foreman-docker/debian/rules
+++ b/plugins/ruby-foreman-docker/debian/rules
@@ -16,10 +16,15 @@ build:
 	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
 	cd /usr/share/foreman && ( \
 		bundle install --local && \
-		bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production \
+		bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production && \
+		bundle exec rake db:migrate RAILS_ENV=development && \
+		bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
+			OUT=/var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) RAILS_ENV=development \
 	)
 	GEM_PATH=$$(cd /usr/share/foreman && bundle show $(PLUGIN)) && \
 		cp -rp $${GEM_PATH}/public/assets/$(PLUGIN) ./
+	[ -e apipie-cache ] || mkdir apipie-cache/
+	cp -rp /var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) ./apipie-cache/
 
 %:
 	dh $@ 

--- a/plugins/ruby-foreman-salt/debian/control
+++ b/plugins/ruby-foreman-salt/debian/control
@@ -2,7 +2,7 @@ Source: ruby-foreman-salt
 Section: ruby
 Priority: extra
 Maintainer: Stephen Benjamin <stephen@redhat.com>
-Build-Depends: debhelper (>= 8.0.0)
+Build-Depends: debhelper (>= 8.0.0), foreman (>= 1.8.0~rc1), foreman-sqlite3 (>= 1.8.0~rc1), ruby-foreman-deface
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_salt
 

--- a/plugins/ruby-foreman-salt/debian/install
+++ b/plugins/ruby-foreman-salt/debian/install
@@ -1,2 +1,3 @@
-foreman_salt.rb     usr/share/foreman/bundler.d
-cache               usr/share/foreman/vendor
+foreman_salt.rb              usr/share/foreman/bundler.d
+cache                        usr/share/foreman/vendor
+apipie-cache/foreman_salt    var/lib/foreman/public/apipie-cache/plugin

--- a/plugins/ruby-foreman-salt/debian/postinst
+++ b/plugins/ruby-foreman-salt/debian/postinst
@@ -43,11 +43,11 @@ if [ -f /usr/share/foreman/config/database.yml ]; then
   if [ ! -z "${DEBUG}" ]; then
     /usr/sbin/foreman-rake db:migrate || true
     /usr/sbin/foreman-rake db:seed || true
-    /usr/sbin/foreman-rake apipie:cache || true
+    /usr/sbin/foreman-rake apipie:cache:index || true
   else
     /usr/sbin/foreman-rake db:migrate >> $LOGFILE 2>&1 || true
     /usr/sbin/foreman-rake db:seed >> $LOGFILE 2>&1 || true
-    /usr/sbin/foreman-rake apipie:cache >> $LOGFILE 2>&1 || true
+    /usr/sbin/foreman-rake apipie:cache:index >> $LOGFILE 2>&1 || true
   fi
 fi
 

--- a/plugins/ruby-foreman-salt/debian/rules
+++ b/plugins/ruby-foreman-salt/debian/rules
@@ -9,5 +9,19 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+PLUGIN = foreman_salt
+
+build:
+	cp cache/* /usr/share/foreman/vendor/cache/
+	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
+	cd /usr/share/foreman && ( \
+		bundle install --local && \
+		bundle exec rake db:migrate RAILS_ENV=development && \
+		bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
+			OUT=/var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) RAILS_ENV=development \
+	)
+	[ -e apipie-cache ] || mkdir apipie-cache/
+	cp -rp /var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) ./apipie-cache/
+
 %:
 	dh $@ 


### PR DESCRIPTION
Both Foreman and plugins that ship API controllers now have API docs for their resources generated at build time, and use `rake apipie:cache:index` to rebuild the resource indexes post-install.

Previously we used `apipie:cache` which also built individual resource pages, however #4478 changed core to build docs for each locale, which made apipie:cache very slow (minutes) during installation.  This PR moves the hard work to build time, so installation of Foreman or a single plugin is now running a very quick index rake task.

The code's near-identical to asset precompilation (as you'll see in ruby-foreman-docker), albeit with an extra db:migrate step (necessary, sorry).  I included a bootdisk 5.0.0 update as it uses the new plugin specification so we can build its API docs.

---

Builds:
* http://ci.theforeman.org/job/packaging_build_deb_coreproject/1724/ :white_check_mark: 
* http://ci.theforeman.org/job/packaging_build_deb_plugin/413/ bootdisk :white_check_mark: 
* http://ci.theforeman.org/job/packaging_build_deb_plugin/418/ docker :white_check_mark: 
* http://ci.theforeman.org/job/packaging_build_deb_plugin/419/ salt :white_check_mark: 