### PR TITLE
Change dynflow arch to 'all'

### DIFF
--- a/dependencies/jessie/dynflow/control
+++ b/dependencies/jessie/dynflow/control
@@ -9,7 +9,7 @@ Standards-Version: 3.9.3
 XS-Ruby-Versions: all
 
 Package: ruby-dynflow
-Architecture: any
+Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, ruby-algebrick (>= 0.7.0), ruby-algebrick (<< 0.8.0), ruby-apipie-params, ruby-concurrent-ruby (>= 0.9.0), ruby-concurrent-ruby (<< 1.0.0), ruby-concurrent-ruby-edge (>= 0.1.0), ruby-concurrent-ruby-edge (<< 0.2.0), ruby-multi-json
 Suggests: doc-base

--- a/dependencies/trusty/dynflow/control
+++ b/dependencies/trusty/dynflow/control
@@ -9,7 +9,7 @@ Standards-Version: 3.9.3
 XS-Ruby-Versions: all
 
 Package: ruby-dynflow
-Architecture: any
+Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, ruby-algebrick (>= 0.7.0), ruby-algebrick (<< 0.8.0), ruby-apipie-params, ruby-concurrent-ruby (>= 0.9.0), ruby-concurrent-ruby (<< 1.0.0), ruby-concurrent-ruby-edge (>= 0.1.0), ruby-concurrent-ruby-edge (<< 0.2.0), ruby-multi-json
 Suggests: doc-base

--- a/dependencies/wheezy/dynflow/control
+++ b/dependencies/wheezy/dynflow/control
@@ -9,7 +9,7 @@ Standards-Version: 3.9.3
 XS-Ruby-Versions: all
 
 Package: ruby-dynflow
-Architecture: any
+Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, ruby-algebrick (>= 0.7.0), ruby-algebrick (<< 0.8.0), ruby-apipie-params, ruby-concurrent-ruby (>= 0.9.0), ruby-concurrent-ruby (<< 1.0.0), ruby-concurrent-ruby-edge (>= 0.1.0), ruby-concurrent-ruby-edge (<< 0.2.0), ruby-multi-json
 Suggests: doc-base


### PR DESCRIPTION
There doesn't appear to be any native content in dynflow, so it should be 'all'.  This will prevent us rebuilding it for ARM archs separately to x86.