### PR TITLE
Fix command to remove bundler.d files

### DIFF
--- a/debian/jessie/foreman-proxy/rules
+++ b/debian/jessie/foreman-proxy/rules
@@ -14,7 +14,7 @@ build:
 	rename 's/.example//' foreman-proxy/* foreman-proxy/settings.d/*
 	touch config/migration_state
 	mv Gemfile Gemfile.in
-	rm -f bundler.d/{development,test,windows}.rb
+	rm -f bundler.d/development.rb bundler.d/test.rb bundler.d/windows.rb
 	dh $@
 
 %:

--- a/debian/precise/foreman-proxy/rules
+++ b/debian/precise/foreman-proxy/rules
@@ -14,7 +14,7 @@ build:
 	rename 's/.example//' foreman-proxy/* foreman-proxy/settings.d/*
 	touch config/migration_state
 	mv Gemfile Gemfile.in
-	rm -f bundler.d/{development,test,windows}.rb
+	rm -f bundler.d/development.rb bundler.d/test.rb bundler.d/windows.rb
 	dh $@
 
 %:

--- a/debian/trusty/foreman-proxy/rules
+++ b/debian/trusty/foreman-proxy/rules
@@ -14,7 +14,7 @@ build:
 	rename 's/.example//' foreman-proxy/* foreman-proxy/settings.d/*
 	touch config/migration_state
 	mv Gemfile Gemfile.in
-	rm -f bundler.d/{development,test,windows}.rb
+	rm -f bundler.d/development.rb bundler.d/test.rb bundler.d/windows.rb
 	dh $@
 
 %:

--- a/debian/wheezy/foreman-proxy/rules
+++ b/debian/wheezy/foreman-proxy/rules
@@ -14,7 +14,7 @@ build:
 	rename 's/.example//' foreman-proxy/* foreman-proxy/settings.d/*
 	touch config/migration_state
 	mv Gemfile Gemfile.in
-	rm -f bundler.d/{development,test,windows}.rb
+	rm -f bundler.d/development.rb bundler.d/test.rb bundler.d/windows.rb
 	dh $@
 
 %:


### PR DESCRIPTION
Seems that the expansion I used quietly fails in the rules file, but this does work (by checking the deb contents).

Followup from #905.