### PR TITLE
fixes #8996 - use Ruby 1.9 for hammer on precise

### DIFF
--- a/dependencies/precise/hammer_cli/changelog
+++ b/dependencies/precise/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (0.2.0-2) stable; urgency=low
+
+  * Use Ruby 1.9 explicitly on Ubuntu/precise
+
+ -- Michael Moll <mmoll@mmoll.at>  Wed, 29 Jul 2015 17:32:35 +0200
+
 ruby-hammer-cli (0.2.0-1) stable; urgency=low
 
   * 0.2.0 release

--- a/dependencies/precise/hammer_cli/control
+++ b/dependencies/precise/hammer_cli/control
@@ -5,13 +5,12 @@ Maintainer: Tomas Strachota <tstrachota@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), gem2deb (>= 0.2.6)
 Standards-Version: 3.9.3
 Homepage: http://github.com/theforeman/hammer-cli
-XS-Ruby-Versions: all
+XS-Ruby-Versions: ruby1.9.1
 
 Package: ruby-hammer-cli
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         rubygems,
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby1.9.1,
          ruby-clamp (>= 0.6.2),
          ruby-rest-client (< 1.7.0),
          ruby-logging,
@@ -21,7 +20,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-fastercsv,
          ruby-mime-types (< 2.0.0),
          ruby-fast-gettext (>= 0.8.0),
-         liblocale-ruby1.8 (>= 2.0.6) | liblocale-ruby1.9.1 (>= 2.0.6),
+         liblocale-ruby1.9.1 (>= 2.0.6),
          ruby-json (>= 1.6.1),
          ruby-apipie-bindings (>= 0.0.10), ruby-apipie-bindings (<< 0.1.0),
          ruby-rb-readline

--- a/dependencies/precise/hammer_cli/patches/change_ruby_shebang.diff
+++ b/dependencies/precise/hammer_cli/patches/change_ruby_shebang.diff
@@ -1,0 +1,8 @@
+--- a/bin/hammer
++++ b/bin/hammer
+@@ -1,4 +1,4 @@
+-#! /usr/bin/env ruby
++#!/usr/bin/ruby
+ 
+ require 'rubygems'
+ require 'clamp'

--- a/dependencies/precise/hammer_cli/patches/series
+++ b/dependencies/precise/hammer_cli/patches/series
@@ -1,0 +1,1 @@
+change_ruby_shebang.diff

--- a/dependencies/precise/hammer_cli_foreman/changelog
+++ b/dependencies/precise/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.2.0-2) stable; urgency=low
+
+  * Use Ruby 1.9 explicitly on Ubuntu/precise
+
+ -- Michael Moll <mmoll@mmoll.at>  Wed, 29 Jul 2015 17:32:35 +0200
+
 ruby-hammer-cli-foreman (0.2.0-1) stable; urgency=low
 
   * 0.2.0 release

--- a/dependencies/precise/hammer_cli_foreman/control
+++ b/dependencies/precise/hammer_cli_foreman/control
@@ -6,12 +6,12 @@ DM-Upload-Allowed: yes
 Build-Depends: debhelper (>= 7.0.50~), gem2deb (>= 0.2.6)
 Standards-Version: 3.9.3
 Homepage: http://github.com/theforeman/hammer-cli-foreman
-XS-Ruby-Versions: all
+XS-Ruby-Versions: ruby1.9.1
 
 Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby1.9.1,
          ruby-hammer-cli (>= 0.2.0)
 Description: Foreman commands for Hammer
  Foreman commands for Hammer CLI

--- a/dependencies/precise/hammer_cli_foreman_bootdisk/changelog
+++ b/dependencies/precise/hammer_cli_foreman_bootdisk/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-bootdisk (0.1.3-2) stable; urgency=low
+
+  * Use Ruby 1.9 explicitly on Ubuntu/precise
+
+ -- Michael Moll <mmoll@mmoll.at>  Wed, 29 Jul 2015 17:32:35 +0200
+
 ruby-hammer-cli-foreman-bootdisk (0.1.3) stable; urgency=low
 
   * 0.1.3 released

--- a/dependencies/precise/hammer_cli_foreman_bootdisk/control
+++ b/dependencies/precise/hammer_cli_foreman_bootdisk/control
@@ -6,12 +6,12 @@ DM-Upload-Allowed: yes
 Build-Depends: debhelper (>= 7.0.50~), gem2deb (>= 0.2.6)
 Standards-Version: 3.9.3
 Homepage: http://github.com/theforeman/hammer_cli_foreman_bootdisk
-XS-Ruby-Versions: all
+XS-Ruby-Versions: ruby1.9.1
 
 Package: ruby-hammer-cli-foreman-bootdisk
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby1.9.1,
          ruby-hammer-cli-foreman (>= 0.1.2)
 Description: Foreman boot disk commands for Hammer CLI
  This Hammer CLI plugin contains set of commands for foreman_bootdisk, a plugin

--- a/dependencies/precise/hammer_cli_foreman_discovery/changelog
+++ b/dependencies/precise/hammer_cli_foreman_discovery/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-discovery (0.0.2-2) stable; urgency=low
+
+  * Use Ruby 1.9 explicitly on Ubuntu/precise
+
+ -- Michael Moll <mmoll@mmoll.at>  Wed, 29 Jul 2015 17:32:35 +0200
+
 ruby-hammer-cli-foreman-discovery (0.0.2-1) stable; urgency=low
 
   * Update to 0.0.2

--- a/dependencies/precise/hammer_cli_foreman_discovery/control
+++ b/dependencies/precise/hammer_cli_foreman_discovery/control
@@ -5,11 +5,11 @@ Maintainer: Michael Moll <mmoll@mmoll.at>
 Build-Depends: debhelper, gem2deb
 Standards-Version: 3.9.5
 Homepage: https://github.com/theforeman/hammer-cli-foreman-discovery
-XS-Ruby-Versions: all
+XS-Ruby-Versions: ruby1.9.1
 
 Package: ruby-hammer-cli-foreman-discovery
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, ruby-hammer-cli-foreman (>= 0.1.2)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby1.9.1, ruby-hammer-cli-foreman (>= 0.1.2)
 Description: Foreman CLI plugin for managing discovery hosts in foreman
  Contains the code for managing host discovery in foreman (results and progress) in the Hammer CLI.

--- a/dependencies/precise/hammer_cli_foreman_docker/changelog
+++ b/dependencies/precise/hammer_cli_foreman_docker/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-docker (0.0.3-2) unstable; urgency=medium
+
+  * Use Ruby 1.9 explicitly on Ubuntu/precise
+
+ -- Michael Moll <mmoll@mmoll.at>  Wed, 29 Jul 2015 17:32:35 +0200
+
 ruby-hammer-cli-foreman-docker (0.0.3-1) unstable; urgency=medium
 
   * Initial release

--- a/dependencies/precise/hammer_cli_foreman_docker/control
+++ b/dependencies/precise/hammer_cli_foreman_docker/control
@@ -5,11 +5,11 @@ Maintainer: Michael Moll <mmoll@mmoll.at>
 Build-Depends: debhelper, gem2deb
 Standards-Version: 3.9.5
 Homepage: https://github.com/theforeman/hammer_cli_foreman_docker
-XS-Ruby-Versions: all
+XS-Ruby-Versions: ruby1.9.1
 
 Package: ruby-hammer-cli-foreman-docker
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, ruby-hammer-cli-foreman (>= 0.1.2)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby1.9.1, ruby-hammer-cli-foreman (>= 0.1.2)
 Description: Foreman Docker-related commands for Hammer
  This Hammer CLI plugin contains set of commands for foreman_docker, a plugin to Foreman for Docker.

--- a/dependencies/precise/hammer_cli_foreman_salt/changelog
+++ b/dependencies/precise/hammer_cli_foreman_salt/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-salt (0.0.4-2) stable; urgency=low
+
+  * Use Ruby 1.9 explicitly on Ubuntu/precise
+
+ -- Michael Moll <mmoll@mmoll.at>  Wed, 29 Jul 2015 17:32:35 +0200
+
 ruby-hammer-cli-foreman-salt (0.0.4-1) stable; urgency=low
 
   * Update to 0.0.4

--- a/dependencies/precise/hammer_cli_foreman_salt/control
+++ b/dependencies/precise/hammer_cli_foreman_salt/control
@@ -5,12 +5,12 @@ Maintainer: Michael Moll <mmoll@mmoll.at>
 Build-Depends: debhelper, gem2deb
 Standards-Version: 3.9.3
 Homepage: http://github.com/theforeman/hammer_cli_foreman_salt
-XS-Ruby-Versions: all
+XS-Ruby-Versions: ruby1.9.1
 
 Package: ruby-hammer-cli-foreman-salt
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby1.9.1,
          ruby-hammer-cli-foreman (>= 0.1.2)
 Description: foreman_salt commands for Hammer CLI
  This Hammer CLI plugin contains the commands for foreman_salt, a plugin

--- a/dependencies/precise/hammer_cli_foreman_ssh/changelog
+++ b/dependencies/precise/hammer_cli_foreman_ssh/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-ssh (0.0.3-2) stable; urgency=low
+
+  * Use Ruby 1.9 explicitly on Ubuntu/precise
+
+ -- Michael Moll <mmoll@mmoll.at>  Wed, 29 Jul 2015 17:32:35 +0200
+
 ruby-hammer-cli-foreman-ssh (0.0.3) stable; urgency=low
 
   * Update to 0.0.3

--- a/dependencies/precise/hammer_cli_foreman_ssh/control
+++ b/dependencies/precise/hammer_cli_foreman_ssh/control
@@ -6,12 +6,12 @@ DM-Upload-Allowed: yes
 Build-Depends: debhelper (>= 7.0.50~), gem2deb (>= 0.2.6)
 Standards-Version: 3.9.3
 Homepage: http://github.com/theforeman/hammer-cli-foreman-ssh
-XS-Ruby-Versions: all
+XS-Ruby-Versions: ruby1.9.1
 
 Package: ruby-hammer-cli-foreman-ssh
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby1.9.1,
          ruby-hammer-cli-foreman (>= 0.1.2),
          ruby-net-ssh-multi (>= 1.2.1)
 Description: Remote SSH commands for Hammer CLI


### PR DESCRIPTION
yet untested.