### PR TITLE
Fixes #13502 - add docker-selinux to build requires

### DIFF
--- a/foreman-selinux/foreman-selinux.spec
+++ b/foreman-selinux/foreman-selinux.spec
@@ -48,6 +48,7 @@ Source0:        http://downloads.theforeman.org/%{name}/%{name}-%{version}%{?das
 BuildRequires:  checkpolicy, selinux-policy-devel, hardlink
 BuildRequires:  policycoreutils >= %{selinux_policycoreutils_ver}
 BuildRequires:  /usr/bin/pod2man
+BuildRequires:  docker-selinux
 BuildArch:      noarch
 
 Requires:           selinux-policy >= %{selinux_policy_ver}


### PR DESCRIPTION
We don't use RHEL 7.2 on our builders yet, but downstream this was failing
because we use one interface and type from that file. This fixes it.

In RHEL/CentOS7 this is in extras repo.