### PR TITLE
fixes #11275, #11170 - pass spaces/quotes in args through SCL wrappers

### DIFF
--- a/ruby-wrapper/ruby-wrapper
+++ b/ruby-wrapper/ruby-wrapper
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-COMMAND="ruby $@"
+COMMAND="ruby"
 SCL=FIXMESCL
 
-scl enable $SCL "$COMMAND"
-
+# Execute a single script with no arguments with 'scl', else it fails to
+# pass spaces/quotes in arguments through correctly (RHBZ#1248418).
+TMP=$(mktemp)
+trap "rm -f $TMP" EXIT
+echo -n $COMMAND > $TMP
+for arg in "$@"; do
+  printf " %q" "$arg" >> $TMP
+done
+scl enable $SCL "bash $TMP"

--- a/ruby-wrapper/ruby-wrapper-rails
+++ b/ruby-wrapper/ruby-wrapper-rails
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-COMMAND="rails $@"
+COMMAND="rails"
 SCL=FIXMESCL
 
-scl enable $SCL "$COMMAND"
-
+# Execute a single script with no arguments with 'scl', else it fails to
+# pass spaces/quotes in arguments through correctly (RHBZ#1248418).
+TMP=$(mktemp)
+trap "rm -f $TMP" EXIT
+echo -n $COMMAND > $TMP
+for arg in "$@"; do
+  printf " %q" "$arg" >> $TMP
+done
+scl enable $SCL "bash $TMP"

--- a/ruby-wrapper/ruby-wrapper-rake
+++ b/ruby-wrapper/ruby-wrapper-rake
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-COMMAND="rake $@"
+COMMAND="rake"
 SCL=FIXMESCL
 
-scl enable $SCL "$COMMAND"
-
+# Execute a single script with no arguments with 'scl', else it fails to
+# pass spaces/quotes in arguments through correctly (RHBZ#1248418).
+TMP=$(mktemp)
+trap "rm -f $TMP" EXIT
+echo -n $COMMAND > $TMP
+for arg in "$@"; do
+  printf " %q" "$arg" >> $TMP
+done
+scl enable $SCL "bash $TMP"


### PR DESCRIPTION
Changes the ruby193/SCL wrappers to create a temporary file containing
all original arguments from the ruby193-* command and then executes it
via "scl enable".  This fixes two quoting-related bugs with these
wrappers.

1. #11170: the "scl enable" command has a bug (RHBZ#1248418) where it
   internally uses temporary shell scripts and doesn't escape double
   quotes, so JSON strings can't be passed through as arguments.
2. #11275: the ruby-wrappers passed through arguments word-by-word,
   causing arguments containing spaces to be split up.  It should have
   used the special quoted "$@" variable.