### PR TITLE
fixes #12912 - switch to CentOS SCLo SIG builds [rpm]

### DIFF
--- a/extras/extras-foreman-rhel6-x86_64
+++ b/extras/extras-foreman-rhel6-x86_64
@@ -1,3 +1,2 @@
-https://www.softwarecollections.org/repos/rhscl/rh-ror41/epel-6-x86_64/noarch/rhscl-rh-ror41-epel-6-x86_64-1-2.noarch.rpm
-https://www.softwarecollections.org/repos/rhscl/rh-ruby22/epel-6-x86_64/noarch/rhscl-rh-ruby22-epel-6-x86_64-1-2.noarch.rpm
-https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-6-x86_64/download/rhscl-v8314-epel-6-x86_64-1-2.noarch.rpm
+http://mirror.centos.org/centos/6/extras/x86_64/Packages/centos-release-scl-6-6.el6.centos.noarch.rpm
+http://mirror.centos.org/centos/6/extras/x86_64/Packages/centos-release-scl-rh-1-1.el6.centos.noarch.rpm

--- a/extras/extras-foreman-rhel7-x86_64
+++ b/extras/extras-foreman-rhel7-x86_64
@@ -1,3 +1,2 @@
-https://www.softwarecollections.org/repos/rhscl/rh-ror41/epel-7-x86_64/noarch/rhscl-rh-ror41-epel-7-x86_64-1-2.noarch.rpm
-https://www.softwarecollections.org/repos/rhscl/rh-ruby22/epel-7-x86_64/noarch/rhscl-rh-ruby22-epel-7-x86_64-1-2.noarch.rpm
-https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-7-x86_64/download/rhscl-v8314-epel-7-x86_64-1-2.noarch.rpm
+http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-1-1.el7.centos.noarch.rpm
+http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-rh-1-1.el7.centos.noarch.rpm

--- a/foreman-release-scl/foreman-release-scl.spec
+++ b/foreman-release-scl/foreman-release-scl.spec
@@ -7,9 +7,9 @@ Group:    Applications/System
 License:  GPLv3+
 URL:      http://theforeman.org
 
-Requires: rhscl-rh-ruby22-epel-%{rhel}-%{_arch}
-Requires: rhscl-rh-ror41-epel-%{rhel}-%{_arch}
-Requires: rhscl-v8314-epel-%{rhel}-%{_arch}
+BuildArch: noarch
+
+Requires: centos-release-scl
 
 %description
 Software Collection repositories provide additional sets of software packages,

--- a/mock/el6-scl.cfg
+++ b/mock/el6-scl.cfg
@@ -43,17 +43,13 @@ enabled=0
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel6&arch=x86_64
 failovermethod=priority
 
-[scl-ror]
-name=scl-ror
-baseurl=https://www.softwarecollections.org/repos/rhscl/rh-ror41/epel-6-x86_64/
+[sclo-rh]
+name=sclo-rh
+baseurl=http://mirror.centos.org/centos/6/sclo/x86_64/rh/
 
-[scl-ruby]
-name=scl-ruby
-baseurl=https://www.softwarecollections.org/repos/rhscl/rh-ruby22/epel-6-x86_64/
-
-[scl-v8]
-name=scl-v8
-baseurl=https://www.softwarecollections.org/repos/rhscl/v8314/epel-6-x86_64/
+[sclo-sclo]
+name=sclo-sclo
+baseurl=http://mirror.centos.org/centos/6/sclo/x86_64/sclo/
 
 [foreman]
 name=foreman

--- a/mock/el7-scl.cfg
+++ b/mock/el7-scl.cfg
@@ -43,17 +43,13 @@ enabled=0
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel7&arch=x86_64
 failovermethod=priority
 
-[scl-ror]
-name=scl-ror
-baseurl=https://www.softwarecollections.org/repos/rhscl/rh-ror41/epel-7-x86_64/
+[sclo-rh]
+name=sclo-rh
+baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/rh/
 
-[scl-ruby]
-name=scl-ruby
-baseurl=https://www.softwarecollections.org/repos/rhscl/rh-ruby22/epel-7-x86_64/
-
-[scl-v8]
-name=scl-v8
-baseurl=https://www.softwarecollections.org/repos/rhscl/v8314/epel-7-x86_64/
+[sclo-sclo]
+name=sclo-sclo
+baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/sclo/
 
 [foreman]
 name=foreman

--- a/repoclosure/yum_el6.conf
+++ b/repoclosure/yum_el6.conf
@@ -36,6 +36,10 @@ failovermethod=priority
 name=el6-scl
 baseurl=http://mirror.centos.org/centos/6/sclo/x86_64/rh/
 
+[el6-scl-sclo]
+name=el6-scl-sclo
+baseurl=http://mirror.centos.org/centos/6/sclo/x86_64/sclo/
+
 [el6-pl-prod]
 name=el6-pl-prod
 baseurl=http://yum.puppetlabs.com/el/6/products/$basearch/

--- a/repoclosure/yum_el7.conf
+++ b/repoclosure/yum_el7.conf
@@ -36,6 +36,10 @@ failovermethod=priority
 name=el7-scl
 baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/rh/
 
+[el7-scl-sclo]
+name=el7-scl-sclo
+baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/sclo/
+
 [el7-pl-prod]
 name=el7-pl-prod
 baseurl=http://yum.puppetlabs.com/el/7/products/$basearch/


### PR DESCRIPTION
Swaps dependencies for softwarecollections.org with the CentOS SCLo SIG
release packages, which are copied into our repo by the mash script when
listed in extras/ so non-CentOS users and those without CentOS Extras
enabled can install it.

The packages are better maintained and will allow us to depend on sclo-*
packages in future.  Maintenance of softwarecollections.org builds seems
to have stopped in favour of the SCLo SIG.

---

Koji's already switched over to using these rebuilds when I was doing the ror41 rebuild as it was easier to mirror the one repo.