### PR TITLE
libaugeas-ruby -> ruby-augeas for Debian/jessie

### DIFF
--- a/debian/jessie/foreman-proxy/control
+++ b/debian/jessie/foreman-proxy/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/theforeman/smart-proxy
 
 Package: foreman-proxy
 Architecture: all
-Depends: ruby2.1|ruby-interpreter, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-rkerberos (>= 0.1.1), libaugeas-ruby, ruby-bundler-ext
+Depends: ruby2.1|ruby-interpreter, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-rkerberos (>= 0.1.1), ruby-augeas, ruby-bundler-ext
 Recommends: sudo, wget, ping, ruby-gssapi, ruby-rubyipmi (>= 0.9.2), foreman-debug
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems

--- a/debian/trusty/foreman-proxy/control
+++ b/debian/trusty/foreman-proxy/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/theforeman/smart-proxy
 
 Package: foreman-proxy
 Architecture: all
-Depends: ruby1.9.1|ruby-interpreter, rake, ruby-sinatra, ruby-rack (>= 1.1.0), ruby-json, ruby-rkerberos (>= 0.1.1), ruby-bundler-ext
+Depends: ruby1.9.1|ruby-interpreter, rake, ruby-sinatra, ruby-rack (>= 1.1.0), ruby-json, ruby-rkerberos (>= 0.1.1), ruby-augeas, ruby-bundler-ext
 Recommends: sudo, wget, ping, ruby-gssapi, ruby-rubyipmi (>= 0.9.2), foreman-debug
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems


### PR DESCRIPTION
As libaugeas-ruby is just a transitional package depending on ruby-augeas this is a noop on Debian/jessie, but makes the -proxy package installable on testing/unstable again.

I'd like to see this also in 1.9, so 1.9.1 packages will get built with this change.