### PR TITLE
refs #14941 - load Kafo lib from relative path [deb]

### DIFF
--- a/dependencies/jessie/kafo/changelog
+++ b/dependencies/jessie/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (0.8.1-2) stable; urgency=low
+
+  * Fix Puppet module patch to load Kafo from relative path
+
+ -- Dominic Cleal <dominic@cleal.org>  Fri, 06 May 2016 15:42:09 +0100
+
 ruby-kafo (0.8.1-1) stable; urgency=low
 
   * Update kafo to 0.8.1

--- a/dependencies/jessie/kafo/patches/fix_require_in_puppet_module.diff
+++ b/dependencies/jessie/kafo/patches/fix_require_in_puppet_module.diff
@@ -2,7 +2,7 @@
 +++ b/modules/kafo_configure/lib/puppet/parser/functions/decrypt.rb
 @@ -1,4 +1,4 @@
 -require File.join(File.dirname(__FILE__), '../../../../../../lib/kafo/password_manager')
-+require File.join('kafo/password_manager')
++require File.join(File.dirname(__FILE__), '../../../../../../password_manager')
  # Decrypts an encrypted password using $kafo_configure::password
  #
  # you can use this function in order to place passwords into your config files

--- a/dependencies/precise/kafo/changelog
+++ b/dependencies/precise/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (0.8.1-2) stable; urgency=low
+
+  * Fix Puppet module patch to load Kafo from relative path
+
+ -- Dominic Cleal <dominic@cleal.org>  Fri, 06 May 2016 15:42:09 +0100
+
 ruby-kafo (0.8.1-1) stable; urgency=low
 
   * Update kafo to 0.8.1

--- a/dependencies/precise/kafo/patches/fix_require_in_puppet_module.diff
+++ b/dependencies/precise/kafo/patches/fix_require_in_puppet_module.diff
@@ -2,7 +2,7 @@
 +++ b/modules/kafo_configure/lib/puppet/parser/functions/decrypt.rb
 @@ -1,4 +1,4 @@
 -require File.join(File.dirname(__FILE__), '../../../../../../lib/kafo/password_manager')
-+require File.join('kafo/password_manager')
++require File.join(File.dirname(__FILE__), '../../../../../../password_manager')
  # Decrypts an encrypted password using $kafo_configure::password
  #
  # you can use this function in order to place passwords into your config files

--- a/dependencies/trusty/kafo/changelog
+++ b/dependencies/trusty/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (0.8.1-2) stable; urgency=low
+
+  * Fix Puppet module patch to load Kafo from relative path
+
+ -- Dominic Cleal <dominic@cleal.org>  Fri, 06 May 2016 15:42:09 +0100
+
 ruby-kafo (0.8.1-1) stable; urgency=low
 
   * Update kafo to 0.8.1

--- a/dependencies/trusty/kafo/patches/fix_require_in_puppet_module.diff
+++ b/dependencies/trusty/kafo/patches/fix_require_in_puppet_module.diff
@@ -2,7 +2,7 @@
 +++ b/modules/kafo_configure/lib/puppet/parser/functions/decrypt.rb
 @@ -1,4 +1,4 @@
 -require File.join(File.dirname(__FILE__), '../../../../../../lib/kafo/password_manager')
-+require File.join('kafo/password_manager')
++require File.join(File.dirname(__FILE__), '../../../../../../password_manager')
  # Decrypts an encrypted password using $kafo_configure::password
  #
  # you can use this function in order to place passwords into your config files

--- a/dependencies/wheezy/kafo/changelog
+++ b/dependencies/wheezy/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (0.8.1-2) stable; urgency=low
+
+  * Fix Puppet module patch to load Kafo from relative path
+
+ -- Dominic Cleal <dominic@cleal.org>  Fri, 06 May 2016 15:42:09 +0100
+
 ruby-kafo (0.8.1-1) stable; urgency=low
 
   * Update kafo to 0.8.1

--- a/dependencies/wheezy/kafo/patches/fix_require_in_puppet_module.diff
+++ b/dependencies/wheezy/kafo/patches/fix_require_in_puppet_module.diff
@@ -2,7 +2,7 @@
 +++ b/modules/kafo_configure/lib/puppet/parser/functions/decrypt.rb
 @@ -1,4 +1,4 @@
 -require File.join(File.dirname(__FILE__), '../../../../../../lib/kafo/password_manager')
-+require File.join('kafo/password_manager')
++require File.join(File.dirname(__FILE__), '../../../../../../password_manager')
  # Decrypts an encrypted password using $kafo_configure::password
  #
  # you can use this function in order to place passwords into your config files

--- a/dependencies/xenial/kafo/changelog
+++ b/dependencies/xenial/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (0.8.1-2) stable; urgency=low
+
+  * Fix Puppet module patch to load Kafo from relative path
+
+ -- Dominic Cleal <dominic@cleal.org>  Fri, 06 May 2016 15:42:09 +0100
+
 ruby-kafo (0.8.1-1) stable; urgency=low
 
   * Update kafo to 0.8.1

--- a/dependencies/xenial/kafo/patches/fix_require_in_puppet_module.diff
+++ b/dependencies/xenial/kafo/patches/fix_require_in_puppet_module.diff
@@ -2,7 +2,7 @@
 +++ b/modules/kafo_configure/lib/puppet/parser/functions/decrypt.rb
 @@ -1,4 +1,4 @@
 -require File.join(File.dirname(__FILE__), '../../../../../../lib/kafo/password_manager')
-+require File.join('kafo/password_manager')
++require File.join(File.dirname(__FILE__), '../../../../../../password_manager')
  # Decrypts an encrypted password using $kafo_configure::password
  #
  # you can use this function in order to place passwords into your config files


### PR DESCRIPTION
Updates the patch to remove the assumption that Puppet and Kafo are in
the same Ruby environment.