### PR TITLE
refs #12295 - uses USR1 signal to handle log rotation (debian version)

### DIFF
--- a/debian/jessie/foreman-proxy/foreman-proxy.init
+++ b/debian/jessie/foreman-proxy/foreman-proxy.init
@@ -106,6 +106,11 @@ do_reload() {
 	return 0
 }
 
+do_logrotate() {
+	start-stop-daemon --stop --signal USR1 --quiet --pidfile $PIDFILE
+	return $?
+}
+
 case "$1" in
   start)
     [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC " "$NAME"
@@ -135,6 +140,11 @@ case "$1" in
 	#do_reload
 	#log_end_msg $?
 	#;;
+  logrotate)
+	log_daemon_msg "Rotating logs $DESC" "$NAME"
+	do_logrotate
+	log_end_msg $?
+	;;        
   restart|force-reload)
 	#
 	# If the "reload" option is implemented then remove the
@@ -158,8 +168,7 @@ case "$1" in
 	esac
 	;;
   *)
-	#echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
-	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload|logrotate}" >&2
 	exit 3
 	;;
 esac

--- a/debian/jessie/foreman-proxy/logrotate
+++ b/debian/jessie/foreman-proxy/logrotate
@@ -7,6 +7,6 @@
   compress
 	daily
   postrotate
-    [ -e /etc/init.d/foreman-proxy ] && /etc/init.d/foreman-proxy restart >/dev/null 2>&1 || true
+    [ -e /etc/init.d/foreman-proxy ] && /etc/init.d/foreman-proxy logrotate >/dev/null 2>&1 || true
   endscript
 }

--- a/debian/precise/foreman-proxy/init.d
+++ b/debian/precise/foreman-proxy/init.d
@@ -106,6 +106,11 @@ do_reload() {
 	return 0
 }
 
+do_logrotate() {
+	start-stop-daemon --stop --signal USR1 --quiet --pidfile $PIDFILE
+	return $?
+}
+
 case "$1" in
   start)
     [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC " "$NAME"
@@ -135,6 +140,11 @@ case "$1" in
 	#do_reload
 	#log_end_msg $?
 	#;;
+  logrotate)
+	log_daemon_msg "Rotating logs $DESC" "$NAME"
+	do_logrotate
+	log_end_msg $?
+	;;        
   restart|force-reload)
 	#
 	# If the "reload" option is implemented then remove the
@@ -158,8 +168,7 @@ case "$1" in
 	esac
 	;;
   *)
-	#echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
-	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload|logrotate}" >&2
 	exit 3
 	;;
 esac

--- a/debian/precise/foreman-proxy/logrotate
+++ b/debian/precise/foreman-proxy/logrotate
@@ -7,6 +7,6 @@
   compress
 	daily
   postrotate
-    [ -e /etc/init.d/foreman-proxy ] && /etc/init.d/foreman-proxy restart >/dev/null 2>&1 || true
+    [ -e /etc/init.d/foreman-proxy ] && /etc/init.d/foreman-proxy logrotate >/dev/null 2>&1 || true
   endscript
 }

--- a/debian/trusty/foreman-proxy/init.d
+++ b/debian/trusty/foreman-proxy/init.d
@@ -106,6 +106,11 @@ do_reload() {
 	return 0
 }
 
+do_logrotate() {
+	start-stop-daemon --stop --signal USR1 --quiet --pidfile $PIDFILE
+	return $?
+}
+
 case "$1" in
   start)
     [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC " "$NAME"
@@ -135,6 +140,11 @@ case "$1" in
 	#do_reload
 	#log_end_msg $?
 	#;;
+  logrotate)
+	log_daemon_msg "Rotating logs $DESC" "$NAME"
+	do_logrotate
+	log_end_msg $?
+	;;        
   restart|force-reload)
 	#
 	# If the "reload" option is implemented then remove the
@@ -158,8 +168,7 @@ case "$1" in
 	esac
 	;;
   *)
-	#echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
-	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload|logrotate}" >&2
 	exit 3
 	;;
 esac

--- a/debian/trusty/foreman-proxy/logrotate
+++ b/debian/trusty/foreman-proxy/logrotate
@@ -7,6 +7,6 @@
   compress
 	daily
   postrotate
-    [ -e /etc/init.d/foreman-proxy ] && /etc/init.d/foreman-proxy restart >/dev/null 2>&1 || true
+    [ -e /etc/init.d/foreman-proxy ] && /etc/init.d/foreman-proxy logrotate >/dev/null 2>&1 || true
   endscript
 }

--- a/debian/wheezy/foreman-proxy/init.d
+++ b/debian/wheezy/foreman-proxy/init.d
@@ -106,6 +106,11 @@ do_reload() {
 	return 0
 }
 
+do_logrotate() {
+	start-stop-daemon --stop --signal USR1 --quiet --pidfile $PIDFILE
+	return $?
+}
+
 case "$1" in
   start)
     [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC " "$NAME"
@@ -135,6 +140,11 @@ case "$1" in
 	#do_reload
 	#log_end_msg $?
 	#;;
+  logrotate)
+	log_daemon_msg "Rotating logs $DESC" "$NAME"
+	do_logrotate
+	log_end_msg $?
+	;;        
   restart|force-reload)
 	#
 	# If the "reload" option is implemented then remove the
@@ -158,8 +168,7 @@ case "$1" in
 	esac
 	;;
   *)
-	#echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
-	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload|logrotate}" >&2
 	exit 3
 	;;
 esac

--- a/debian/wheezy/foreman-proxy/logrotate
+++ b/debian/wheezy/foreman-proxy/logrotate
@@ -7,6 +7,6 @@
   compress
 	daily
   postrotate
-    [ -e /etc/init.d/foreman-proxy ] && /etc/init.d/foreman-proxy restart >/dev/null 2>&1 || true
+    [ -e /etc/init.d/foreman-proxy ] && /etc/init.d/foreman-proxy logrotate >/dev/null 2>&1 || true
   endscript
 }


### PR DESCRIPTION
Pls. see theforeman/smart-proxy#394 for the corresponding changes in smart-proxy