### PR TITLE
refs #10787 - remove foreman-compute subpackage deps

### DIFF
--- a/debian/jessie/foreman/control
+++ b/debian/jessie/foreman/control
@@ -101,7 +101,7 @@ Package: foreman-ec2
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman, foreman-compute, ${misc:Depends}
+Depends: foreman, ${misc:Depends}
 Description: metapackage providing EC2 dependencies for Foreman
  This package provides Amazon EC2 dependencies for Foreman, a
  flexible systems management web application.
@@ -112,7 +112,7 @@ Package: foreman-libvirt
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman, foreman-compute, pkg-config, libvirt-dev, ${misc:Depends}
+Depends: foreman, pkg-config, libvirt-dev, ${misc:Depends}
 Description: metapackage providing libvirt dependencies for Foreman
  This package provides libvirt dependencies for Foreman, a
  flexible systems management web application.
@@ -190,7 +190,7 @@ Package: foreman-gce
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman, foreman-compute, ${misc:Depends}
+Depends: foreman, ${misc:Depends}
 Description: metapackage providing GCE dependencies for Foreman
  This package provides Google Compute Engine dependencies for Foreman,
  a flexible systems management web application.

--- a/debian/precise/foreman/control
+++ b/debian/precise/foreman/control
@@ -101,7 +101,7 @@ Package: foreman-ec2
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman, foreman-compute, ${misc:Depends}
+Depends: foreman, ${misc:Depends}
 Description: metapackage providing EC2 dependencies for Foreman
  This package provides Amazon EC2 dependencies for Foreman, a
  flexible systems management web application.
@@ -112,7 +112,7 @@ Package: foreman-libvirt
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman, foreman-compute, pkg-config, libvirt-dev, ${misc:Depends}
+Depends: foreman, pkg-config, libvirt-dev, ${misc:Depends}
 Description: metapackage providing libvirt dependencies for Foreman
  This package provides libvirt dependencies for Foreman, a
  flexible systems management web application.
@@ -190,7 +190,7 @@ Package: foreman-gce
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman, foreman-compute, ${misc:Depends}
+Depends: foreman, ${misc:Depends}
 Description: metapackage providing GCE dependencies for Foreman
  This package provides Google Compute Engine dependencies for Foreman,
  a flexible systems management web application.

--- a/debian/trusty/foreman/control
+++ b/debian/trusty/foreman/control
@@ -100,7 +100,7 @@ Package: foreman-ec2
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman, foreman-compute, ${misc:Depends}
+Depends: foreman, ${misc:Depends}
 Description: metapackage providing EC2 dependencies for Foreman
  This package provides Amazon EC2 dependencies for Foreman, a
  flexible systems management web application.
@@ -111,7 +111,7 @@ Package: foreman-libvirt
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman, foreman-compute, pkg-config, libvirt-dev, ${misc:Depends}
+Depends: foreman, pkg-config, libvirt-dev, ${misc:Depends}
 Description: metapackage providing libvirt dependencies for Foreman
  This package provides libvirt dependencies for Foreman, a
  flexible systems management web application.
@@ -189,7 +189,7 @@ Package: foreman-gce
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman, foreman-compute, ${misc:Depends}
+Depends: foreman, ${misc:Depends}
 Description: metapackage providing GCE dependencies for Foreman
  This package provides Google Compute Engine dependencies for Foreman,
  a flexible systems management web application.

--- a/debian/wheezy/foreman/control
+++ b/debian/wheezy/foreman/control
@@ -100,7 +100,7 @@ Package: foreman-ec2
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman, foreman-compute, ${misc:Depends}
+Depends: foreman, ${misc:Depends}
 Description: metapackage providing EC2 dependencies for Foreman
  This package provides Amazon EC2 dependencies for Foreman, a
  flexible systems management web application.
@@ -111,7 +111,7 @@ Package: foreman-libvirt
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman, foreman-compute, pkg-config, libvirt-dev, ${misc:Depends}
+Depends: foreman, pkg-config, libvirt-dev, ${misc:Depends}
 Description: metapackage providing libvirt dependencies for Foreman
  This package provides libvirt dependencies for Foreman, a
  flexible systems management web application.
@@ -189,7 +189,7 @@ Package: foreman-gce
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman, foreman-compute, ${misc:Depends}
+Depends: foreman, ${misc:Depends}
 Description: metapackage providing GCE dependencies for Foreman
  This package provides Google Compute Engine dependencies for Foreman,
  a flexible systems management web application.


### PR DESCRIPTION
Only from these three CRs as their bundler groups are now truly independent of the main Fog group (https://github.com/theforeman/foreman/commit/3f73d0054d935e220c74a87dc0bcbbd8731dc5dd).