### PR TITLE
Add `EnvironmentFile` to the service unit file of foreman-proxy.

### DIFF
--- a/foreman-proxy/foreman-proxy.service
+++ b/foreman-proxy/foreman-proxy.service
@@ -8,6 +8,7 @@ Type=forking
 User=foreman-proxy
 ExecStart=/usr/share/foreman-proxy/bin/smart-proxy
 PIDFile=/run/foreman-proxy/foreman-proxy.pid
+EnvironmentFile=-/etc/sysconfig/foreman-proxy
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The old init script used to source /etc/sysconfig/foreman-proxy for
environment variables and this behavior wasn't carried over to the
systemd unit file.

This makes it possible to set custom environment variables via
`/etc/sysconfig/foreman-proxy` again.