### PR TITLE
refs #10003 - use new config migration script [deb]

### DIFF
--- a/debian/jessie/foreman-proxy/install
+++ b/debian/jessie/foreman-proxy/install
@@ -4,6 +4,7 @@ bin                       usr/share/foreman-proxy
 bundler.d                 usr/share/foreman-proxy
 config.ru                 usr/share/foreman-proxy
 extra/migrate_settings.rb usr/share/foreman-proxy/extra
+extra/migrations          usr/share/foreman-proxy/extra
 Gemfile.in                usr/share/foreman-proxy
 lib                       usr/share/foreman-proxy
 modules                   usr/share/foreman-proxy

--- a/debian/jessie/foreman-proxy/postinst
+++ b/debian/jessie/foreman-proxy/postinst
@@ -41,23 +41,22 @@ case "$1" in
 
     chmod 0700 "/var/cache/foreman-proxy"
 
-    if [ -d /var/lib/foreman-proxy ] ; then
-      # Migrate legacy monolithic proxy config
-      # To detect if a migration is needed, we run the script in a tmpdir and
-      # check if the data in the tmpdir is the same as what's already in place
-      cd /var/lib/foreman-proxy
-      if $FOREMAN_HOME/extra/migrate_settings.rb ./settings.yml; then
-        mv settings.yml $CONFIGDIR/settings.yml
-        ls *.yml >/dev/null 2>&1 && mv *.yml $CONFIGDIR/settings.d/
+    TEMP=$(mktemp -d)
+    trap "rm -rf $TEMP" EXIT
+    (
+      cd $TEMP
+      if ruby $FOREMAN_HOME/extra/migrate_settings.rb -t . > /var/log/foreman-proxy/migrate_settings.log 2>&1; then
+        (
+          cd result && for f in migration_state settings.yml settings.d/*.yml; do
+            [ -e "$f" ] && cat $f > ${CONFIGDIR}/$f
+          done
+        )
+        # from monolithic to split config files
+        egrep -q '^:settings_directory' ${CONFIGDIR}/settings.yml || \
+          sed -i "/^---/ a #replace default location of \"settings.d\"\n:settings_directory: ${CONFIGDIR}/settings.d\n" \
+            ${CONFIGDIR}/settings.yml
       fi
-      cd /tmp && rm -rf /var/lib/foreman-proxy
-      # If we migrated, we also need to fix the settings.d dir
-      if grep -q ^:settings_directory: $CONFIGDIR/settings.yml; then
-        sed -i "s|:settings_directory:.*|:settings_directory: $CONFIGDIR/settings.d|" $CONFIGDIR/settings.yml
-      else
-        echo ":settings_directory: $CONFIGDIR/settings.d" >> $CONFIGDIR/settings.yml
-      fi
-    fi
+    )
   ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/jessie/foreman-proxy/preinst
+++ b/debian/jessie/foreman-proxy/preinst
@@ -20,12 +20,6 @@ case "$1" in
         rm -rf  $FOREMAN_HOME/config
         ln -snf $CONFIGDIR $FOREMAN_HOME/config
       fi
-
-      # Backup config for migration, if required
-      rm -rf /var/lib/foreman-proxy
-      if [ ! -d $CONFIGDIR/settings.d ] ; then
-        cp -r $CONFIGDIR /var/lib/
-      fi
     ;;
     *)
         echo "preinst called with unknown argument \`$1'" >&2

--- a/debian/jessie/foreman-proxy/rules
+++ b/debian/jessie/foreman-proxy/rules
@@ -11,6 +11,7 @@
 
 build:
 	rename 's/.example//' config/settings.d/*
+	touch config/migration_state
 	mv config foreman-proxy # dh_install doesn't rename things
 	mv Gemfile Gemfile.in
 	dh $@

--- a/debian/precise/foreman-proxy/install
+++ b/debian/precise/foreman-proxy/install
@@ -4,6 +4,7 @@ bin                       usr/share/foreman-proxy
 bundler.d                 usr/share/foreman-proxy
 config.ru                 usr/share/foreman-proxy
 extra/migrate_settings.rb usr/share/foreman-proxy/extra
+extra/migrations          usr/share/foreman-proxy/extra
 Gemfile.in                usr/share/foreman-proxy
 lib                       usr/share/foreman-proxy
 modules                   usr/share/foreman-proxy

--- a/debian/precise/foreman-proxy/postinst
+++ b/debian/precise/foreman-proxy/postinst
@@ -41,23 +41,22 @@ case "$1" in
 
     chmod 0700 "/var/cache/foreman-proxy"
 
-    if [ -d /var/lib/foreman-proxy ] ; then
-      # Migrate legacy monolithic proxy config
-      # To detect if a migration is needed, we run the script in a tmpdir and
-      # check if the data in the tmpdir is the same as what's already in place
-      cd /var/lib/foreman-proxy
-      if $FOREMAN_HOME/extra/migrate_settings.rb ./settings.yml; then
-        mv settings.yml $CONFIGDIR/settings.yml
-        ls *.yml >/dev/null 2>&1 && mv *.yml $CONFIGDIR/settings.d/
+    TEMP=$(mktemp -d)
+    trap "rm -rf $TEMP" EXIT
+    (
+      cd $TEMP
+      if ruby $FOREMAN_HOME/extra/migrate_settings.rb -t . > /var/log/foreman-proxy/migrate_settings.log 2>&1; then
+        (
+          cd result && for f in migration_state settings.yml settings.d/*.yml; do
+            [ -e "$f" ] && cat $f > ${CONFIGDIR}/$f
+          done
+        )
+        # from monolithic to split config files
+        egrep -q '^:settings_directory' ${CONFIGDIR}/settings.yml || \
+          sed -i "/^---/ a #replace default location of \"settings.d\"\n:settings_directory: ${CONFIGDIR}/settings.d\n" \
+            ${CONFIGDIR}/settings.yml
       fi
-      cd /tmp && rm -rf /var/lib/foreman-proxy
-      # If we migrated, we also need to fix the settings.d dir
-      if grep -q ^:settings_directory: $CONFIGDIR/settings.yml; then
-        sed -i "s|:settings_directory:.*|:settings_directory: $CONFIGDIR/settings.d|" $CONFIGDIR/settings.yml
-      else
-        echo ":settings_directory: $CONFIGDIR/settings.d" >> $CONFIGDIR/settings.yml
-      fi
-    fi
+    )
   ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/precise/foreman-proxy/preinst
+++ b/debian/precise/foreman-proxy/preinst
@@ -20,12 +20,6 @@ case "$1" in
         rm -rf  $FOREMAN_HOME/config
         ln -snf $CONFIGDIR $FOREMAN_HOME/config
       fi
-
-      # Backup config for migration, if required
-      rm -rf /var/lib/foreman-proxy
-      if [ ! -d $CONFIGDIR/settings.d ] ; then
-        cp -r $CONFIGDIR /var/lib/
-      fi
     ;;
     *)
         echo "preinst called with unknown argument \`$1'" >&2

--- a/debian/precise/foreman-proxy/rules
+++ b/debian/precise/foreman-proxy/rules
@@ -11,6 +11,7 @@
 
 build:
 	rename 's/.example//' config/settings.d/*
+	touch config/migration_state
 	mv config foreman-proxy # dh_install doesn't rename things
 	mv Gemfile Gemfile.in
 	dh $@

--- a/debian/trusty/foreman-proxy/install
+++ b/debian/trusty/foreman-proxy/install
@@ -4,6 +4,7 @@ bin                       usr/share/foreman-proxy
 bundler.d                 usr/share/foreman-proxy
 config.ru                 usr/share/foreman-proxy
 extra/migrate_settings.rb usr/share/foreman-proxy/extra
+extra/migrations          usr/share/foreman-proxy/extra
 Gemfile.in                usr/share/foreman-proxy
 lib                       usr/share/foreman-proxy
 modules                   usr/share/foreman-proxy

--- a/debian/trusty/foreman-proxy/postinst
+++ b/debian/trusty/foreman-proxy/postinst
@@ -41,23 +41,22 @@ case "$1" in
 
     chmod 0700 "/var/cache/foreman-proxy"
 
-    if [ -d /var/lib/foreman-proxy ] ; then
-      # Migrate legacy monolithic proxy config
-      # To detect if a migration is needed, we run the script in a tmpdir and
-      # check if the data in the tmpdir is the same as what's already in place
-      cd /var/lib/foreman-proxy
-      if $FOREMAN_HOME/extra/migrate_settings.rb ./settings.yml; then
-        mv settings.yml $CONFIGDIR/settings.yml
-        ls *.yml >/dev/null 2>&1 && mv *.yml $CONFIGDIR/settings.d/
+    TEMP=$(mktemp -d)
+    trap "rm -rf $TEMP" EXIT
+    (
+      cd $TEMP
+      if ruby $FOREMAN_HOME/extra/migrate_settings.rb -t . > /var/log/foreman-proxy/migrate_settings.log 2>&1; then
+        (
+          cd result && for f in migration_state settings.yml settings.d/*.yml; do
+            [ -e "$f" ] && cat $f > ${CONFIGDIR}/$f
+          done
+        )
+        # from monolithic to split config files
+        egrep -q '^:settings_directory' ${CONFIGDIR}/settings.yml || \
+          sed -i "/^---/ a #replace default location of \"settings.d\"\n:settings_directory: ${CONFIGDIR}/settings.d\n" \
+            ${CONFIGDIR}/settings.yml
       fi
-      cd /tmp && rm -rf /var/lib/foreman-proxy
-      # If we migrated, we also need to fix the settings.d dir
-      if grep -q ^:settings_directory: $CONFIGDIR/settings.yml; then
-        sed -i "s|:settings_directory:.*|:settings_directory: $CONFIGDIR/settings.d|" $CONFIGDIR/settings.yml
-      else
-        echo ":settings_directory: $CONFIGDIR/settings.d" >> $CONFIGDIR/settings.yml
-      fi
-    fi
+    )
   ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/trusty/foreman-proxy/preinst
+++ b/debian/trusty/foreman-proxy/preinst
@@ -20,12 +20,6 @@ case "$1" in
         rm -rf  $FOREMAN_HOME/config
         ln -snf $CONFIGDIR $FOREMAN_HOME/config
       fi
-
-      # Backup config for migration, if required
-      rm -rf /var/lib/foreman-proxy
-      if [ ! -d $CONFIGDIR/settings.d ] ; then
-        cp -r $CONFIGDIR /var/lib/
-      fi
     ;;
     *)
         echo "preinst called with unknown argument \`$1'" >&2

--- a/debian/trusty/foreman-proxy/rules
+++ b/debian/trusty/foreman-proxy/rules
@@ -11,6 +11,7 @@
 
 build:
 	rename 's/.example//' config/settings.d/*
+	touch config/migration_state
 	mv config foreman-proxy # dh_install doesn't rename things
 	mv Gemfile Gemfile.in
 	dh $@

--- a/debian/wheezy/foreman-proxy/install
+++ b/debian/wheezy/foreman-proxy/install
@@ -4,6 +4,7 @@ bin                       usr/share/foreman-proxy
 bundler.d                 usr/share/foreman-proxy
 config.ru                 usr/share/foreman-proxy
 extra/migrate_settings.rb usr/share/foreman-proxy/extra
+extra/migrations          usr/share/foreman-proxy/extra
 Gemfile.in                usr/share/foreman-proxy
 lib                       usr/share/foreman-proxy
 modules                   usr/share/foreman-proxy

--- a/debian/wheezy/foreman-proxy/postinst
+++ b/debian/wheezy/foreman-proxy/postinst
@@ -41,23 +41,22 @@ case "$1" in
 
     chmod 0700 "/var/cache/foreman-proxy"
 
-    if [ -d /var/lib/foreman-proxy ] ; then
-      # Migrate legacy monolithic proxy config
-      # To detect if a migration is needed, we run the script in a tmpdir and
-      # check if the data in the tmpdir is the same as what's already in place
-      cd /var/lib/foreman-proxy
-      if $FOREMAN_HOME/extra/migrate_settings.rb ./settings.yml; then
-        mv settings.yml $CONFIGDIR/settings.yml
-        ls *.yml >/dev/null 2>&1 && mv *.yml $CONFIGDIR/settings.d/
+    TEMP=$(mktemp -d)
+    trap "rm -rf $TEMP" EXIT
+    (
+      cd $TEMP
+      if ruby $FOREMAN_HOME/extra/migrate_settings.rb -t . > /var/log/foreman-proxy/migrate_settings.log 2>&1; then
+        (
+          cd result && for f in migration_state settings.yml settings.d/*.yml; do
+            [ -e "$f" ] && cat $f > ${CONFIGDIR}/$f
+          done
+        )
+        # from monolithic to split config files
+        egrep -q '^:settings_directory' ${CONFIGDIR}/settings.yml || \
+          sed -i "/^---/ a #replace default location of \"settings.d\"\n:settings_directory: ${CONFIGDIR}/settings.d\n" \
+            ${CONFIGDIR}/settings.yml
       fi
-      cd /tmp && rm -rf /var/lib/foreman-proxy
-      # If we migrated, we also need to fix the settings.d dir
-      if grep -q ^:settings_directory: $CONFIGDIR/settings.yml; then
-        sed -i "s|:settings_directory:.*|:settings_directory: $CONFIGDIR/settings.d|" $CONFIGDIR/settings.yml
-      else
-        echo ":settings_directory: $CONFIGDIR/settings.d" >> $CONFIGDIR/settings.yml
-      fi
-    fi
+    )
   ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/wheezy/foreman-proxy/preinst
+++ b/debian/wheezy/foreman-proxy/preinst
@@ -20,12 +20,6 @@ case "$1" in
         rm -rf  $FOREMAN_HOME/config
         ln -snf $CONFIGDIR $FOREMAN_HOME/config
       fi
-
-      # Backup config for migration, if required
-      rm -rf /var/lib/foreman-proxy
-      if [ ! -d $CONFIGDIR/settings.d ] ; then
-        cp -r $CONFIGDIR /var/lib/
-      fi
     ;;
     *)
         echo "preinst called with unknown argument \`$1'" >&2

--- a/debian/wheezy/foreman-proxy/rules
+++ b/debian/wheezy/foreman-proxy/rules
@@ -11,6 +11,7 @@
 
 build:
 	rename 's/.example//' config/settings.d/*
+	touch config/migration_state
 	mv config foreman-proxy # dh_install doesn't rename things
 	mv Gemfile Gemfile.in
 	dh $@


### PR DESCRIPTION
I've only been able to test this by testing the scripts standalone, which is pretty much copied from #664, as I don't have a quick way to build a package from both the smart proxy + packaging branches.