### PR TITLE
Remove dependency on Foreman from dynflow (DEB)

### DIFF
--- a/plugins/ruby-foreman-dynflow/debian/changelog
+++ b/plugins/ruby-foreman-dynflow/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-dynflow (0.8.1-2) stable; urgency=low
+
+  * 0.8.2-2 released
+
+ -- Stephen Benjamin <stephen@bitbin.de>  Tue, 11 Aug 2015 12:27:00 -0500
+
 ruby-foreman-dynflow (0.8.2-1) stable; urgency=low
 
   * 0.8.2-1 released

--- a/plugins/ruby-foreman-dynflow/debian/control
+++ b/plugins/ruby-foreman-dynflow/debian/control
@@ -8,5 +8,5 @@ Homepage: https://github.com/Dynflow/dynflow
 
 Package: ruby-foreman-dynflow
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman
+Depends: ${misc:Depends}, bundler
 Description: Ruby workflow/orchestration engine


### PR DESCRIPTION
We need dynflow on the smart proxies.  Dynflow doesn't require foreman, but I have some questions about to handle this:

- Can we just call this ruby-dynflow? It's not a foreman package, but no idea how to "rename" a deb package and obsolete the other one

- What about postinst? It's using foreman ruby, can we make it only use system ruby?