### PR TITLE
update kafo to 0.6.12 (DEB)

### DIFF
--- a/dependencies/jessie/kafo/changelog
+++ b/dependencies/jessie/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (0.6.12-1) stable; urgency=low
+
+  * Update to 0.6.12
+
+ -- Michael Moll <mmoll@mmoll.at>  Fri, 28 Aug 2015 15:47:12 +0200
+
 ruby-kafo (0.6.11-1) stable; urgency=low
 
   * Treat any return value from stdlib's validate_* functions as success

--- a/dependencies/jessie/kafo/control
+++ b/dependencies/jessie/kafo/control
@@ -2,20 +2,25 @@ Source: ruby-kafo
 Section: ruby
 Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
-Build-Depends: debhelper (>= 7.0.50~), gem2deb (>= 0.3.0~)
 Standards-Version: 3.9.3
+Build-Depends: debhelper (>= 7.0.50~),
+               gem2deb
 Homepage: https://github.com/theforeman/kafo
 XS-Ruby-Versions: all
 
 Package: ruby-kafo
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         puppet (< 4.0.0),
-         ruby-clamp,
-         ruby-highline (< 1.7),
+Depends: ruby | ruby-interpreter,
+         puppet (<< 4.0.0),
+         ruby-clamp (>= 0.6.2),
+         ruby-highline (<< 2.0),
+         ruby-highline (>= 1.6.21),
          ruby-kafo-parsers,
-         ruby-logging (< 2.0.0),
-         ruby-powerbar
-Description: If you write puppet modules for installing your software, you can use kafo to create powerful installer
- A gem for making installations based on puppet user friendly
+         ruby-logging (<< 3.0.0),
+         ruby-powerbar,
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: Ruby gem for making installations based on puppet user friendly
+ If you write puppet modules for installing your software,
+ you can use kafo to create powerful installer

--- a/dependencies/jessie/kafo/copyright
+++ b/dependencies/jessie/kafo/copyright
@@ -1,33 +1,27 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: kafo
-Source: FIXME <http://example.com/>
+Source: https://github.com/theforeman/kafo
 
 Files: *
-Copyright: <years> <put author's name and email here>
-           <years> <likewise for another author>
-License: GPL-2+ (FIXME)
- This program is free software; you can redistribute it
- and/or modify it under the terms of the GNU General Public
- License as published by the Free Software Foundation; either
- version 2 of the License, or (at your option) any later
- version.
- .
- This program is distributed in the hope that it will be
- useful, but WITHOUT ANY WARRANTY; without even the implied
- warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
- PURPOSE.  See the GNU General Public License for more
- details.
- .
- You should have received a copy of the GNU General Public
- License along with this package; if not, write to the Free
- Software Foundation, Inc., 51 Franklin St, Fifth Floor,
- Boston, MA  02110-1301 USA
- .
- On Debian systems, the full text of the GNU General Public
- License version 2 can be found in the file
- `/usr/share/common-licenses/GPL-2'.
+Copyright: 2013-2015 Marek Hulán <ares@igloonet.cz>
+           2013-2015 Foreman developers <foreman-dev@googlegroups.com>
+License: GPL-3+
 
 Files: debian/*
-Copyright: 2013  <>
-License:
- [LICENSE TEXT]
+Copyright: 2013-2015 Foreman developers <foreman-dev@googlegroups.com>
+License: GPL-3+
+Comment: The Debian packaging is licensed under the same terms as the original package.
+
+License: GPL-3+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the full text of the GNU General Public License
+ version 3 can be found in the file `/usr/share/common-licenses/GPL-3'.

--- a/dependencies/precise/kafo/changelog
+++ b/dependencies/precise/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (0.6.12-1) stable; urgency=low
+
+  * Update to 0.6.12
+
+ -- Michael Moll <mmoll@mmoll.at>  Fri, 28 Aug 2015 15:47:12 +0200
+
 ruby-kafo (0.6.11-1) stable; urgency=low
 
   * Treat any return value from stdlib's validate_* functions as success

--- a/dependencies/precise/kafo/control
+++ b/dependencies/precise/kafo/control
@@ -2,20 +2,25 @@ Source: ruby-kafo
 Section: ruby
 Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
-Build-Depends: debhelper (>= 7.0.50~), gem2deb (>= 0.2.6)
 Standards-Version: 3.9.3
+Build-Depends: debhelper (>= 7.0.50~),
+               gem2deb
 Homepage: https://github.com/theforeman/kafo
 XS-Ruby-Versions: all
 
 Package: ruby-kafo
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         puppet (< 4.0.0),
-         ruby-clamp,
-         ruby-highline (< 1.7),
+Depends: ruby | ruby-interpreter,
+         puppet (<< 4.0.0),
+         ruby-clamp (>= 0.6.2),
+         ruby-highline (<< 1.7),
+         ruby-highline (>= 1.6.21),
          ruby-kafo-parsers,
-         ruby-logging (< 2.0.0),
-         ruby-powerbar
-Description: If you write puppet modules for installing your software, you can use kafo to create powerful installer
- A gem for making installations based on puppet user friendly
+         ruby-logging (<< 2.0.0),
+         ruby-powerbar,
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: Ruby gem for making installations based on puppet user friendly
+ If you write puppet modules for installing your software,
+ you can use kafo to create powerful installer

--- a/dependencies/precise/kafo/copyright
+++ b/dependencies/precise/kafo/copyright
@@ -1,33 +1,27 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: kafo
-Source: FIXME <http://example.com/>
+Source: https://github.com/theforeman/kafo
 
 Files: *
-Copyright: <years> <put author's name and email here>
-           <years> <likewise for another author>
-License: GPL-2+ (FIXME)
- This program is free software; you can redistribute it
- and/or modify it under the terms of the GNU General Public
- License as published by the Free Software Foundation; either
- version 2 of the License, or (at your option) any later
- version.
- .
- This program is distributed in the hope that it will be
- useful, but WITHOUT ANY WARRANTY; without even the implied
- warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
- PURPOSE.  See the GNU General Public License for more
- details.
- .
- You should have received a copy of the GNU General Public
- License along with this package; if not, write to the Free
- Software Foundation, Inc., 51 Franklin St, Fifth Floor,
- Boston, MA  02110-1301 USA
- .
- On Debian systems, the full text of the GNU General Public
- License version 2 can be found in the file
- `/usr/share/common-licenses/GPL-2'.
+Copyright: 2013-2015 Marek Hulán <ares@igloonet.cz>
+           2013-2015 Foreman developers <foreman-dev@googlegroups.com>
+License: GPL-3+
 
 Files: debian/*
-Copyright: 2013  <>
-License:
- [LICENSE TEXT]
+Copyright: 2013-2015 Foreman developers <foreman-dev@googlegroups.com>
+License: GPL-3+
+Comment: The Debian packaging is licensed under the same terms as the original package.
+
+License: GPL-3+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the full text of the GNU General Public License
+ version 3 can be found in the file `/usr/share/common-licenses/GPL-3'.

--- a/dependencies/trusty/kafo/changelog
+++ b/dependencies/trusty/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (0.6.12-1) stable; urgency=low
+
+  * Update to 0.6.12
+
+ -- Michael Moll <mmoll@mmoll.at>  Fri, 28 Aug 2015 15:47:12 +0200
+
 ruby-kafo (0.6.11-1) stable; urgency=low
 
   * Treat any return value from stdlib's validate_* functions as success

--- a/dependencies/trusty/kafo/control
+++ b/dependencies/trusty/kafo/control
@@ -2,20 +2,25 @@ Source: ruby-kafo
 Section: ruby
 Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
-Build-Depends: debhelper (>= 7.0.50~), gem2deb (>= 0.3.0~)
 Standards-Version: 3.9.3
+Build-Depends: debhelper (>= 7.0.50~),
+               gem2deb
 Homepage: https://github.com/theforeman/kafo
 XS-Ruby-Versions: all
 
 Package: ruby-kafo
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         puppet (< 4.0.0),
-         ruby-clamp,
-         ruby-highline (< 1.7),
+Depends: ruby | ruby-interpreter,
+         puppet (<< 4.0.0),
+         ruby-clamp (>= 0.6.2),
+         ruby-highline (<< 1.7),
+         ruby-highline (>= 1.6.21),
          ruby-kafo-parsers,
-         ruby-logging (< 2.0.0),
-         ruby-powerbar
-Description: If you write puppet modules for installing your software, you can use kafo to create powerful installer
- A gem for making installations based on puppet user friendly
+         ruby-logging (<< 2.0.0),
+         ruby-powerbar,
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: Ruby gem for making installations based on puppet user friendly
+ If you write puppet modules for installing your software,
+ you can use kafo to create powerful installer

--- a/dependencies/trusty/kafo/copyright
+++ b/dependencies/trusty/kafo/copyright
@@ -1,33 +1,27 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: kafo
-Source: FIXME <http://example.com/>
+Source: https://github.com/theforeman/kafo
 
 Files: *
-Copyright: <years> <put author's name and email here>
-           <years> <likewise for another author>
-License: GPL-2+ (FIXME)
- This program is free software; you can redistribute it
- and/or modify it under the terms of the GNU General Public
- License as published by the Free Software Foundation; either
- version 2 of the License, or (at your option) any later
- version.
- .
- This program is distributed in the hope that it will be
- useful, but WITHOUT ANY WARRANTY; without even the implied
- warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
- PURPOSE.  See the GNU General Public License for more
- details.
- .
- You should have received a copy of the GNU General Public
- License along with this package; if not, write to the Free
- Software Foundation, Inc., 51 Franklin St, Fifth Floor,
- Boston, MA  02110-1301 USA
- .
- On Debian systems, the full text of the GNU General Public
- License version 2 can be found in the file
- `/usr/share/common-licenses/GPL-2'.
+Copyright: 2013-2015 Marek Hulán <ares@igloonet.cz>
+           2013-2015 Foreman developers <foreman-dev@googlegroups.com>
+License: GPL-3+
 
 Files: debian/*
-Copyright: 2013  <>
-License:
- [LICENSE TEXT]
+Copyright: 2013-2015 Foreman developers <foreman-dev@googlegroups.com>
+License: GPL-3+
+Comment: The Debian packaging is licensed under the same terms as the original package.
+
+License: GPL-3+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the full text of the GNU General Public License
+ version 3 can be found in the file `/usr/share/common-licenses/GPL-3'.

--- a/dependencies/wheezy/kafo/changelog
+++ b/dependencies/wheezy/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (0.6.12-1) stable; urgency=low
+
+  * Update to 0.6.12
+
+ -- Michael Moll <mmoll@mmoll.at>  Fri, 28 Aug 2015 15:47:12 +0200
+
 ruby-kafo (0.6.11-1) stable; urgency=low
 
   * Treat any return value from stdlib's validate_* functions as success

--- a/dependencies/wheezy/kafo/control
+++ b/dependencies/wheezy/kafo/control
@@ -2,20 +2,25 @@ Source: ruby-kafo
 Section: ruby
 Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
-Build-Depends: debhelper (>= 7.0.50~), gem2deb (>= 0.3.0~)
 Standards-Version: 3.9.3
+Build-Depends: debhelper (>= 7.0.50~),
+               gem2deb
 Homepage: https://github.com/theforeman/kafo
 XS-Ruby-Versions: all
 
 Package: ruby-kafo
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         puppet (< 4.0.0),
-         ruby-clamp,
-         ruby-highline (< 1.7),
+Depends: ruby | ruby-interpreter,
+         puppet (<< 4.0.0),
+         ruby-clamp (>= 0.6.2),
+         ruby-highline (<< 1.7),
+         ruby-highline (>= 1.6.21),
          ruby-kafo-parsers,
-         ruby-logging (< 2.0.0),
-         ruby-powerbar
-Description: If you write puppet modules for installing your software, you can use kafo to create powerful installer
- A gem for making installations based on puppet user friendly
+         ruby-logging (<< 2.0.0),
+         ruby-powerbar,
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: Ruby gem for making installations based on puppet user friendly
+ If you write puppet modules for installing your software,
+ you can use kafo to create powerful installer

--- a/dependencies/wheezy/kafo/copyright
+++ b/dependencies/wheezy/kafo/copyright
@@ -1,33 +1,27 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: kafo
-Source: FIXME <http://example.com/>
+Source: https://github.com/theforeman/kafo
 
 Files: *
-Copyright: <years> <put author's name and email here>
-           <years> <likewise for another author>
-License: GPL-2+ (FIXME)
- This program is free software; you can redistribute it
- and/or modify it under the terms of the GNU General Public
- License as published by the Free Software Foundation; either
- version 2 of the License, or (at your option) any later
- version.
- .
- This program is distributed in the hope that it will be
- useful, but WITHOUT ANY WARRANTY; without even the implied
- warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
- PURPOSE.  See the GNU General Public License for more
- details.
- .
- You should have received a copy of the GNU General Public
- License along with this package; if not, write to the Free
- Software Foundation, Inc., 51 Franklin St, Fifth Floor,
- Boston, MA  02110-1301 USA
- .
- On Debian systems, the full text of the GNU General Public
- License version 2 can be found in the file
- `/usr/share/common-licenses/GPL-2'.
+Copyright: 2013-2015 Marek Hulán <ares@igloonet.cz>
+           2013-2015 Foreman developers <foreman-dev@googlegroups.com>
+License: GPL-3+
 
 Files: debian/*
-Copyright: 2013  <>
-License:
- [LICENSE TEXT]
+Copyright: 2013-2015 Foreman developers <foreman-dev@googlegroups.com>
+License: GPL-3+
+Comment: The Debian packaging is licensed under the same terms as the original package.
+
+License: GPL-3+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the full text of the GNU General Public License
+ version 3 can be found in the file `/usr/share/common-licenses/GPL-3'.


### PR DESCRIPTION
...and some other changes to get more lintian clean.
As there were no code changes, this is safe for 1.9, too