### PR TITLE
Update deface to 1.0.1 (deb)

### DIFF
--- a/debian/jessie/foreman/debian.rb
+++ b/debian/jessie/foreman/debian.rb
@@ -1,2 +1,2 @@
 # Extra debian gems to go in the vendoring cache
-gem 'nokogiri', '~> 1.5.0'
+gem 'nokogiri', '~> 1.6.0'

--- a/debian/precise/foreman/debian.rb
+++ b/debian/precise/foreman/debian.rb
@@ -1,2 +1,2 @@
 # Extra debian gems to go in the vendoring cache
-gem 'nokogiri', '~> 1.5.0'
+gem 'nokogiri', '~> 1.6.0'

--- a/debian/trusty/foreman/debian.rb
+++ b/debian/trusty/foreman/debian.rb
@@ -1,2 +1,2 @@
 # Extra debian gems to go in the vendoring cache
-gem 'nokogiri', '~> 1.5.0'
+gem 'nokogiri', '~> 1.6.0'

--- a/debian/wheezy/foreman/debian.rb
+++ b/debian/wheezy/foreman/debian.rb
@@ -1,2 +1,2 @@
 # Extra debian gems to go in the vendoring cache
-gem 'nokogiri', '~> 1.5.0'
+gem 'nokogiri', '~> 1.6.0'

--- a/plugins/ruby-foreman-deface/debian/changelog
+++ b/plugins/ruby-foreman-deface/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-deface (1.0.1) stable; urgency=low
+
+  * Update to 1.0.1
+
+ -- Dominic Cleal <dcleal@redhat.com>  Fri, 21 Aug 2015 09:30:23 +0100
+
 ruby-foreman-deface (0.9.1-2) stable; urgency=low
 
   * Set HOME to ~foreman as rb-readline requires it

--- a/plugins/ruby-foreman-deface/debian/gem.list
+++ b/plugins/ruby-foreman-deface/debian/gem.list
@@ -1,2 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/deface-0.9.1.gem"
+GEMS="https://rubygems.org/downloads/deface-1.0.1.gem"
+GEMS="$GEMS https://rubygems.org/downloads/colorize-0.7.7.gem"

--- a/plugins/ruby-foreman-deface/foreman_deface.rb
+++ b/plugins/ruby-foreman-deface/foreman_deface.rb
@@ -1,1 +1,1 @@
-gem 'deface'
+gem 'deface', '1.0.1'


### PR DESCRIPTION
Change core Foreman packages to ship nokogiri 1.6.x as a requirement
for deface 1.x.