### PR TITLE
Scap client is not in SCL

### DIFF
--- a/comps/comps-foreman-plugins-rhel6.xml
+++ b/comps/comps-foreman-plugins-rhel6.xml
@@ -30,7 +30,6 @@
       <packagereq type="default">ruby193-rubygem-foreman_param_lookup</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_reserve</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_salt</packagereq>
-      <packagereq type="default">ruby193-rubygem-foreman_scap_client</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_setup</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_simplify</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_snapshot</packagereq>
@@ -39,6 +38,7 @@
       <packagereq type="default">ruby193-rubygem-foreman_xen</packagereq>
       <packagereq type="default">ruby193-rubygem-ovirt_provision_plugin</packagereq>
       <packagereq type="default">ruby193-rubygem-puppetdb_foreman</packagereq>
+      <packagereq type="default">rubygem-foreman_scap_client</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_bootdisk</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_discovery</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_docker</packagereq>
@@ -111,7 +111,6 @@
       <packagereq type="default">ruby193-rubygem-foreman_param_lookup-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_reserve-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_salt-doc</packagereq>
-      <packagereq type="default">ruby193-rubygem-foreman_scap_client-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_setup-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_simplify-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_snapshot-doc</packagereq>
@@ -129,6 +128,7 @@
       <packagereq type="default">ruby193-rubygem-scaptimony-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-wicked-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-zscheduler-doc</packagereq>
+      <packagereq type="default">rubygem-foreman_scap_client-doc</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_bootdisk-doc</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_discovery-doc</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_docker-doc</packagereq>

--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -30,7 +30,6 @@
       <packagereq type="default">ruby193-rubygem-foreman_param_lookup</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_reserve</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_salt</packagereq>
-      <packagereq type="default">ruby193-rubygem-foreman_scap_client</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_setup</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_simplify</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_snapshot</packagereq>
@@ -39,6 +38,7 @@
       <packagereq type="default">ruby193-rubygem-foreman_xen</packagereq>
       <packagereq type="default">ruby193-rubygem-ovirt_provision_plugin</packagereq>
       <packagereq type="default">ruby193-rubygem-puppetdb_foreman</packagereq>
+      <packagereq type="default">rubygem-foreman_scap_client</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_bootdisk</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_discovery</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_docker</packagereq>
@@ -115,7 +115,6 @@
       <packagereq type="default">ruby193-rubygem-foreman_param_lookup-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_reserve-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_salt-doc</packagereq>
-      <packagereq type="default">ruby193-rubygem-foreman_scap_client-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_setup-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_simplify-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-foreman_snapshot-doc</packagereq>
@@ -134,6 +133,7 @@
       <packagereq type="default">ruby193-rubygem-wicked-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-zscheduler-doc</packagereq>
       <packagereq type="default">rubygem-chef-api-doc</packagereq>
+      <packagereq type="default">rubygem-foreman_scap_client-doc</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_bootdisk-doc</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_discovery-doc</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_docker-doc</packagereq>


### PR DESCRIPTION
Package is built without SCL http://koji.katello.org/koji/packageinfo?packageID=806 (which makes sense)