### PR TITLE
bug: Resolve difference between service unit and config

### DIFF
--- a/foreman-proxy/foreman-proxy.service
+++ b/foreman-proxy/foreman-proxy.service
@@ -4,10 +4,9 @@ Wants=basic.target
 After=basic.target network.target
 
 [Service]
-Type=forking
+Type=simple
 User=foreman-proxy
 ExecStart=/usr/share/foreman-proxy/bin/smart-proxy
-PIDFile=/run/foreman-proxy/foreman-proxy.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
In configuring system the foreman-proxy service refuses to start.
Upon investigation this is due to a conflict in the default
settings.yml file and the systemd service unit.  In the
settings.yml file the default behavior is to run in the foreground
while in the systemd service unit the process is specified as
forking, utilizing a pid file. Either the settings file for
systemd based systems needs to be changed to reflect the intended
behavior of the service unit or the service unit needs to be
changed to reflect the desired behavior of settings.yml.
