### PR TITLE
Remove unused bundler.d files [deb]

### DIFF
--- a/debian/jessie/foreman-proxy/rules
+++ b/debian/jessie/foreman-proxy/rules
@@ -14,6 +14,7 @@ build:
 	rename 's/.example//' foreman-proxy/* foreman-proxy/settings.d/*
 	touch config/migration_state
 	mv Gemfile Gemfile.in
+	rm -f bundler.d/{development,test,windows}.rb
 	dh $@
 
 %:

--- a/debian/precise/foreman-proxy/rules
+++ b/debian/precise/foreman-proxy/rules
@@ -14,6 +14,7 @@ build:
 	rename 's/.example//' foreman-proxy/* foreman-proxy/settings.d/*
 	touch config/migration_state
 	mv Gemfile Gemfile.in
+	rm -f bundler.d/{development,test,windows}.rb
 	dh $@
 
 %:

--- a/debian/trusty/foreman-proxy/rules
+++ b/debian/trusty/foreman-proxy/rules
@@ -14,6 +14,7 @@ build:
 	rename 's/.example//' foreman-proxy/* foreman-proxy/settings.d/*
 	touch config/migration_state
 	mv Gemfile Gemfile.in
+	rm -f bundler.d/{development,test,windows}.rb
 	dh $@
 
 %:

--- a/debian/wheezy/foreman-proxy/rules
+++ b/debian/wheezy/foreman-proxy/rules
@@ -14,6 +14,7 @@ build:
 	rename 's/.example//' foreman-proxy/* foreman-proxy/settings.d/*
 	touch config/migration_state
 	mv Gemfile Gemfile.in
+	rm -f bundler.d/{development,test,windows}.rb
 	dh $@
 
 %:


### PR DESCRIPTION
Unknown platforms in bundler.d/windows.rb causes a startup failure on
the older Bundler on 12.04, 14.04 and Wheezy.

---

    /usr/share/foreman-proxy/Gemfile.in:6:in `instance_eval': `x64_mingw` is not a valid platform. The available options are: [:ruby, :ruby_18, :ruby_19, :mri, :mri_18, :mri_19, :rbx, :jruby, :mswin, :mingw, :mingw_18, :mingw_19] (Bundler::DslError)

(Sorry, new PR as I got the branch name wrong.)