### PR TITLE
drop foreman-cli dependency onto foreman (RPM)

### DIFF
--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -230,7 +230,6 @@ BuildRequires: facter
 %package cli
 Summary: Foreman CLI
 Group: Applications/System
-Requires: %{name} = %{version}-%{release}
 Requires: %{?scl_prefix}rubygem(hammer_cli_foreman)
 
 %description cli


### PR DESCRIPTION
references theforeman/puppet-foreman#327, Debian packages never had that dependency