### PR TITLE
Extend custom fetcher to get source from local checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Packages in the plugins repo:
 
     tito release koji-foreman-plugins --test --scratch
 
-Core Foreman packages without nightly sources stored:
+Core nightly Foreman packages:
 
 * foreman: `tito release --scratch --arg jenkins_job=test_develop koji-foreman-nightly`
 * foreman-installer: `tito release --scratch --arg jenkins_job=packaging_trigger_installer_develop koji-foreman-nightly`
@@ -65,6 +65,11 @@ Core Foreman packages without nightly sources stored:
 * foreman-selinux: `tito release --scratch --arg jenkins_job=packaging_trigger_selinux_develop koji-foreman-nightly`
 * rubygem-hammer\_cli: `tito release --scratch --arg jenkins_job=test_hammer_cli koji-foreman-nightly`
 * rubygem-hammer\_cli\_foreman: `tito release --scratch --arg jenkins_job=test_hammer_cli_foreman koji-foreman-nightly`
+
+Using a local git checkout, change `source_dir` as appropriate:
+
+* Core packages: `tito release --scratch --arg source_dir=~/foreman koji-foreman-nightly`
+* Plugins: `tito release --scratch --arg source_dir=~/foreman_bootdisk koji-foreman-plugins-nightly`
 
 ### Alternative method with koji access
 

--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -23,3 +23,8 @@ autobuild_tags = foreman-plugins-nightly-fedora19 foreman-plugins-nightly-rhel6 
 [koji-foreman-plugins-rhel7]
 releaser = tito.release.KojiReleaser
 autobuild_tags = foreman-plugins-nightly-rhel7
+
+[koji-foreman-plugins-nightly]
+releaser = tito.release.KojiReleaser
+autobuild_tags = foreman-plugins-nightly-fedora19 foreman-plugins-nightly-rhel6 foreman-plugins-nightly-rhel7
+builder = tito.builder.FetchBuilder

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -9,7 +9,7 @@ tagger = tito.tagger.ReleaseTagger
 lib_dir = rel-eng/custom/
 
 [builder]
-fetch_strategy = custom.JenkinsSourceStrategy
+fetch_strategy = custom.ForemanSourceStrategy
 
 # Blacklist any non-SCL packages that are missing SCL macros or they get built
 # in the SCL tag rather than -nonscl.  Don't forget -rhel7 below too!


### PR DESCRIPTION
Our custom tito sources fetcher, usually used to pull nightly sources from
Jenkins, can now take a "source_dir" argument pointing to a local checkout.
If it's a rubygem, it'll build the gem and otherwise calls "rake
pkg:generate_source" (defined in all Foreman projects) to generate a
tarball.

This allows easy scratch building of a git branch.  See the README change
for usage.

@iNecas I think this is what you were asking after yesterday.