### PR TITLE
Update dynflow to 0.7.9

### DIFF
--- a/rubygem-dynflow/dynflow-0.7.8.gem
+++ b/rubygem-dynflow/dynflow-0.7.8.gem
@@ -1,1 +1,0 @@
-../.git/annex/objects/Qw/8k/SHA256E-s799232--b7e15ad3301da61eae609a341a497e2c076089dbddeab7c58e960fcaeacb3bff.8.gem/SHA256E-s799232--b7e15ad3301da61eae609a341a497e2c076089dbddeab7c58e960fcaeacb3bff.8.gem

--- a/rubygem-dynflow/dynflow-0.7.9.gem
+++ b/rubygem-dynflow/dynflow-0.7.9.gem
@@ -1,0 +1,1 @@
+../.git/annex/objects/gj/8v/SHA256E-s796672--df1b9ffb6a23252fac6e6d842bdea25cfc1d98ccd366d8139a31cf60cecc144c.9.gem/SHA256E-s796672--df1b9ffb6a23252fac6e6d842bdea25cfc1d98ccd366d8139a31cf60cecc144c.9.gem

--- a/rubygem-dynflow/rubygem-dynflow.spec
+++ b/rubygem-dynflow/rubygem-dynflow.spec
@@ -6,7 +6,7 @@
 
 Summary: DYNamic workFLOW engine
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 0.7.8
+Version: 0.7.9
 Release: 1%{?dist}
 Group: Development/Languages
 License: MIT


### PR DESCRIPTION
The templates work introduced a conflict with the sinatra 1.3 global
helpers. This version avoids introducing this global methods.

The deb PR on it's way as well.