### PR TITLE
fixes #14454 - permit and prefer puppet-agent (AIO) [deb]

### DIFF
--- a/debian/jessie/foreman-installer/control
+++ b/debian/jessie/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet (>= 3.0.0), ruby-kafo (>= 0.8.0)
+               puppet-agent | puppet (>= 3.0.0), ruby-kafo (>= 0.8.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all
@@ -14,8 +14,7 @@ Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-kafo (>= 0.8.0),
-         ruby-apipie-bindings (>= 0.0.6),
-         puppet (>= 3.0.0),
+         puppet-agent | puppet (>= 3.0.0),
          curl,
          lsb-release
 Description: Automated puppet-based installer for The Foreman

--- a/debian/precise/foreman-installer/control
+++ b/debian/precise/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet (>= 3.0.0), ruby-kafo (>= 0.8.0)
+               puppet-agent | puppet (>= 3.0.0), ruby-kafo (>= 0.8.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all
@@ -14,8 +14,7 @@ Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-kafo (>= 0.8.0),
-         ruby-apipie-bindings (>= 0.0.6),
-         puppet (>= 3.0.0),
+         puppet-agent | puppet (>= 3.0.0),
          rubygems,
          curl,
          lsb-release

--- a/debian/trusty/foreman-installer/control
+++ b/debian/trusty/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet (>= 3.0.0), ruby-kafo (>= 0.8.0)
+               puppet-agent | puppet (>= 3.0.0), ruby-kafo (>= 0.8.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all
@@ -14,8 +14,7 @@ Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-kafo (>= 0.8.0),
-         ruby-apipie-bindings (>= 0.0.6),
-         puppet (>= 3.0.0),
+         puppet-agent | puppet (>= 3.0.0),
          curl,
          lsb-release
 Description: Automated puppet-based installer for The Foreman

--- a/debian/wheezy/foreman-installer/control
+++ b/debian/wheezy/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet (>= 3.0.0), ruby-kafo (>= 0.8.0)
+               puppet-agent | puppet (>= 3.0.0), ruby-kafo (>= 0.8.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all
@@ -14,8 +14,7 @@ Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-kafo (>= 0.8.0),
-         ruby-apipie-bindings (>= 0.0.6),
-         puppet (>= 3.0.0),
+         puppet-agent | puppet (>= 3.0.0),
          curl,
          lsb-release
 Description: Automated puppet-based installer for The Foreman

--- a/debian/xenial/foreman-installer/control
+++ b/debian/xenial/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet (>= 3.0.0), ruby-kafo (>= 0.8.0)
+               puppet-agent | puppet (>= 3.0.0), ruby-kafo (>= 0.8.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all
@@ -14,8 +14,7 @@ Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-kafo (>= 0.8.0),
-         ruby-apipie-bindings (>= 0.0.6),
-         puppet (>= 3.0.0),
+         puppet-agent | puppet (>= 3.0.0),
          curl,
          lsb-release
 Description: Automated puppet-based installer for The Foreman


### PR DESCRIPTION
1. Allows and prefers puppet-agent for installation.
1. apipie-bindings is no longer a dependency as the appropriate package is installed at runtime (this was here for some older 2.7 support as it couldn't load on the fly, but is now unsupported).

Depends on:

1. ~~#1128~~
1. ~~#1127~~
1. ~~Kafo release with https://github.com/theforeman/kafo/pull/150~~