### PR TITLE
Replace libxml2-dev dependency with zlib1g for nokogiri 1.6

### DIFF
--- a/debian/jessie/foreman/control
+++ b/debian/jessie/foreman/control
@@ -4,7 +4,7 @@ Section: web
 Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 7), cdbs, bundler (>= 1.1), ruby2.1-dev, git | git-core,
-               libxml2-dev, libxslt1-dev, libmysqlclient-dev, libpq-dev, pkg-config,
+               zlib1g-dev, libmysqlclient-dev, libpq-dev, pkg-config,
                libvirt-dev, libsqlite3-dev, facter, build-essential, curl
 Homepage: http://www.theforeman.org/
 
@@ -12,7 +12,7 @@ Package: foreman
 Architecture: any
 Section: web
 Priority: extra
-Depends: ruby2.1, bundler (>= 1.1), libxslt1-dev,
+Depends: ruby2.1, bundler (>= 1.1), zlib1g-dev,
          ruby2.1-dev, facter, build-essential,
          rake (>=0.8.4), ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug
@@ -89,7 +89,7 @@ Architecture: all
 Section: web
 Priority: extra
 Recommends: foreman-ec2
-Depends: foreman, libxml2-dev, libxslt1-dev, ${misc:Depends}
+Depends: foreman, ${misc:Depends}
 Description: metapackage providing fog dependencies for Foreman,
  adding OpenStack and Rackspace compute resource support.
  This package provides fog dependencies for Foreman, a

--- a/debian/precise/foreman/control
+++ b/debian/precise/foreman/control
@@ -5,7 +5,7 @@ Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 7), cdbs, bundler (>= 1.2), ruby1.9.3 (>= 1:1.9.3.545),
                ruby1.9.1-dev (>= 1:1.9.3.545), git | git-core,
-               libxml2-dev, libxslt1-dev, libmysqlclient-dev, libpq-dev, pkg-config,
+               zlib1g-dev, libmysqlclient-dev, libpq-dev, pkg-config,
                libvirt-dev, libsqlite3-dev, facter, build-essential
 Homepage: http://www.theforeman.org/
 
@@ -14,7 +14,7 @@ Architecture: any
 Section: web
 Priority: extra
 Depends: ruby1.9.3 (>= 1:1.9.3.545), bundler (>= 1.2), ruby1.9.1-dev (>= 1:1.9.3.545),
-         libxml2-dev, libxslt1-dev, facter (>= 1.6.12-1puppetlabs2), build-essential,
+         zlib1g-dev, facter (>= 1.6.12-1puppetlabs2), build-essential,
          rake (>=0.8.4), ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug
 Description: Systems management web interface
@@ -89,7 +89,7 @@ Architecture: all
 Section: web
 Priority: extra
 Recommends: foreman-ec2
-Depends: foreman, libxml2-dev, libxslt1-dev, ${misc:Depends}
+Depends: foreman, ${misc:Depends}
 Description: metapackage providing fog dependencies for Foreman,
  adding OpenStack and Rackspace compute resource support.
  This package provides fog dependencies for Foreman, a

--- a/debian/trusty/foreman/control
+++ b/debian/trusty/foreman/control
@@ -4,7 +4,7 @@ Section: web
 Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 7), cdbs, bundler (>= 1.2), ruby, ruby1.9.1-dev, git | git-core,
-               libxml2-dev, libxslt1-dev, libmysqlclient-dev, libpq-dev, pkg-config,
+               zlib1g-dev, libmysqlclient-dev, libpq-dev, pkg-config,
                libvirt-dev, libsqlite3-dev, facter, build-essential
 Homepage: http://www.theforeman.org/
 
@@ -13,7 +13,7 @@ Architecture: any
 Section: web
 Priority: extra
 Depends: rubygems1.8 | ruby1.9.1, bundler (>= 1.2), ruby-dev,
-         libxml2-dev, libxslt1-dev, facter, build-essential,
+         zlib1g-dev, facter, build-essential,
          rake (>=0.8.4), ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug
 Description: Systems management web interface
@@ -88,7 +88,7 @@ Architecture: all
 Section: web
 Priority: extra
 Recommends: foreman-ec2
-Depends: foreman, libxml2-dev, libxslt1-dev, ${misc:Depends}
+Depends: foreman, ${misc:Depends}
 Description: metapackage providing fog dependencies for Foreman,
  adding OpenStack and Rackspace compute resource support.
  This package provides fog dependencies for Foreman, a

--- a/debian/wheezy/foreman/control
+++ b/debian/wheezy/foreman/control
@@ -4,7 +4,7 @@ Section: web
 Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 7), cdbs, bundler (>= 1.1), ruby1.9.1-dev, git | git-core,
-               libxml2-dev, libxslt1-dev, libmysqlclient-dev, libpq-dev, pkg-config,
+               zlib1g-dev, libmysqlclient-dev, libpq-dev, pkg-config,
                libvirt-dev, libsqlite3-dev, facter, build-essential
 Homepage: http://www.theforeman.org/
 
@@ -12,7 +12,7 @@ Package: foreman
 Architecture: any
 Section: web
 Priority: extra
-Depends: ruby1.9.1, bundler (>= 1.1), libxslt1-dev,
+Depends: ruby1.9.1, bundler (>= 1.1), zlib1g-dev,
          ruby1.9.1-dev, facter, build-essential,
          rake (>=0.8.4), ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug
@@ -88,7 +88,7 @@ Architecture: all
 Section: web
 Priority: extra
 Recommends: foreman-ec2
-Depends: foreman, libxml2-dev, libxslt1-dev, ${misc:Depends}
+Depends: foreman, ${misc:Depends}
 Description: metapackage providing fog dependencies for Foreman,
  adding OpenStack and Rackspace compute resource support.
  This package provides fog dependencies for Foreman, a


### PR DESCRIPTION
nokogiri 1.6.x builds its own libxml2 during the gem installation
process, so allow it to do that rather than link against the system
libxml2.

---

Tests OK for me, I no longer need libxml2-dev and xslt to install Foreman.  You can reproduce this failure just by installing foreman-sqlite3 on a clean install without the zlib dev library installed already.

<pre>
Installing nokogiri (1.6.6.2) with native extensions 
Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

        /usr/bin/ruby1.9.1 extconf.rb 
checking if the C compiler accepts ... yes
Building nokogiri using packaged libraries.
checking for gzdopen() in -lz... no
zlib is missing; necessary for building libxml2
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of
necessary libraries and/or headers.  Check the mkmf.log file for more
details.  You may need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/usr/bin/ruby1.9.1
        --help
        --clean
        --use-system-libraries
        --enable-static
        --disable-static
        --with-zlib-dir
        --without-zlib-dir
        --with-zlib-include
        --without-zlib-include=${zlib-dir}/include
        --with-zlib-lib
        --without-zlib-lib=${zlib-dir}/lib
        --enable-cross-build
        --disable-cross-build


Gem files will remain installed in /usr/share/foreman/vendor/ruby/1.9.1/gems/nokogiri-1.6.6.2 for inspection.
Results logged to /usr/share/foreman/vendor/ruby/1.9.1/gems/nokogiri-1.6.6.2/ext/nokogiri/gem_make.out
An error occured while installing nokogiri (1.6.6.2), and Bundler cannot continue.
Make sure that `gem install nokogiri -v '1.6.6.2'` succeeds before bundling.
</pre>