### PR TITLE
update foreman_xen to 0.3.0 (DEB)

### DIFF
--- a/plugins/ruby-foreman-xen/debian/changelog
+++ b/plugins/ruby-foreman-xen/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-xen (0.3.0-1) stable; urgency=low
+
+  * 0.3.0 released
+
+ -- Michael Moll <mmoll@mmoll.at>  Fri, 26 Feb 2016 22:29:05 +0100
+
 ruby-foreman-xen (0.2.4-1) stable; urgency=low
 
   * 0.2.4 released

--- a/plugins/ruby-foreman-xen/debian/control
+++ b/plugins/ruby-foreman-xen/debian/control
@@ -8,6 +8,6 @@ Homepage: https://github.com/theforeman/foreman-xen
 
 Package: ruby-foreman-xen
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman-compute (>= 1.10.0~rc1)
+Depends: ${misc:Depends}, bundler, foreman (>= 1.11.0~rc1)
 Description: Foreman XenServer compute resource
  XenServer compute resource plugin for Foreman

--- a/plugins/ruby-foreman-xen/debian/gem.list
+++ b/plugins/ruby-foreman-xen/debian/gem.list
@@ -1,2 +1,2 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_xen-0.2.4.gem"
+GEMS="https://rubygems.org/downloads/foreman_xen-0.3.0.gem"

--- a/plugins/ruby-foreman-xen/foreman_xen.rb
+++ b/plugins/ruby-foreman-xen/foreman_xen.rb
@@ -1,1 +1,1 @@
-gem 'foreman_xen', '0.2.4'
+gem 'foreman_xen', '0.3.0'


### PR DESCRIPTION
Also for 1.11, please. As the fog gem itself still depends on fog-xenserver, no action is needed here (yet).