### PR TITLE
safe_yaml for Fedora 19

### DIFF
--- a/comps/comps-foreman-plugins-fedora19.xml
+++ b/comps/comps-foreman-plugins-fedora19.xml
@@ -79,6 +79,7 @@
       <packagereq type="default">rubygem-newt</packagereq>
       <packagereq type="default">rubygem-opennebula</packagereq>
       <packagereq type="default">rubygem-openscap</packagereq>
+      <packagereq type="default">rubygem-safe_yaml</packagereq>
       <packagereq type="default">rubygem-satyr</packagereq>
       <packagereq type="default">rubygem-wicked</packagereq>
       <packagereq type="default">rubygem-zscheduler</packagereq>
@@ -144,6 +145,7 @@
       <packagereq type="default">rubygem-newt-doc</packagereq>
       <packagereq type="default">rubygem-opennebula-doc</packagereq>
       <packagereq type="default">rubygem-ovirt_provision_plugin-doc</packagereq>
+      <packagereq type="default">rubygem-safe_yaml-doc</packagereq>
       <packagereq type="default">rubygem-satyr-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_abrt-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_chef-doc</packagereq>

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -424,6 +424,7 @@ whitelist = rubygem-algebrick
   rubygem-logify
   rubygem-ovirt_provision_plugin
   rubygem-puppetdb_foreman
+  rubygem-safe_yaml
   rubygem-satyr
   rubygem-smart_proxy_abrt
   rubygem-smart_proxy_discovery


### PR DESCRIPTION
Addition to the tito.props and comps -  foreman_deployments were added to the fedora 19 section, so safe_yaml has to be there as well - sorry I did not notice earlier :cry: 