### PR TITLE
fixes #12671 - switch Ubuntu 14.04 to ruby2.0 packages [deb]

### DIFF
--- a/debian/trusty/foreman/control
+++ b/debian/trusty/foreman/control
@@ -3,7 +3,7 @@ Maintainer: Greg Sutcliffe <greg.sutcliffe@gmail.com>
 Section: web
 Priority: extra
 Standards-Version: 3.9.1
-Build-Depends: debhelper (>= 7), cdbs, bundler (>= 1.2), ruby, ruby1.9.1-dev, git | git-core,
+Build-Depends: debhelper (>= 7), cdbs, bundler (>= 1.2), ruby2.0, ruby2.0-dev, git | git-core,
                zlib1g-dev, libmysqlclient-dev, libpq-dev, pkg-config, libvirt-dev,
                libsqlite3-dev, facter, build-essential, nodejs
 Homepage: http://www.theforeman.org/
@@ -12,7 +12,7 @@ Package: foreman
 Architecture: any
 Section: web
 Priority: extra
-Depends: rubygems1.8 | ruby1.9.1, bundler (>= 1.2), ruby-dev,
+Depends: ruby2.0, bundler (>= 1.2), ruby2.0-dev,
          zlib1g-dev, facter, build-essential,
          rake (>=0.8.4), ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug

--- a/debian/trusty/foreman/links
+++ b/debian/trusty/foreman/links
@@ -8,4 +8,4 @@ var/cache/foreman		usr/share/foreman/tmp
 var/lib/foreman/db		usr/share/foreman/db
 var/log/foreman			usr/share/foreman/log
 var/lib/foreman/public		usr/share/foreman/public
-usr/bin/ruby		usr/bin/foreman-ruby
+usr/bin/ruby2.0		usr/bin/foreman-ruby

--- a/debian/trusty/foreman/rules
+++ b/debian/trusty/foreman/rules
@@ -16,10 +16,12 @@ build/foreman::
 	/bin/cp config/settings.yaml.example config/settings.yaml
 	/bin/cp config/database.yml.example config/database.yml
 	/bin/cp config/email.yaml.example config/email.yaml
-	/usr/bin/bundle pack --all
-	/usr/bin/bundle exec rake locale:pack assets:precompile
-	/usr/bin/bundle exec rake db:migrate --trace RAILS_ENV=production
-	/usr/bin/bundle exec rake apipie:cache cache_part=resources --trace RAILS_ENV=production
+	/usr/bin/ruby2.0 /usr/bin/bundle pack --all
+	/usr/bin/ruby2.0 /usr/bin/bundle exec rake locale:pack assets:precompile
+	/usr/bin/ruby2.0 /usr/bin/bundle exec rake db:migrate --trace RAILS_ENV=production
+	/usr/bin/ruby2.0 /usr/bin/bundle exec rake apipie:cache cache_part=resources --trace RAILS_ENV=production
 	/bin/rm db/production.sqlite3
 	/bin/rm db/development.sqlite3
+	# Use rake2.0 explicitly
+	/bin/sed -ri 'sX/usr/bin/rake$$X/usr/bin/rake2.0X' extras/dbmigrate script/foreman-rake
 	/bin/mkdir -p .ssh


### PR DESCRIPTION
Seems OK with a small bit of testing, the app starts and Puppet still runs.  I had to change PassengerRuby to either /usr/bin/foreman-ruby or ruby2.0, which I'll send a PR to puppet-foreman for too.