### PR TITLE
fixes #12761 - bump epoch of ruby-net-ssh version constraint

### DIFF
--- a/plugins/smart_proxy_remote_execution_ssh/changelog
+++ b/plugins/smart_proxy_remote_execution_ssh/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-remote-execution-ssh (0.0.8-3) stable; urgency=low
+
+  * bump epoch of ruby-net-ssh version constraint
+
+ -- Michael Moll <mmoll@mmoll.at>  Thu, 10 Dec 2015 12:01:36 +0100
+
 ruby-smart-proxy-remote-execution-ssh (0.0.8-2) stable; urgency=low
 
   * corrected ruby-net-ssh version constraint

--- a/plugins/smart_proxy_remote_execution_ssh/control
+++ b/plugins/smart_proxy_remote_execution_ssh/control
@@ -10,6 +10,6 @@ XS-Ruby-Versions: all
 Package: ruby-smart-proxy-remote-execution-ssh
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.9.0~rc3), ruby-smart-proxy-dynflow (>= 0.0.4), ruby-smart-proxy-dynflow (<< 0.1.0), ruby-net-scp, ruby-net-ssh (<= 2.10.0)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.9.0~rc3), ruby-smart-proxy-dynflow (>= 0.0.4), ruby-smart-proxy-dynflow (<< 0.1.0), ruby-net-scp, ruby-net-ssh (<= 1:2.10.0)
 Description: SSH remote execution provider for Foreman smart proxy
  SSH remote execution provider for Foreman smart proxy


### PR DESCRIPTION
also for 1.10, please