### PR TITLE
Add lsb-release dep for LSB facts (fixes #12134)

### DIFF
--- a/debian/jessie/foreman-installer/control
+++ b/debian/jessie/foreman-installer/control
@@ -14,7 +14,8 @@ XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-kafo (>= 0.6.5),
          puppet (>= 2.7.0),
-         curl
+         curl,
+         lsb-release
 Description: Automated puppet-based installer for The Foreman
  Foreman-installer is a set of puppet modules wrapped in ruby
  library to provide a nice frontend menu for configuring it.

--- a/debian/precise/foreman-installer/control
+++ b/debian/precise/foreman-installer/control
@@ -16,7 +16,8 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-apipie-bindings (>= 0.0.6),
          puppet (>= 3.0.0),
          rubygems,
-         curl
+         curl,
+         lsb-release
 Description: Automated puppet-based installer for The Foreman
  Foreman-installer is a set of puppet modules wrapped in ruby
  library to provide a nice frontend menu for configuring it.

--- a/debian/trusty/foreman-installer/control
+++ b/debian/trusty/foreman-installer/control
@@ -14,7 +14,8 @@ XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-kafo (>= 0.6.5),
          puppet (>= 2.7.0),
-         curl
+         curl,
+         lsb-release
 Description: Automated puppet-based installer for The Foreman
  Foreman-installer is a set of puppet modules wrapped in ruby
  library to provide a nice frontend menu for configuring it.

--- a/debian/wheezy/foreman-installer/control
+++ b/debian/wheezy/foreman-installer/control
@@ -14,7 +14,8 @@ XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-kafo (>= 0.6.5),
          puppet (>= 2.7.0),
-         curl
+         curl,
+         lsb-release
 Description: Automated puppet-based installer for The Foreman
  Foreman-installer is a set of puppet modules wrapped in ruby
  library to provide a nice frontend menu for configuring it.


### PR DESCRIPTION
Some foreman puppet deployment scripts depends on LSB based facts to create proper configurations files. LSB release command is not installed in Debian/Ubuntu system, so add the explicit dependency on foreman-installer package