### PR TITLE
Add missing polyglot dependency on 1.11+

### DIFF
--- a/plugins/ruby-foreman-deface/debian/changelog
+++ b/plugins/ruby-foreman-deface/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-deface (1.0.2-2) stable; urgency=low
+
+  * Add missing polyglot dependency on 1.11+
+
+ -- Dominic Cleal <dominic@cleal.org>  Mon, 29 Feb 2016 12:39:30 +0000
+
 ruby-foreman-deface (1.0.2-1) stable; urgency=low
 
   * 1.0.2 released

--- a/plugins/ruby-foreman-deface/debian/gem.list
+++ b/plugins/ruby-foreman-deface/debian/gem.list
@@ -1,3 +1,4 @@
 # list of gem urls to download via Jenkins, space separated
 GEMS="https://rubygems.org/downloads/deface-1.0.2.gem"
 GEMS="$GEMS https://rubygems.org/downloads/colorize-0.7.7.gem"
+GEMS="$GEMS https://rubygems.org/downloads/polyglot-0.3.5.gem"


### PR DESCRIPTION
On Foreman 1.10 via Rails 3, mail 2.5.x and its treetop dependency,
polyglot was included in the main Foreman gem cache.  On 1.11 with
mail 2.6.x, the treetop dependency was removed and so it has to be
added to the deface package.

Should be cherry picked to deb/1.11 too please.