### PR TITLE
fixes #11152 - add docbook-xsl to installer build-depends (DEB)

### DIFF
--- a/debian/jessie/foreman-installer/control
+++ b/debian/jessie/foreman-installer/control
@@ -3,7 +3,7 @@ Section: ruby
 Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
-               xsltproc, git, ca-certificates, ruby-dev
+               xsltproc, docbook-xsl, git, ca-certificates, ruby-dev
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all

--- a/debian/precise/foreman-installer/control
+++ b/debian/precise/foreman-installer/control
@@ -3,7 +3,7 @@ Section: ruby
 Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
-               xsltproc, git, ca-certificates, ruby-dev
+               xsltproc, docbook-xsl, git, ca-certificates, ruby-dev
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all

--- a/debian/trusty/foreman-installer/control
+++ b/debian/trusty/foreman-installer/control
@@ -3,7 +3,7 @@ Section: ruby
 Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
-               xsltproc, git, ca-certificates, ruby-dev
+               xsltproc, docbook-xsl, git, ca-certificates, ruby-dev
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all

--- a/debian/wheezy/foreman-installer/control
+++ b/debian/wheezy/foreman-installer/control
@@ -3,7 +3,7 @@ Section: ruby
 Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
-               xsltproc, git, ca-certificates, ruby-dev
+               xsltproc, docbook-xsl, git, ca-certificates, ruby-dev
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all


### PR DESCRIPTION
xsltproc was not able to resolve the XSL for docbook locally and tried
retrieving it from the internet, leading to build errors in case of
flakey connections.

FreeBSD's packaging CI does offline builds by purpose, exposing the bug reliably. Maybe something similar should be applied to RPMs as well.