### PR TITLE
Update hammer_cli_foreman_discovery to 0.0.2

### DIFF
--- a/dependencies/precise/hammer_cli_foreman_discovery/changelog
+++ b/dependencies/precise/hammer_cli_foreman_discovery/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-discovery (0.0.2-1) stable; urgency=low
+
+  * Update to 0.0.2
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 20 Mar 2015 12:56:22 +0000
+
 ruby-hammer-cli-foreman-discovery (0.0.1-1) unstable; urgency=medium
 
   * Initial release

--- a/dependencies/precise/hammer_cli_foreman_discovery/foreman_discovery.yml
+++ b/dependencies/precise/hammer_cli_foreman_discovery/foreman_discovery.yml
@@ -1,2 +1,0 @@
-:foreman_discovery:
-  :enable_module: true

--- a/dependencies/precise/hammer_cli_foreman_discovery/install
+++ b/dependencies/precise/hammer_cli_foreman_discovery/install
@@ -1,4 +1,4 @@
-debian/foreman_discovery.yml  etc/hammer/cli.modules.d
+config/foreman_discovery.yml  etc/hammer/cli.modules.d
 locale/de                     usr/share/locale
 locale/en                     usr/share/locale
 locale/en_GB                  usr/share/locale

--- a/dependencies/trusty/hammer_cli_foreman_discovery/changelog
+++ b/dependencies/trusty/hammer_cli_foreman_discovery/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-discovery (0.0.2-1) stable; urgency=low
+
+  * Update to 0.0.2
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 20 Mar 2015 12:56:22 +0000
+
 ruby-hammer-cli-foreman-discovery (0.0.1-1) unstable; urgency=medium
 
   * Initial release

--- a/dependencies/trusty/hammer_cli_foreman_discovery/foreman_discovery.yml
+++ b/dependencies/trusty/hammer_cli_foreman_discovery/foreman_discovery.yml
@@ -1,2 +1,0 @@
-:foreman_discovery:
-  :enable_module: true

--- a/dependencies/trusty/hammer_cli_foreman_discovery/install
+++ b/dependencies/trusty/hammer_cli_foreman_discovery/install
@@ -1,4 +1,4 @@
-debian/foreman_discovery.yml  etc/hammer/cli.modules.d
+config/foreman_discovery.yml  etc/hammer/cli.modules.d
 locale/de                     usr/share/locale
 locale/en                     usr/share/locale
 locale/en_GB                  usr/share/locale

--- a/dependencies/wheezy/hammer_cli_foreman_discovery/changelog
+++ b/dependencies/wheezy/hammer_cli_foreman_discovery/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-discovery (0.0.2-1) stable; urgency=low
+
+  * Update to 0.0.2
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 20 Mar 2015 12:56:22 +0000
+
 ruby-hammer-cli-foreman-discovery (0.0.1-1) unstable; urgency=medium
 
   * Initial release

--- a/dependencies/wheezy/hammer_cli_foreman_discovery/foreman_discovery.yml
+++ b/dependencies/wheezy/hammer_cli_foreman_discovery/foreman_discovery.yml
@@ -1,2 +1,0 @@
-:foreman_discovery:
-  :enable_module: true

--- a/dependencies/wheezy/hammer_cli_foreman_discovery/install
+++ b/dependencies/wheezy/hammer_cli_foreman_discovery/install
@@ -1,4 +1,4 @@
-debian/foreman_discovery.yml  etc/hammer/cli.modules.d
+config/foreman_discovery.yml  etc/hammer/cli.modules.d
 locale/de                     usr/share/locale
 locale/en                     usr/share/locale
 locale/en_GB                  usr/share/locale


### PR DESCRIPTION
I think just deb/develop for now, then we'll build for 1.7 and 1.8 once the corresponding foreman_discovery's done.