### PR TITLE
refs #14453 - require kafo 0.8.0 for parser cache [deb]

### DIFF
--- a/debian/jessie/foreman-installer/control
+++ b/debian/jessie/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet (>= 3.0.0), ruby-kafo (>= 0.7.1)
+               puppet (>= 3.0.0), ruby-kafo (>= 0.8.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all
@@ -13,7 +13,7 @@ Package: foreman-installer
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-kafo (>= 0.7.1),
+         ruby-kafo (>= 0.8.0),
          ruby-apipie-bindings (>= 0.0.6),
          puppet (>= 3.0.0),
          curl,

--- a/debian/precise/foreman-installer/control
+++ b/debian/precise/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet (>= 3.0.0), ruby-kafo (>= 0.7.1)
+               puppet (>= 3.0.0), ruby-kafo (>= 0.8.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all
@@ -13,7 +13,7 @@ Package: foreman-installer
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-kafo (>= 0.7.1),
+         ruby-kafo (>= 0.8.0),
          ruby-apipie-bindings (>= 0.0.6),
          puppet (>= 3.0.0),
          rubygems,

--- a/debian/trusty/foreman-installer/control
+++ b/debian/trusty/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet (>= 3.0.0), ruby-kafo (>= 0.7.1)
+               puppet (>= 3.0.0), ruby-kafo (>= 0.8.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all
@@ -13,7 +13,7 @@ Package: foreman-installer
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-kafo (>= 0.7.1),
+         ruby-kafo (>= 0.8.0),
          ruby-apipie-bindings (>= 0.0.6),
          puppet (>= 3.0.0),
          curl,

--- a/debian/wheezy/foreman-installer/control
+++ b/debian/wheezy/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet (>= 3.0.0), ruby-kafo (>= 0.7.1)
+               puppet (>= 3.0.0), ruby-kafo (>= 0.8.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all
@@ -13,7 +13,7 @@ Package: foreman-installer
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-kafo (>= 0.7.1),
+         ruby-kafo (>= 0.8.0),
          ruby-apipie-bindings (>= 0.0.6),
          puppet (>= 3.0.0),
          curl,

--- a/debian/xenial/foreman-installer/control
+++ b/debian/xenial/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet (>= 3.0.0), ruby-kafo (>= 0.7.1)
+               puppet (>= 3.0.0), ruby-kafo (>= 0.8.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all
@@ -13,7 +13,7 @@ Package: foreman-installer
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-kafo (>= 0.7.1),
+         ruby-kafo (>= 0.8.0),
          ruby-apipie-bindings (>= 0.0.6),
          puppet (>= 3.0.0),
          curl,


### PR DESCRIPTION
Dependent on https://github.com/theforeman/foreman-installer/pull/172. This means puppet-strings isn't required at runtime when using AIO, and it's faster than parsing on the fly.