### PR TITLE
Update Hammer to 0.5.1 [deb]

### DIFF
--- a/dependencies/jessie/hammer_cli/changelog
+++ b/dependencies/jessie/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (0.5.1-1) stable; urgency=low
+
+  * 0.5.1 released
+
+ -- Tomas Strachota <tstrachota@redhat.com>  Tue, 15 Dec 2015 16:49:58 +0000
+
 ruby-hammer-cli (0.4.0-1) stable; urgency=low
 
   * 0.4.0 release

--- a/dependencies/jessie/hammer_cli_foreman/changelog
+++ b/dependencies/jessie/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.5.1-1) stable; urgency=low
+
+  * 0.5.1 release
+
+ -- Michael Moll <mmoll@mmoll.at>  Mon, 14 Dec 2015 19:59:23 +0100
+
 ruby-hammer-cli-foreman (0.4.0-1) stable; urgency=low
 
   * 0.4.0 release

--- a/dependencies/jessie/hammer_cli_foreman/control
+++ b/dependencies/jessie/hammer_cli_foreman/control
@@ -12,6 +12,6 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 0.4.0)
+         ruby-hammer-cli (>= 0.5.0)
 Description: Foreman commands for Hammer
  Foreman commands for Hammer CLI

--- a/dependencies/precise/hammer_cli/changelog
+++ b/dependencies/precise/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (0.5.1-1) stable; urgency=low
+
+  * 0.5.1 released
+
+ -- Tomas Strachota <tstrachota@redhat.com>  Tue, 15 Dec 2015 16:49:58 +0000
+
 ruby-hammer-cli (0.4.0-1) stable; urgency=low
 
   * 0.4.0 release

--- a/dependencies/precise/hammer_cli_foreman/changelog
+++ b/dependencies/precise/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.5.1-1) stable; urgency=low
+
+  * 0.5.1 release
+
+ -- Michael Moll <mmoll@mmoll.at>  Mon, 14 Dec 2015 19:59:23 +0100
+
 ruby-hammer-cli-foreman (0.4.0-1) stable; urgency=low
 
   * 0.4.0 release

--- a/dependencies/precise/hammer_cli_foreman/control
+++ b/dependencies/precise/hammer_cli_foreman/control
@@ -12,6 +12,6 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby1.9.1,
-         ruby-hammer-cli (>= 0.4.0)
+         ruby-hammer-cli (>= 0.5.0)
 Description: Foreman commands for Hammer
  Foreman commands for Hammer CLI

--- a/dependencies/trusty/hammer_cli/changelog
+++ b/dependencies/trusty/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (0.5.1-1) stable; urgency=low
+
+  * 0.5.1 released
+
+ -- Tomas Strachota <tstrachota@redhat.com>  Tue, 15 Dec 2015 16:49:58 +0000
+
 ruby-hammer-cli (0.4.0-1) stable; urgency=low
 
   * 0.4.0 release

--- a/dependencies/trusty/hammer_cli_foreman/changelog
+++ b/dependencies/trusty/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.5.1-1) stable; urgency=low
+
+  * 0.5.1 release
+
+ -- Michael Moll <mmoll@mmoll.at>  Mon, 14 Dec 2015 19:59:23 +0100
+
 ruby-hammer-cli-foreman (0.4.0-1) stable; urgency=low
 
   * 0.4.0 release

--- a/dependencies/trusty/hammer_cli_foreman/control
+++ b/dependencies/trusty/hammer_cli_foreman/control
@@ -12,6 +12,6 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 0.4.0)
+         ruby-hammer-cli (>= 0.5.0)
 Description: Foreman commands for Hammer
  Foreman commands for Hammer CLI

--- a/dependencies/wheezy/hammer_cli/changelog
+++ b/dependencies/wheezy/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (0.5.1-1) stable; urgency=low
+
+  * 0.5.1 released
+
+ -- Tomas Strachota <tstrachota@redhat.com>  Tue, 15 Dec 2015 16:49:58 +0000
+
 ruby-hammer-cli (0.4.0-1) stable; urgency=low
 
   * 0.4.0 release

--- a/dependencies/wheezy/hammer_cli_foreman/changelog
+++ b/dependencies/wheezy/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.5.1-1) stable; urgency=low
+
+  * 0.5.1 release
+
+ -- Michael Moll <mmoll@mmoll.at>  Mon, 14 Dec 2015 19:59:23 +0100
+
 ruby-hammer-cli-foreman (0.4.0-1) stable; urgency=low
 
   * 0.4.0 release

--- a/dependencies/wheezy/hammer_cli_foreman/control
+++ b/dependencies/wheezy/hammer_cli_foreman/control
@@ -12,6 +12,6 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 0.4.0)
+         ruby-hammer-cli (>= 0.5.0)
 Description: Foreman commands for Hammer
  Foreman commands for Hammer CLI


### PR DESCRIPTION
Requested by @tstrachota for Foreman 1.10.1 (due this week), RPMs are tagged already.