### PR TITLE
Refs #10154 - added rubygem-locale to non-scl rhel6

### DIFF
--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -76,6 +76,7 @@ whitelist = foreman-installer
   rubygem-highline
   rubygem-librarian-puppet
   rubygem-little-plugger
+  rubygem-locale
   rubygem-logging
   rubygem-multi_json
   rubygem-netrc


### PR DESCRIPTION
non-SCL rubygem-locale is missing from RHEL6 repos and Hammer is failing.

So far I'm not sure what changed or why we didn't caught this earlier.

Related Hammer PR: https://github.com/theforeman/hammer-cli/pull/168