### PR TITLE
Release foreman_remote_execution 0.2.3 (DEB)

### DIFF
--- a/plugins/ruby-foreman-remote-execution/debian/changelog
+++ b/plugins/ruby-foreman-remote-execution/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution (0.2.3-1) stable; urgency=low
+
+  * 0.2.3 released
+
+ -- Stephen Benjamin <stbenjam@redhat.com>  Thu, 11 Feb 2016 11:45:17 -0500
+
 ruby-foreman-remote-execution (0.2.2-1) stable; urgency=low
 
   * 0.2.2 released

--- a/plugins/ruby-foreman-remote-execution/debian/gem.list
+++ b/plugins/ruby-foreman-remote-execution/debian/gem.list
@@ -1,2 +1,2 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_remote_execution-0.2.2.gem"
+GEMS="https://rubygems.org/downloads/foreman_remote_execution-0.2.3.gem"

--- a/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
+++ b/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
@@ -1,1 +1,1 @@
-gem 'foreman_remote_execution', '0.2.2'
+gem 'foreman_remote_execution', '0.2.3'


### PR DESCRIPTION
This contains the view fix for rails update. For 1.10 and nightly.