### PR TITLE
refs #10203 - make default scap content available to Foreman

### DIFF
--- a/rubygem-foreman_openscap/rubygem-foreman_openscap.spec
+++ b/rubygem-foreman_openscap/rubygem-foreman_openscap.spec
@@ -24,6 +24,7 @@ URL: https://github.com/OpenSCAP/foreman_openscap
 Source0: http://rubygems.org/downloads/%{gem_name}-%{version}.gem
 
 Requires: foreman >= 1.5.0
+Requires: scap-security-guide >= 0.1.22
 
 Requires: %{?scl_prefix}rubygem(deface)
 Requires: %{?scl_prefix}rubygem(scaptimony) >= 0.3.0


### PR DESCRIPTION
foreman_openscap has a [seed](https://github.com/OpenSCAP/foreman_openscap/blob/master/db/seeds.d/openscap_scap_default.rb) and a [bulk uploader](https://github.com/OpenSCAP/foreman_openscap/blob/master/lib/foreman_openscap/bulk_upload.rb#L12), which takes scap content from scap-security-guide and creates default scap_content in Foreman