### PR TITLE
update hammer_cli(_foreman) to 0.4.0 (DEB)

### DIFF
--- a/dependencies/jessie/hammer_cli/changelog
+++ b/dependencies/jessie/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (0.4.0-1) stable; urgency=low
+
+  * 0.4.0 release
+
+ -- Michael Moll <mmoll@mmoll.at>  Mon, 21 Sep 2015 23:37:32 +0200
+
 ruby-hammer-cli (0.3.0-1) stable; urgency=low
 
   * 0.3.0 release

--- a/dependencies/jessie/hammer_cli/control
+++ b/dependencies/jessie/hammer_cli/control
@@ -11,18 +11,13 @@ Package: ruby-hammer-cli
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-clamp (>= 0.6.2),
-         ruby-rest-client (< 1.7.0),
+         ruby-clamp (>= 1.0.0),
          ruby-logging,
          ruby-table-print (>= 1.5.1),
          ruby-awesome-print,
          ruby-highline,
-         ruby-fastercsv,
-         ruby-mime-types (< 2.0.0),
          ruby-fast-gettext (>= 0.8.0),
          ruby-locale (>= 2.0.6),
-         ruby-json (>= 1.6.1),
-         ruby-apipie-bindings (>= 0.0.10), ruby-apipie-bindings (<< 0.1.0),
-         ruby-rb-readline
+         ruby-apipie-bindings (>= 0.0.14), ruby-apipie-bindings (<< 0.1.0)
 Description: Universal command-line interface
  Hammer cli provides universal extendable CLI interface for ruby apps

--- a/dependencies/jessie/hammer_cli_foreman/changelog
+++ b/dependencies/jessie/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.4.0-1) stable; urgency=low
+
+  * 0.4.0 release
+
+ -- Michael Moll <mmoll@mmoll.at>  Mon, 21 Sep 2015 23:37:32 +0200
+
 ruby-hammer-cli-foreman (0.3.0-1) stable; urgency=low
 
   * 0.3.0 release

--- a/dependencies/jessie/hammer_cli_foreman/control
+++ b/dependencies/jessie/hammer_cli_foreman/control
@@ -12,6 +12,6 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 0.3.0)
+         ruby-hammer-cli (>= 0.4.0)
 Description: Foreman commands for Hammer
  Foreman commands for Hammer CLI

--- a/dependencies/precise/hammer_cli/changelog
+++ b/dependencies/precise/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (0.4.0-1) stable; urgency=low
+
+  * 0.4.0 release
+
+ -- Michael Moll <mmoll@mmoll.at>  Mon, 21 Sep 2015 23:37:32 +0200
+
 ruby-hammer-cli (0.3.0-1) stable; urgency=low
 
   * 0.3.0 release

--- a/dependencies/precise/hammer_cli/control
+++ b/dependencies/precise/hammer_cli/control
@@ -11,18 +11,13 @@ Package: ruby-hammer-cli
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby1.9.1,
-         ruby-clamp (>= 0.6.2),
-         ruby-rest-client (< 1.7.0),
+         ruby-clamp (>= 1.0.0),
          ruby-logging,
          ruby-table-print (>= 1.5.1),
          ruby-awesome-print,
          ruby-highline,
-         ruby-fastercsv,
-         ruby-mime-types (< 2.0.0),
          ruby-fast-gettext (>= 0.8.0),
          liblocale-ruby1.9.1 (>= 2.0.6),
-         ruby-json (>= 1.6.1),
-         ruby-apipie-bindings (>= 0.0.10), ruby-apipie-bindings (<< 0.1.0),
-         ruby-rb-readline
+         ruby-apipie-bindings (>= 0.0.14), ruby-apipie-bindings (<< 0.1.0)
 Description: Universal command-line interface
  Hammer cli provides universal extendable CLI interface for ruby apps

--- a/dependencies/precise/hammer_cli_foreman/changelog
+++ b/dependencies/precise/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.4.0-1) stable; urgency=low
+
+  * 0.4.0 release
+
+ -- Michael Moll <mmoll@mmoll.at>  Mon, 21 Sep 2015 23:37:32 +0200
+
 ruby-hammer-cli-foreman (0.3.0-1) stable; urgency=low
 
   * 0.3.0 release

--- a/dependencies/precise/hammer_cli_foreman/control
+++ b/dependencies/precise/hammer_cli_foreman/control
@@ -12,6 +12,6 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby1.9.1,
-         ruby-hammer-cli (>= 0.3.0)
+         ruby-hammer-cli (>= 0.4.0)
 Description: Foreman commands for Hammer
  Foreman commands for Hammer CLI

--- a/dependencies/trusty/hammer_cli/changelog
+++ b/dependencies/trusty/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (0.4.0-1) stable; urgency=low
+
+  * 0.4.0 release
+
+ -- Michael Moll <mmoll@mmoll.at>  Mon, 21 Sep 2015 23:37:32 +0200
+
 ruby-hammer-cli (0.3.0-1) stable; urgency=low
 
   * 0.3.0 release

--- a/dependencies/trusty/hammer_cli/control
+++ b/dependencies/trusty/hammer_cli/control
@@ -11,17 +11,13 @@ Package: ruby-hammer-cli
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-clamp (>= 0.6.2),
-         ruby-rest-client (< 1.7.0),
+         ruby-clamp (>= 1.0.0),
          ruby-logging,
          ruby-table-print (>= 1.5.1),
          ruby-awesome-print,
          ruby-highline,
-         ruby-mime-types (< 2.0.0),
          ruby-fast-gettext (>= 0.8.0),
          ruby-locale (>= 2.0.6),
-         ruby-json (>= 1.6.1),
-         ruby-apipie-bindings (>= 0.0.10), ruby-apipie-bindings (<< 0.1.0),
-         ruby-rb-readline
+         ruby-apipie-bindings (>= 0.0.14), ruby-apipie-bindings (<< 0.1.0)
 Description: Universal command-line interface
  Hammer cli provides universal extendable CLI interface for ruby apps

--- a/dependencies/trusty/hammer_cli_foreman/changelog
+++ b/dependencies/trusty/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.4.0-1) stable; urgency=low
+
+  * 0.4.0 release
+
+ -- Michael Moll <mmoll@mmoll.at>  Mon, 21 Sep 2015 23:37:32 +0200
+
 ruby-hammer-cli-foreman (0.3.0-1) stable; urgency=low
 
   * 0.3.0 release

--- a/dependencies/trusty/hammer_cli_foreman/control
+++ b/dependencies/trusty/hammer_cli_foreman/control
@@ -12,6 +12,6 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 0.3.0)
+         ruby-hammer-cli (>= 0.4.0)
 Description: Foreman commands for Hammer
  Foreman commands for Hammer CLI

--- a/dependencies/wheezy/hammer_cli/changelog
+++ b/dependencies/wheezy/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (0.4.0-1) stable; urgency=low
+
+  * 0.4.0 release
+
+ -- Michael Moll <mmoll@mmoll.at>  Mon, 21 Sep 2015 23:37:32 +0200
+
 ruby-hammer-cli (0.3.0-1) stable; urgency=low
 
   * 0.3.0 release

--- a/dependencies/wheezy/hammer_cli/control
+++ b/dependencies/wheezy/hammer_cli/control
@@ -11,18 +11,13 @@ Package: ruby-hammer-cli
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-clamp (>= 0.6.2),
-         ruby-rest-client (< 1.7.0),
+         ruby-clamp (>= 1.0.0),
          ruby-logging,
          ruby-table-print (>= 1.5.1),
          ruby-awesome-print,
          ruby-highline,
-         ruby-fastercsv,
-         ruby-mime-types (< 2.0.0),
          ruby-fast-gettext (>= 0.8.0),
          ruby-locale (>= 2.0.6),
-         ruby-json (>= 1.6.1),
-         ruby-apipie-bindings (>= 0.0.10), ruby-apipie-bindings (<< 0.1.0),
-         ruby-rb-readline
+         ruby-apipie-bindings (>= 0.0.14), ruby-apipie-bindings (<< 0.1.0)
 Description: Universal command-line interface
  Hammer cli provides universal extendable CLI interface for ruby apps

--- a/dependencies/wheezy/hammer_cli_foreman/changelog
+++ b/dependencies/wheezy/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.4.0-1) stable; urgency=low
+
+  * 0.4.0 release
+
+ -- Michael Moll <mmoll@mmoll.at>  Mon, 21 Sep 2015 23:37:32 +0200
+
 ruby-hammer-cli-foreman (0.3.0-1) stable; urgency=low
 
   * 0.3.0 release

--- a/dependencies/wheezy/hammer_cli_foreman/control
+++ b/dependencies/wheezy/hammer_cli_foreman/control
@@ -12,6 +12,6 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 0.3.0)
+         ruby-hammer-cli (>= 0.4.0)
 Description: Foreman commands for Hammer
  Foreman commands for Hammer CLI


### PR DESCRIPTION
ideally this could also go to 1.9 for the reduced dependencies to ease life on Debian/testing