### PR TITLE
Include therubyracer as the JS engine on wheezy/precise

### DIFF
--- a/debian/precise/foreman/foreman-assets.install
+++ b/debian/precise/foreman/foreman-assets.install
@@ -1,1 +1,2 @@
 bundler.d/assets.rb /usr/share/foreman/bundler.d
+bundler.d/therubyracer.rb /usr/share/foreman/bundler.d

--- a/debian/wheezy/foreman/foreman-assets.install
+++ b/debian/wheezy/foreman/foreman-assets.install
@@ -1,1 +1,2 @@
 bundler.d/assets.rb /usr/share/foreman/bundler.d
+bundler.d/therubyracer.rb /usr/share/foreman/bundler.d


### PR DESCRIPTION
A continuation of #799, which I think may fix the build error under #803.  I'll try and build another plugin package on top of this to check.