### PR TITLE
Organizations and locations should be enabled for apipie docs

### DIFF
--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -508,6 +508,9 @@ make -C locale all-mo
 mv Gemfile Gemfile.in
 cp config/database.yml.example config/database.yml
 cp config/settings.yaml.example config/settings.yaml
+#we need to allow taxonomies so apipie cache renders documentation with them
+sed -i 's/:locations_enabled: false/:locations_enabled: true/' config/settings.yaml
+sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' config/settings.yaml
 export BUNDLER_EXT_NOSTRICT=1
 export BUNDLER_EXT_GROUPS="default assets"
 %{scl_rake} assets:precompile RAILS_ENV=production --trace


### PR DESCRIPTION
I know we have taxonomies disabled by default but it might be better to generate apipie docs including taxonomies in API (note that hammer works regardless, since we generate index during installer run)