### PR TITLE
Release foreman_remote_execution 0.2.2 - DEB - 1.10

### DIFF
--- a/plugins/ruby-foreman-remote-execution/debian/changelog
+++ b/plugins/ruby-foreman-remote-execution/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution (0.2.2-1) stable; urgency=low
+
+  * 0.2.2 released
+
+ -- Stephen Benjamin <stbenjam@redhat.com>  Mon, 25 Jan 2016 11:21:55 +0100
+
 ruby-foreman-remote-execution (0.2.1-1) stable; urgency=low
 
   * 0.2.1 released

--- a/plugins/ruby-foreman-remote-execution/debian/control
+++ b/plugins/ruby-foreman-remote-execution/debian/control
@@ -8,6 +8,6 @@ Homepage: https://github.com/theforeman/foreman_remote_execution
 
 Package: ruby-foreman-remote-execution
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.10.0~rc2), foreman (<< 1.11), ruby-foreman-tasks (>= 0.7.11), ruby-foreman-tasks (<< 0.8.0), ruby-foreman-deface
+Depends: ${misc:Depends}, bundler, foreman (>= 1.10.0~rc2), ruby-foreman-tasks (>= 0.7.11), ruby-foreman-tasks (<< 0.8.0), ruby-foreman-deface
 Description: Foreman Remote Execution Plugin
   A plugin bringing remote execution to the Foreman, completing the config management functionality with remote management functionality

--- a/plugins/ruby-foreman-remote-execution/debian/gem.list
+++ b/plugins/ruby-foreman-remote-execution/debian/gem.list
@@ -1,2 +1,2 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_remote_execution-0.2.1.gem"
+GEMS="https://rubygems.org/downloads/foreman_remote_execution-0.2.2.gem"

--- a/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
+++ b/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
@@ -1,1 +1,1 @@
-gem 'foreman_remote_execution', '0.2.1'
+gem 'foreman_remote_execution', '0.2.2'


### PR DESCRIPTION
We needed a new release to fix a small problem (https://github.com/theforeman/foreman_remote_execution/pull/133), sorry.  Also fixed the 1.10 dependency.
