### PR TITLE
Precompile assets in the production Rails environment [deb]

### DIFF
--- a/debian/jessie/foreman/rules
+++ b/debian/jessie/foreman/rules
@@ -18,9 +18,8 @@ build/foreman::
 	/bin/cp config/email.yaml.example config/email.yaml
 	/usr/bin/gem install -f thor -v '0.19.1'
 	/usr/bin/bundle package
-	/usr/bin/bundle exec rake locale:pack assets:precompile
+	/usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production
 	/usr/bin/bundle exec rake db:migrate --trace RAILS_ENV=production
 	/usr/bin/bundle exec rake apipie:cache cache_part=resources --trace RAILS_ENV=production
 	/bin/rm db/production.sqlite3
-	/bin/rm db/development.sqlite3
 	/bin/mkdir -p .ssh

--- a/debian/precise/foreman/rules
+++ b/debian/precise/foreman/rules
@@ -16,11 +16,10 @@ build/foreman::
 	/bin/cp config/database.yml.example config/database.yml
 	/bin/cp config/email.yaml.example config/email.yaml
 	/usr/bin/bundle pack --all
-	/usr/bin/bundle exec rake locale:pack assets:precompile
+	/usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production
 	/usr/bin/bundle exec rake db:migrate --trace RAILS_ENV=production
 	/usr/bin/bundle exec rake apipie:cache cache_part=resources --trace RAILS_ENV=production
 	/bin/rm db/production.sqlite3
-	/bin/rm db/development.sqlite3
 	# Use rake1.9.1 explicitly
 	/bin/sed -ri 'sX/usr/bin/rake$$X/usr/bin/rake1.9.1X' extras/dbmigrate script/foreman-rake
 	/bin/mkdir -p .ssh

--- a/debian/trusty/foreman/rules
+++ b/debian/trusty/foreman/rules
@@ -17,11 +17,10 @@ build/foreman::
 	/bin/cp config/database.yml.example config/database.yml
 	/bin/cp config/email.yaml.example config/email.yaml
 	/usr/bin/ruby2.0 /usr/bin/bundle pack --all
-	/usr/bin/ruby2.0 /usr/bin/bundle exec rake locale:pack assets:precompile
+	/usr/bin/ruby2.0 /usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production
 	/usr/bin/ruby2.0 /usr/bin/bundle exec rake db:migrate --trace RAILS_ENV=production
 	/usr/bin/ruby2.0 /usr/bin/bundle exec rake apipie:cache cache_part=resources --trace RAILS_ENV=production
 	/bin/rm db/production.sqlite3
-	/bin/rm db/development.sqlite3
 	# Use rake2.0 explicitly
 	/bin/sed -ri 'sX/usr/bin/rake$$X/usr/bin/rake2.0X' extras/dbmigrate script/foreman-rake
 	/bin/mkdir -p .ssh

--- a/debian/wheezy/foreman/rules
+++ b/debian/wheezy/foreman/rules
@@ -16,9 +16,8 @@ build/foreman::
 	/bin/cp config/database.yml.example config/database.yml
 	/bin/cp config/email.yaml.example config/email.yaml
 	/usr/bin/bundle pack
-	/usr/bin/bundle exec rake locale:pack assets:precompile
+	/usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production
 	/usr/bin/bundle exec rake db:migrate --trace RAILS_ENV=production
 	/usr/bin/bundle exec rake apipie:cache cache_part=resources --trace RAILS_ENV=production
 	/bin/rm db/production.sqlite3
-	/bin/rm db/development.sqlite3
 	/bin/mkdir -p .ssh


### PR DESCRIPTION
Ensures the correct filenames are generated with digests etc.

---

Currently you'll find JS and other assets being loaded from /javascripts/dashboard.js etc, but it should be with the digest in the filename.  Check that the dashboard page renders properly, and not like this:

![screenshot from 2015-12-22 15-45-37](https://cloud.githubusercontent.com/assets/482089/11959024/0fc6275a-a8c3-11e5-9c1f-e1d2d48e68d9.png)
