### PR TITLE
Add GitHub PR template to indicate branches for plugin updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+For plugin updates, please indicate which repos this should be built into:
+
+* [x] Nightly
+* [ ] 1.11
+* [ ] 1.10
+* [ ] 1.9
+
+See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
+
+---


### PR DESCRIPTION
I tested on a repo and the user's own commit message gets appended to the template, after the horizontal rule.