### PR TITLE
Increase the epoch number for the concurrent-ruby gems

### DIFF
--- a/rubygem-concurrent-ruby-edge/rubygem-concurrent-ruby-edge.spec
+++ b/rubygem-concurrent-ruby-edge/rubygem-concurrent-ruby-edge.spec
@@ -7,7 +7,8 @@
 Summary: Edge concepts for the modern concurrency tools for Ruby
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.1.0
-Release: 1%{?dist}
+Release: 2%{?dist}
+Epoch: 1
 Group: Development/Languages
 
 License: MIT

--- a/rubygem-concurrent-ruby/rubygem-concurrent-ruby.spec
+++ b/rubygem-concurrent-ruby/rubygem-concurrent-ruby.spec
@@ -7,7 +7,8 @@
 Summary: Modern concurrency tools for Ruby
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.9.0
-Release: 1%{?dist}
+Release: 2%{?dist}
+Epoch: 1
 Group: Development/Languages
 
 License: MIT


### PR DESCRIPTION
The previous version numbers (0.9.0.pre3/0.1.0.pre3) were considered higher 
from the yum perspective, than the 0.9.0/0.1.0