### PR TITLE
update foreman_templates to 2.0.3 (DEB)

### DIFF
--- a/plugins/ruby-foreman-templates/debian/changelog
+++ b/plugins/ruby-foreman-templates/debian/changelog
@@ -1,3 +1,10 @@
+ruby-foreman-templates (2.0.2-1) stable; urgency=low
+
+  * 2.0.2 released
+  * Rails requirement relaxed to work with Rails 4
+
+ -- Greg Sutcliffe <greg.sutcliffe@gmail.com>  Tue, 29 Dec 2015 20:17:15 +0000
+
 ruby-foreman-templates (2.0.1-1) stable; urgency=low
 
   * 2.0.1 released

--- a/plugins/ruby-foreman-templates/debian/gem.list
+++ b/plugins/ruby-foreman-templates/debian/gem.list
@@ -1,4 +1,4 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_templates-2.0.1.gem"
+GEMS="https://rubygems.org/downloads/foreman_templates-2.0.2.gem"
 GEMS="$GEMS https://rubygems.org/downloads/diffy-3.0.7.gem"
 GEMS="$GEMS https://rubygems.org/downloads/git-1.2.9.1.gem"

--- a/plugins/ruby-foreman-templates/debian/postinst
+++ b/plugins/ruby-foreman-templates/debian/postinst
@@ -12,7 +12,7 @@ fi
 . /usr/share/debconf/confmodule
 
 LOGFILE='/var/log/foreman-install.log'
-PLUGIN='puppetdb_foreman'
+PLUGIN='foreman_templates'
 
 # if this script aborts with an error dpkg can
 # hang if daemons have been started

--- a/plugins/ruby-foreman-templates/foreman_templates.rb
+++ b/plugins/ruby-foreman-templates/foreman_templates.rb
@@ -1,1 +1,1 @@
-gem 'foreman_templates', '2.0.1'
+gem 'foreman_templates', '2.0.2'


### PR DESCRIPTION
Deb changes for templates 2.0.2. Should be suitable for 1.10 / 1.9 but currently untested by me.