### PR TITLE
Add kafo to installer build deps to generate man page [deb]

### DIFF
--- a/debian/jessie/foreman-installer/control
+++ b/debian/jessie/foreman-installer/control
@@ -3,7 +3,8 @@ Section: ruby
 Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
-               xsltproc, docbook-xsl, git, ca-certificates, ruby-dev
+               xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
+               puppet (>= 3.0.0), ruby-kafo (>= 0.7.1)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all

--- a/debian/precise/foreman-installer/control
+++ b/debian/precise/foreman-installer/control
@@ -3,7 +3,8 @@ Section: ruby
 Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
-               xsltproc, docbook-xsl, git, ca-certificates, ruby-dev
+               xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
+               puppet (>= 3.0.0), ruby-kafo (>= 0.7.1)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all

--- a/debian/trusty/foreman-installer/control
+++ b/debian/trusty/foreman-installer/control
@@ -3,7 +3,8 @@ Section: ruby
 Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
-               xsltproc, docbook-xsl, git, ca-certificates, ruby-dev
+               xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
+               puppet (>= 3.0.0), ruby-kafo (>= 0.7.1)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all

--- a/debian/wheezy/foreman-installer/control
+++ b/debian/wheezy/foreman-installer/control
@@ -3,7 +3,8 @@ Section: ruby
 Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
-               xsltproc, docbook-xsl, git, ca-certificates, ruby-dev
+               xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
+               puppet (>= 3.0.0), ruby-kafo (>= 0.7.1)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all


### PR DESCRIPTION
With kafo-export-params available, the installer rake build will
generate an extended man page containing a list of parameters.