### PR TITLE
[do not merge] Add foreman-plugins-nonscl-nightly-rhel* tags

### DIFF
--- a/koji/copy-tags-commands.sh
+++ b/koji/copy-tags-commands.sh
@@ -44,6 +44,7 @@ clone() {
   echo kkoji add-target $PRODUCT-$VERSION-$SYSTEM $PRODUCT-$VERSION-$SYSTEM-build $PRODUCT-$VERSION-$SYSTEM
 }
 
+### Foreman
 PRODUCT=foreman
 # clone non-SCL OSes, nonscl tags for SCL OSes
 for SYSTEM in $NONSCL_SYSTEMS $(echo $SCL_SYSTEMS | sed 's/\(^\| \)/\1nonscl-/g'); do
@@ -53,12 +54,23 @@ done
 # clone SCL tags, inherit from nonscl
 for SYSTEM in $SCL_SYSTEMS; do
   clone $PRODUCT-$OLD-$SYSTEM $PRODUCT-$VERSION-$SYSTEM
-  echo kkoji add-tag-inheritance --priority=10 $PRODUCT-$VERSION-$SYSTEM foreman-$VERSION-nonscl-$SYSTEM
+  echo kkoji add-tag-inheritance --priority=10 $PRODUCT-$VERSION-$SYSTEM $PRODUCT-$VERSION-nonscl-$SYSTEM
 done
 
+### Plugins
 PRODUCT=foreman-plugins
-# clone plugin tags, inherit from SCL tags
-for SYSTEM in $NONSCL_SYSTEMS $SCL_SYSTEMS; do
+# clone plugin tags for non-SCL OSes, nonscl tags for SCL OSes
+for SYSTEM in $NONSCL_SYSTEMS $(echo $SCL_SYSTEMS | sed 's/\(^\| \)/\1nonscl-/g'); do
   clone $PRODUCT-$OLD-$SYSTEM $PRODUCT-$VERSION-$SYSTEM
+done
+
+# clone SCL tags, inherit from nonscl
+for SYSTEM in $SCL_SYSTEMS; do
+  clone $PRODUCT-$OLD-$SYSTEM $PRODUCT-$VERSION-$SYSTEM
+  echo kkoji add-tag-inheritance --priority=10 $PRODUCT-$VERSION-$SYSTEM $PRODUCT-$VERSION-nonscl-$SYSTEM
+done
+
+# inherit core Foreman tags into both non-SCL and SCL plugin tags
+for SYSTEM in $NONSCL_SYSTEMS $SCL_SYSTEMS $(echo $SCL_SYSTEMS | sed 's/\(^\| \)/\1nonscl-/g'); do
   echo kkoji add-tag-inheritance --priority=10 $PRODUCT-$VERSION-$SYSTEM-build foreman-$VERSION-$SYSTEM
 done

--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -10,11 +10,11 @@ builder.jenkins_url = http://ci.theforeman.org
 
 [koji-foreman-plugins]
 releaser = tito.release.KojiReleaser
-autobuild_tags = foreman-plugins-nightly-fedora19 foreman-plugins-nightly-rhel6 foreman-plugins-nightly-rhel7
+autobuild_tags = foreman-plugins-nightly-nonscl-rhel6 foreman-plugins-nightly-nonscl-rhel7 foreman-plugins-nightly-fedora19 foreman-plugins-nightly-rhel6 foreman-plugins-nightly-rhel7
 builder.rpmbuild_options = --define "foremandist .fm1_10"
 
 [koji-foreman-plugins-nightly]
 releaser = tito.release.KojiReleaser
-autobuild_tags = foreman-plugins-nightly-fedora19 foreman-plugins-nightly-rhel6 foreman-plugins-nightly-rhel7
+autobuild_tags = foreman-plugins-nightly-nonscl-rhel6 foreman-plugins-nightly-nonscl-rhel7 foreman-plugins-nightly-fedora19 foreman-plugins-nightly-rhel6 foreman-plugins-nightly-rhel7
 builder = tito.builder.FetchBuilder
 builder.rpmbuild_options = --define "foremandist .fm1_10"

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -187,8 +187,7 @@ whitelist = foreman
 [foreman-plugins-nightly-rhel6]
 disttag = .el6
 scl = ruby193
-whitelist = ipxe
-  rubygem-algebrick
+whitelist = rubygem-algebrick
   rubygem-angular-rails-templates
   rubygem-apipie-params
   rubygem-archive-tar-minitar
@@ -204,7 +203,6 @@ whitelist = ipxe
   rubygem-ffi
   rubygem-git
   rubygem-jgrep
-  rubygem-newt
   rubygem-openscap
   rubygem-opennebula
   rubygem-foreman_abrt
@@ -230,7 +228,6 @@ whitelist = ipxe
   rubygem-foreman_param_lookup
   rubygem-foreman_reserve
   rubygem-foreman_salt
-  rubygem-foreman_scap_client
   rubygem-foreman_setup
   rubygem-foreman_simplify
   rubygem-foreman_snapshot
@@ -249,15 +246,21 @@ whitelist = ipxe
   rubygem-net-ssh-multi
   rubygem-ovirt_provision_plugin
   rubygem-puppetdb_foreman
-  rubygem-satyr
   rubygem-scaptimony
+  rubygem-wicked
+  rubygem-zscheduler
+
+[foreman-plugins-nightly-nonscl-rhel6]
+disttag = .el6
+whitelist = ipxe
+  rubygem-foreman_scap_client
+  rubygem-newt
+  rubygem-satyr
   rubygem-smart_proxy_abrt
   rubygem-smart_proxy_discovery
   rubygem-smart_proxy_openscap
   rubygem-smart_proxy_pulp
   rubygem-smart_proxy_salt
-  rubygem-wicked
-  rubygem-zscheduler
 
 [foreman-plugins-nightly-rhel7]
 disttag = .el7
@@ -267,7 +270,6 @@ whitelist = rubygem-algebrick
   rubygem-apipie-params
   rubygem-archive-tar-minitar
   rubygem-bastion
-  rubygem-chef-api
   rubygem-commonjs
   rubygem-concurrent-ruby
   rubygem-concurrent-ruby-edge
@@ -279,7 +281,6 @@ whitelist = rubygem-algebrick
   rubygem-ffi
   rubygem-git
   rubygem-jgrep
-  rubygem-newt
   rubygem-openscap
   rubygem-opennebula
   rubygem-foreman_abrt
@@ -305,7 +306,6 @@ whitelist = rubygem-algebrick
   rubygem-foreman_param_lookup
   rubygem-foreman_reserve
   rubygem-foreman_salt
-  rubygem-foreman_scap_client
   rubygem-foreman_setup
   rubygem-foreman_simplify
   rubygem-foreman_snapshot
@@ -326,16 +326,22 @@ whitelist = rubygem-algebrick
   rubygem-net-ssh-multi
   rubygem-ovirt_provision_plugin
   rubygem-puppetdb_foreman
-  rubygem-satyr
   rubygem-scaptimony
+  rubygem-wicked
+  rubygem-zscheduler
+
+[foreman-plugins-nightly-nonscl-rhel7]
+disttag = .el7
+whitelist = rubygem-chef-api
+  rubygem-foreman_scap_client
+  rubygem-newt
+  rubygem-satyr
   rubygem-smart_proxy_abrt
-  rubygem-smart_proxy_discovery
   rubygem-smart_proxy_chef
+  rubygem-smart_proxy_discovery
   rubygem-smart_proxy_openscap
   rubygem-smart_proxy_pulp
   rubygem-smart_proxy_salt
-  rubygem-wicked
-  rubygem-zscheduler
 
 [foreman-plugins-nightly-fedora19]
 disttag = .fc19


### PR DESCRIPTION
Allow building of a package in a non-SCL manner, or in both SCL and
non-SCL tags through the koji-foreman-plugins releaser.

Will be merged on Weds when I plan to make the corresponding changes to the foreman-plugins-nightly-* tags in Koji (https://groups.google.com/forum/#!topic/foreman-dev/RUeJtbnGBBA).

copy-tags-commands.sh generates this for plugins:
<pre>
$ koji/copy-tags-commands.sh nightly 1.10
clone foreman-plugins-nightly-fedora19 foreman-plugins-1.10-fedora19
clone foreman-plugins-nightly-nonscl-rhel6 foreman-plugins-1.10-nonscl-rhel6
clone foreman-plugins-nightly-nonscl-rhel7 foreman-plugins-1.10-nonscl-rhel7
clone foreman-plugins-nightly-rhel6 foreman-plugins-1.10-rhel6
kkoji add-tag-inheritance --priority=10 foreman-plugins-1.10-rhel6 foreman-plugins-1.10-nonscl-rhel6
clone foreman-plugins-nightly-rhel7 foreman-plugins-1.10-rhel7
kkoji add-tag-inheritance --priority=10 foreman-plugins-1.10-rhel7 foreman-plugins-1.10-nonscl-rhel7
kkoji add-tag-inheritance --priority=10 foreman-plugins-1.10-fedora19-build foreman-1.10-fedora19
kkoji add-tag-inheritance --priority=10 foreman-plugins-1.10-rhel6-build foreman-1.10-rhel6
kkoji add-tag-inheritance --priority=10 foreman-plugins-1.10-rhel7-build foreman-1.10-rhel7
kkoji add-tag-inheritance --priority=10 foreman-plugins-1.10-nonscl-rhel6-build foreman-1.10-nonscl-rhel6
kkoji add-tag-inheritance --priority=10 foreman-plugins-1.10-nonscl-rhel7-build foreman-1.10-nonscl-rhel7
</pre>

Should lead to a tag inheritance layout looking like this for SCL OSes:

<pre>
foreman-plugins
  foreman-plugins-nonscl
    foreman-nonscl
  foreman
    [ foreman-nonscl ]
</pre>