### PR TITLE
update foreman_xen to 0.0.6 (DEB)

### DIFF
--- a/plugins/ruby-foreman-xen/debian/changelog
+++ b/plugins/ruby-foreman-xen/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-xen (0.0.6-1) stable; urgency=low
+
+  * 0.0.6 released
+
+ -- Michael Moll <mmoll@mmoll.at>  Tue, 12 May 2015, 20:38:17 +0200
+
 ruby-foreman-xen (0.0.4.1-1) stable; urgency=low
 
   * Set HOME to ~foreman as rb-readline requires it

--- a/plugins/ruby-foreman-xen/debian/control
+++ b/plugins/ruby-foreman-xen/debian/control
@@ -8,6 +8,6 @@ Homepage: https://github.com/theforeman/foreman-xen
 
 Package: ruby-foreman-xen
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman-compute (>= 1.6.0~rc1),
+Depends: ${misc:Depends}, bundler, foreman-compute (>= 1.6.0~rc1), foreman-compute (<<1.8.0~rc1)
 Description: Foreman XenServer compute resource
  XenServer compute resource plugin for Foreman

--- a/plugins/ruby-foreman-xen/debian/gem.list
+++ b/plugins/ruby-foreman-xen/debian/gem.list
@@ -1,2 +1,2 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_xen-0.0.4.1.gem"
+GEMS="https://rubygems.org/downloads/foreman_xen-0.0.6.gem"

--- a/plugins/ruby-foreman-xen/foreman_xen.rb
+++ b/plugins/ruby-foreman-xen/foreman_xen.rb
@@ -1,1 +1,1 @@
-gem 'foreman_xen', '0.0.4.1'
+gem 'foreman_xen', '0.0.6'


### PR DESCRIPTION
And mark incompatible with foreman 1.8, because of the networking changes. I'd like to have this in nightly, 1.8 and 1.7, so people upgrading from 1.7 will at least know, it won't work.