### PR TITLE
update rubyipmi to 0.9.1 (DEB)

### DIFF
--- a/dependencies/precise/rubyipmi/changelog
+++ b/dependencies/precise/rubyipmi/changelog
@@ -1,3 +1,9 @@
+ruby-rubyipmi (0.9.1-1) unstable; urgency=low
+
+  * Update to 0.9.1
+
+ -- Michael Moll <mmoll@mmoll.at>  Tue, 10 Mar 2014 23:36:13 +0100
+
 ruby-rubyipmi (0.8.1-1) unstable; urgency=low
 
   * Update to 0.8.1

--- a/dependencies/trusty/rubyipmi/changelog
+++ b/dependencies/trusty/rubyipmi/changelog
@@ -1,3 +1,9 @@
+ruby-rubyipmi (0.9.1-1) unstable; urgency=low
+
+  * Update to 0.9.1
+
+ -- Michael Moll <mmoll@mmoll.at>  Tue, 10 Mar 2014 23:36:13 +0100
+
 ruby-rubyipmi (0.8.1-1) unstable; urgency=low
 
   * Update to 0.8.1

--- a/dependencies/wheezy/rubyipmi/changelog
+++ b/dependencies/wheezy/rubyipmi/changelog
@@ -1,3 +1,9 @@
+ruby-rubyipmi (0.9.1-1) unstable; urgency=low
+
+  * Update to 0.9.1
+
+ -- Michael Moll <mmoll@mmoll.at>  Tue, 10 Mar 2014 23:36:13 +0100
+
 ruby-rubyipmi (0.8.1-1) unstable; urgency=low
 
   * Update to 0.8.1


### PR DESCRIPTION
http://ci.theforeman.org/job/packaging_build_deb_dependency/652/ is :green_heart: and the resulting package seems to work for me on Debian/wheezy, although I don't have IPMI h/w to test.