### PR TITLE
foreman_templates: bump deb to 1.5.0

### DIFF
--- a/plugins/ruby-foreman-templates/debian/changelog
+++ b/plugins/ruby-foreman-templates/debian/changelog
@@ -1,3 +1,12 @@
+ruby-foreman-templates (1.5.0-1) unstable; urgency=low
+
+  * Release 1.5.0
+  * Use Git gem to handle cloning
+  * Support attempted automatic branch detection
+  * Add options for when to do OS association
+
+ -- Greg Sutcliffe <gsutclif@redhat.com>  Tue, 17 Mar 2015 21:49:00 +0000
+
 ruby-foreman-templates (1.4.0-4) stable; urgency=low
 
   * Set HOME to ~foreman as rb-readline requires it

--- a/plugins/ruby-foreman-templates/debian/copyright
+++ b/plugins/ruby-foreman-templates/debian/copyright
@@ -3,11 +3,11 @@ Upstream-Name: ruby-foreman-templates
 Source: https://github.com/theforeman/foreman_templates
 
 Files: *
-Copyright: 2012-2013 Red Hat Inc. <foreman-dev@googlegroups.com>
+Copyright: 2012-2015 Red Hat Inc. <foreman-dev@googlegroups.com>
 License: GPL-3.0+
 
 Files: debian/*
-Copyright: 2013 Red Hat Inc. <foreman-dev@googlegroups.com>
+Copyright: 2013-2015 Red Hat Inc. <foreman-dev@googlegroups.com>
 License: GPL-3.0+
 
 License: GPL-3.0+

--- a/plugins/ruby-foreman-templates/debian/gem.list
+++ b/plugins/ruby-foreman-templates/debian/gem.list
@@ -1,3 +1,4 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_templates-1.4.0.gem"
+GEMS="https://rubygems.org/downloads/foreman_templates-1.5.0.gem"
 GEMS="$GEMS https://rubygems.org/downloads/diffy-3.0.6.gem"
+GEMS="$GEMS https://rubygems.org/downloads/git-1.2.9.1.gem"

--- a/plugins/ruby-foreman-templates/foreman_templates.rb
+++ b/plugins/ruby-foreman-templates/foreman_templates.rb
@@ -1,1 +1,1 @@
-gem 'foreman_templates', '1.4.0'
+gem 'foreman_templates', '1.5.0'


### PR DESCRIPTION
This is probably suitable for pretty much every branch, ever, but I'll start here :)

Scratchbuild: http://stagingdeb.theforeman.org/pool/plugins/GregSutcliffe/r/ruby-foreman-templates/ruby-foreman-templates_9999-plugin+scratchbuild+201503172157_all.deb

New gem is present:
```
[greg:/tmp]$ dpkg -x ruby-foreman-templates_9999-plugin+scratchbuild+201503172157_all.deb foo                                                                              
[greg:/tmp]$ find foo -iname "*git*"
foo/usr/share/foreman/vendor/cache/git-1.2.9.1.gem
```
@mmoll can you test? @domcleal can you do the rpm honours? Thanks both :)