### PR TITLE
fixes #12491 - only remove local token secret on removal

### DIFF
--- a/debian/jessie/foreman/foreman.prerm
+++ b/debian/jessie/foreman/foreman.prerm
@@ -9,7 +9,7 @@ set -e
 
 #DEBHELPER#
 
-if [ -f /usr/share/foreman/config/initializers/local_secret_token.rb ]; then
+if [ -f /usr/share/foreman/config/initializers/local_secret_token.rb -a "x$1" = xremove ]; then
   rm -f /usr/share/foreman/config/initializers/local_secret_token.rb
 fi
 

--- a/debian/precise/foreman/foreman.prerm
+++ b/debian/precise/foreman/foreman.prerm
@@ -9,7 +9,7 @@ set -e
 
 #DEBHELPER#
 
-if [ -f /usr/share/foreman/config/initializers/local_secret_token.rb ]; then
+if [ -f /usr/share/foreman/config/initializers/local_secret_token.rb -a "x$1" = xremove ]; then
   rm -f /usr/share/foreman/config/initializers/local_secret_token.rb
 fi
 

--- a/debian/trusty/foreman/foreman.prerm
+++ b/debian/trusty/foreman/foreman.prerm
@@ -9,7 +9,7 @@ set -e
 
 #DEBHELPER#
 
-if [ -f /usr/share/foreman/config/initializers/local_secret_token.rb ]; then
+if [ -f /usr/share/foreman/config/initializers/local_secret_token.rb -a "x$1" = xremove ]; then
   rm -f /usr/share/foreman/config/initializers/local_secret_token.rb
 fi
 

--- a/debian/wheezy/foreman/foreman.prerm
+++ b/debian/wheezy/foreman/foreman.prerm
@@ -9,7 +9,7 @@ set -e
 
 #DEBHELPER#
 
-if [ -f /usr/share/foreman/config/initializers/local_secret_token.rb ]; then
+if [ -f /usr/share/foreman/config/initializers/local_secret_token.rb -a "x$1" = xremove ]; then
   rm -f /usr/share/foreman/config/initializers/local_secret_token.rb
 fi
 


### PR DESCRIPTION
This won't help on an upgrade to the fixed package, but if you install the fixed package and then upgrade/downgrade to something else, the secret should stay intact.

<pre>
dpkg: warning: downgrading foreman from 9999-jessie+scratchbuild+201511161322 to 1.10.0~rc2-1
(Reading database ... 65752 files and directories currently installed.)
Preparing to unpack .../foreman_1.10.0~rc2-1_amd64.deb ...
+ set -e
+ . /usr/share/debconf/confmodule
+ [ !  ]
+ PERL_DL_NONLAZY=1
+ export PERL_DL_NONLAZY
+ [  ]
+ exec /usr/share/debconf/frontend /var/lib/dpkg/info/foreman.prerm upgrade 1.10.0~rc2-1
+ set -e
+ . /usr/share/debconf/confmodule
+ [ ! 1 ]
+ [ -z  ]
+ exec
+ [  ]
+ exec
+ DEBCONF_REDIR=1
+ export DEBCONF_REDIR
+ [ -x /etc/init.d/foreman ]
+ invoke-rc.d foreman stop
+ [ -f /usr/share/foreman/config/initializers/local_secret_token.rb -a xupgrade = xremove ]
+ exit 0
+ set -e
+ exit 0
Unpacking foreman (1.10.0~rc2-1) over (9999-jessie+scratchbuild+201511161322) ...
</pre>

Notice (versus the bug report) that it's not deleted above.

<pre>
+ /usr/sbin/foreman-rake apipie:cache:index
2015-11-16 16:11:52 +0000 | Started
...
2015-11-16 16:12:19 +0000 | Finished
+ [ ! -f config/initializers/local_secret_token.rb ]
+ chown -Rf foreman:foreman /usr/share/foreman
+ [ -x /etc/init.d/foreman ]
</pre>

On full removal of the fixed package:

<pre>
Removing foreman (9999-jessie+scratchbuild+201511161322) ...
+ set -e
+ . /usr/share/debconf/confmodule
+ [ !  ]
+ PERL_DL_NONLAZY=1
+ export PERL_DL_NONLAZY
+ [  ]
+ exec /usr/share/debconf/frontend /var/lib/dpkg/info/foreman.prerm remove
+ set -e
+ . /usr/share/debconf/confmodule
+ [ ! 1 ]
+ [ -z  ]
+ exec
+ [  ]
+ exec
+ DEBCONF_REDIR=1
+ export DEBCONF_REDIR
+ [ -x /etc/init.d/foreman ]
+ invoke-rc.d foreman stop
+ [ -f /usr/share/foreman/config/initializers/local_secret_token.rb -a xremove = xremove ]
+ rm -f /usr/share/foreman/config/initializers/local_secret_token.rb
+ exit 0
</pre>