### PR TITLE
Added rubygem-newt

### DIFF
--- a/comps/comps-foreman-fedora19.xml
+++ b/comps/comps-foreman-fedora19.xml
@@ -76,6 +76,7 @@
       <packagereq type="default">rubygem-mysql2</packagereq>
       <packagereq type="default">rubygem-net-ldap</packagereq>
       <packagereq type="default">rubygem-net-scp</packagereq>
+      <packagereq type="default">rubygem-newt</packagereq>
       <packagereq type="default">rubygem-po_to_json</packagereq>
       <packagereq type="default">rubygem-powerbar</packagereq>
       <packagereq type="default">rubygem-quiet_assets</packagereq>
@@ -147,6 +148,7 @@
       <packagereq type="default">rubygem-mysql2-doc</packagereq>
       <packagereq type="default">rubygem-net-ldap-doc</packagereq>
       <packagereq type="default">rubygem-net-scp-doc</packagereq>
+      <packagereq type="default">rubygem-newt-doc</packagereq>
       <packagereq type="default">rubygem-po_to_json-doc</packagereq>
       <packagereq type="default">rubygem-powerbar-doc</packagereq>
       <packagereq type="default">rubygem-quiet_assets-doc</packagereq>

--- a/comps/comps-foreman-rhel6.xml
+++ b/comps/comps-foreman-rhel6.xml
@@ -89,6 +89,7 @@
       <packagereq type="default">ruby193-rubygem-net-ldap</packagereq>
       <packagereq type="default">ruby193-rubygem-net-scp</packagereq>
       <packagereq type="default">ruby193-rubygem-net-ssh</packagereq>
+      <packagereq type="default">ruby193-rubygem-newt</packagereq>
       <packagereq type="default">ruby193-rubygem-nokogiri</packagereq>
       <packagereq type="default">ruby193-rubygem-oauth</packagereq>
       <packagereq type="default">ruby193-rubygem-paint</packagereq>
@@ -228,6 +229,7 @@
       <packagereq type="default">ruby193-rubygem-netrc-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-net-scp-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-net-ssh-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-newt-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-nokogiri-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-paint-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-passenger-doc</packagereq>

--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -89,6 +89,7 @@
       <packagereq type="default">ruby193-rubygem-net-ldap</packagereq>
       <packagereq type="default">ruby193-rubygem-net-scp</packagereq>
       <packagereq type="default">ruby193-rubygem-net-ssh</packagereq>
+      <packagereq type="default">ruby193-rubygem-newt</packagereq>
       <packagereq type="default">ruby193-rubygem-nokogiri</packagereq>
       <packagereq type="default">ruby193-rubygem-oauth</packagereq>
       <packagereq type="default">ruby193-rubygem-paint</packagereq>
@@ -230,6 +231,7 @@
       <packagereq type="default">ruby193-rubygem-netrc-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-net-scp-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-net-ssh-doc</packagereq>
+      <packagereq type="default">ruby193-rubygem-newt-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-nokogiri-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-paint-doc</packagereq>
       <packagereq type="default">ruby193-rubygem-passenger-doc</packagereq>

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -23,6 +23,7 @@ blacklist = foreman-installer
   rubygem-clamp
   rubygem-hammer_cli
   rubygem-hammer_cli_foreman
+  rubygem-newt
   rubygem-powerbar
   rubygem-rack-protection
   rubygem-rb-readline
@@ -43,6 +44,7 @@ blacklist = foreman-installer
   rubygem-clamp
   rubygem-hammer_cli
   rubygem-hammer_cli_foreman
+  rubygem-newt
   rubygem-powerbar
   rubygem-rack-protection
   rubygem-rb-readline
@@ -179,6 +181,7 @@ whitelist = foreman
   rubygem-mysql2
   rubygem-net-ldap
   rubygem-net-scp
+  rubygem-newt
   rubygem-po_to_json
   rubygem-powerbar
   rubygem-quiet_assets

--- a/rubygem-newt/newt-0.9.4.gem
+++ b/rubygem-newt/newt-0.9.4.gem
@@ -1,0 +1,1 @@
+../.git/annex/objects/f2/8g/SHA256E-s11776--5c29747df0a71ad9ff4c8ef15451829bb57972bfda5d3a1b29a1d4eee1b73a8e.4.gem/SHA256E-s11776--5c29747df0a71ad9ff4c8ef15451829bb57972bfda5d3a1b29a1d4eee1b73a8e.4.gem

--- a/rubygem-newt/rubygem-newt.spec
+++ b/rubygem-newt/rubygem-newt.spec
@@ -1,0 +1,81 @@
+%{?scl:%scl_package rubygem-%{gem_name}}
+%{!?scl:%global pkg_name %{name}}
+
+%if 0%{?rhel} == 6 && 0%{!?scl:1}
+%{!?gem_extdir_mri:%global gem_extdir_mri %(ruby -rrbconfig -e "puts Config::CONFIG['sitearchdir']")}
+%global gem_extdir_mri_lib %{gem_extdir_mri}
+%else
+%{!?gem_extdir_mri:%global gem_extdir_mri %{gem_extdir}}
+%global gem_extdir_mri_lib %{gem_extdir_mri}/lib
+%endif
+
+%global gem_name newt
+
+Summary: Ruby bindings for newt
+Name: %{?scl_prefix}rubygem-%{gem_name}
+
+Version: 0.9.4
+Release: 1%{?dist}
+Group: Development/Languages
+License: MIT
+URL: https://github.com/theforeman/ruby-newt
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
+
+Requires: %{?scl_prefix}ruby
+Requires: %{?scl_prefix}rubygems
+
+Requires: newt
+
+BuildRequires: %{?scl_prefix}ruby
+BuildRequires: %{?scl_prefix}rubygems
+BuildRequires: %{?scl_prefix}rubygems-devel
+BuildRequires: %{?scl_prefix}ruby-devel
+
+BuildRequires: newt-devel
+
+Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
+
+%description
+Ruby bindings for the newt TUI library allows creation of rich
+user text-based experience in Ruby language.
+
+%package doc
+BuildArch:  noarch
+Requires:   %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+Summary:    Documentation for rubygem-%{gem_name}
+
+%description doc
+This package contains documentation for rubygem-%{gem_name}.
+
+%prep
+%setup -q -c -T
+mkdir -p .%{gem_dir}
+%{?scl:scl enable %{scl} "}
+gem install --local --install-dir .%{gem_dir} \
+            --force %{SOURCE0}
+%{?scl:"}
+find .%{gem_dir}
+
+%build
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -a .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+mkdir -p %{buildroot}%{gem_extdir_mri_lib}/ruby_newt
+mv %{buildroot}%{gem_instdir}/lib/ruby_newt/ruby_newt.so %{buildroot}%{gem_extdir_mri_lib}/ruby_newt/ruby_newt.so
+rm -rf %{buildroot}%{gem_dir}/gems/%{gem_name}-%{version}/{ext,tmp,.require_paths}
+
+%files
+%dir %{gem_instdir}
+%{gem_libdir}
+%{gem_extdir_mri}
+%exclude %{gem_cache}
+%{gem_spec}
+
+%files doc
+%doc %{gem_docdir}
+%doc %{gem_instdir}/README.rdoc
+
+%changelog


### PR DESCRIPTION
This is NONSCL, for discovery image to introduce TUI feature. If possible
please include in 1.9.

F19: http://koji.katello.org/koji/taskinfo?taskID=285900
EL6: http://koji.katello.org/koji/taskinfo?taskID=285902
EL7: http://koji.katello.org/koji/taskinfo?taskID=285903

Tests on RHEL:

```
[root@fsix ~]# rpm -ql rubygem-newt
/usr/lib/ruby/gems/1.8/gems/newt-0.9.4
/usr/lib/ruby/gems/1.8/gems/newt-0.9.4/lib
/usr/lib/ruby/gems/1.8/gems/newt-0.9.4/lib/newt.rb
/usr/lib/ruby/gems/1.8/gems/newt-0.9.4/lib/ruby_newt
/usr/lib/ruby/gems/1.8/gems/newt-0.9.4/lib/version.rb
/usr/lib/ruby/gems/1.8/specifications/newt-0.9.4.gemspec
/usr/lib64/ruby/site_ruby/1.8/x86_64-linux
/usr/lib64/ruby/site_ruby/1.8/x86_64-linux/ruby_newt
/usr/lib64/ruby/site_ruby/1.8/x86_64-linux/ruby_newt/ruby_newt.so
[root@fsix ~]# irb
irb(main):001:0> require "rubygems"
=> true
irb(main):002:0> require "newt"
=> true
```

```
[root@fseven ~]# rpm -ql rubygem-newt
/usr/lib64/gems/ruby/newt-0.9.4
/usr/lib64/gems/ruby/newt-0.9.4/lib
/usr/lib64/gems/ruby/newt-0.9.4/lib/ruby_newt
/usr/lib64/gems/ruby/newt-0.9.4/lib/ruby_newt/ruby_newt.so
/usr/share/gems/gems/newt-0.9.4
/usr/share/gems/gems/newt-0.9.4/lib
/usr/share/gems/gems/newt-0.9.4/lib/newt.rb
/usr/share/gems/gems/newt-0.9.4/lib/ruby_newt
/usr/share/gems/gems/newt-0.9.4/lib/version.rb
/usr/share/gems/specifications/newt-0.9.4.gemspec
[root@fseven ~]# irb
irb(main):001:0> require "newt"
=> true
```