### PR TITLE
Better branched builds with Foreman version macro [rpm]

### DIFF
--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -225,6 +225,7 @@ for Yum.
 %files release
 %config %{_sysconfdir}/yum.repos.d/*
 /etc/pki/rpm-gpg/*
+%{_sysconfdir}/rpm/macros.%{name}-dist
 
 %package libvirt
 Summary: Foreman libvirt support
@@ -360,6 +361,7 @@ Meta package to install asset pipeline support.
 Summary: Foreman plugin support
 Group: Development/Libraries
 Requires: %{name} = %{version}-%{release}
+Requires: %{name}-release = %{version}-%{release}
 Requires: %{name}-sqlite = %{version}-%{release}
 
 %description plugin
@@ -558,6 +560,11 @@ cat > %{buildroot}%{_sysconfdir}/rpm/macros.%{name} << EOF
 %%%{name}_db_migrate   %%{%{name}_rake} db:migrate >> %%{%{name}_log_dir}/db_migrate.log 2>&1 || :
 %%%{name}_db_seed      %%{%{name}_rake} db:seed >> %%{%{name}_log_dir}/db_seed.log 2>&1 || :
 %%%{name}_restart      (/sbin/service %{name} status && /sbin/service %{name} restart) >/dev/null 2>&1
+EOF
+
+cat > %{buildroot}%{_sysconfdir}/rpm/macros.%{name}-dist << EOF
+# Version to use like a dist tag
+%%%{name}dist .fm$(echo %{version} | awk -F. '{print $1 "_" $2}')
 EOF
 
 cat > %{buildroot}%{_sysconfdir}/rpm/macros.%{name}-plugin << EOF

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -7,6 +7,7 @@
 builder = tito.builder.GitAnnexBuilder
 tagger = tito.tagger.ReleaseTagger
 lib_dir = rel-eng/custom/
+tag_suffix = .fm1_9
 
 [builder]
 fetch_strategy = custom.JenkinsSourceStrategy

--- a/rubygem-bastion/rubygem-bastion.spec
+++ b/rubygem-bastion/rubygem-bastion.spec
@@ -16,7 +16,7 @@
 Summary:    UI plugin for Foreman providing AngularJS structure
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    1.0.1
-Release:    1%{?dist}
+Release:    1%{?foremandist}%{?dist}
 Group:      Applications/System
 License:    GPLv2+
 URL:        http://github.com/katello/bastion

--- a/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
+++ b/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
@@ -21,7 +21,7 @@
 Summary: Tasks support for Foreman with Dynflow integration
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.6.13
-Release: 2%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Group: Development/Libraries
 License: GPLv3
 URL: http://github.com/theforeman/foreman-tasks

--- a/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
+++ b/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
@@ -19,7 +19,7 @@
 Summary:    Create boot disks to provision hosts with Foreman
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    5.0.0
-Release:    1%{?dist}
+Release:    1%{?foremandist}%{?dist}
 Group:      Applications/System
 License:    GPLv3
 URL:        http://github.com/theforeman/foreman_bootdisk

--- a/rubygem-foreman_discovery/rubygem-foreman_discovery.spec
+++ b/rubygem-foreman_discovery/rubygem-foreman_discovery.spec
@@ -28,7 +28,7 @@
 Summary:    MaaS Discovery Plugin for Foreman
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    %{mainver}
-Release:    %{?prever:0.}%{release}%{?prever}%{?dist}
+Release:    %{?prever:0.}%{release}%{?prever}%{?foremandist}%{?dist}
 Group:      Applications/System
 License:    GPLv3
 URL:        http://github.com/theforeman/foreman_discovery

--- a/rubygem-foreman_docker/rubygem-foreman_docker.spec
+++ b/rubygem-foreman_docker/rubygem-foreman_docker.spec
@@ -19,7 +19,7 @@
 Summary:    A Foreman plugin for Docker container management
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    1.2.4
-Release:    1.fm1_9%{?dist}
+Release:    1%{?foremandist}%{?dist}
 Group:      Applications/System
 License:    GPLv3
 URL:        http://github.com/theforeman/foreman-docker

--- a/rubygem-foreman_openscap/rubygem-foreman_openscap.spec
+++ b/rubygem-foreman_openscap/rubygem-foreman_openscap.spec
@@ -16,7 +16,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.4.0
-Release: 1%{?dist}
+Release: 1%{?foremandist}%{?dist}
 Summary: Foreman plug-in for displaying OpenSCAP audit reports
 Group: Applications/System
 License: GPLv3

--- a/rubygem-foreman_salt/rubygem-foreman_salt.spec
+++ b/rubygem-foreman_salt/rubygem-foreman_salt.spec
@@ -18,7 +18,7 @@
 Summary:    Plugin for Salt integration with Foreman
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    2.0.2
-Release:    1%{?dist}
+Release:    1%{?foremandist}%{?dist}
 Group:      Applications/System
 License:    GPLv3
 URL:        http://github.com/theforeman/foreman_salt


### PR DESCRIPTION
Packages (plugins) built on foreman output different binary RPMs due to the
version of Foreman they're built against, as macros change.  The .fm1_9 string
is put into the release field to differentiate the EVRs, since koji and tito
both rely on its uniqueness - building the same EVR on rpm/1.8 and rpm/1.7 to
get both 1.8 and 1.7 builds would otherwise not be possible.

(Consider `rubygem-foreman_docker-1.2.4-1.el7` where %post might have
different behaviour between versions, so `-1.fm1_8.el7` allows both to exist.)

This adds a %foremandist macro to foreman-release, which is used in plugin
release fields to differentiate them.  It will be added to the buildroots in
koji so it can be expanded.  (`Release: 1%{?foremandist}%{?dist}`)

For tito, the tag_suffix configuration is set so the version number is also
included in its git tags for uniqueness across branches.

This is a pre-req for our own SCL, as rebuilding packages on multiple branches
will be common when the SCL configuration differs, instead of retagging.  It
will perhaps allow us to build most plugins on versioned branches easily rather
than retagging develop builds to older versions.  [In the same way that deb/* works.]

All packages using Foreman at build time have the dist tag added to release.