### PR TITLE
Use zpassenger.load for passenger

### DIFF
--- a/rubygem-passenger/apache-passenger.conf.in
+++ b/rubygem-passenger/apache-passenger.conf.in
@@ -1,4 +1,3 @@
-LoadModule passenger_module modules/mod_passenger.so
 <IfModule mod_passenger.c>
    PassengerRoot @PASSENGERROOT@
    PassengerRuby @BINDIR@/ruby

--- a/rubygem-passenger/rubygem-passenger.spec
+++ b/rubygem-passenger/rubygem-passenger.spec
@@ -46,6 +46,7 @@ Source1: passenger.logrotate
 Source2: rubygem-passenger.tmpfiles
 Source10: apache-passenger.conf.in
 Source11: locations.ini
+Source12: zpassenger.load.in
 
 # Include sys/types.h for GCC 4.7
 Patch2:         rubygem-passenger-4.0.18-gcc47-include-sys_types.patch
@@ -315,15 +316,9 @@ install -pm 0755 buildout/apache2/mod_passenger.so %{buildroot}/%{_httpd_moddir}
 %{__sed} -e 's|@PASSENGERROOT@|%{gem_instdir}/lib/phusion_passenger/locations.ini|g' %{SOURCE10} > passenger.conf
 %{__sed} -i 's|@BINDIR@|%{_bindir}|' passenger.conf
 
-%if "%{_httpd_modconfdir}" != "%{_httpd_confdir}"
-%{__sed} -n /^LoadModule/p passenger.conf > 10-passenger.conf
-%{__sed} -i /^LoadModule/d passenger.conf
-touch -r %{SOURCE10} 10-passenger.conf
-install -pm 0644 10-passenger.conf %{buildroot}%{_httpd_modconfdir}/passenger.conf
-%endif
 touch -r %{SOURCE10} passenger.conf
 install -pm 0644 passenger.conf %{buildroot}%{_httpd_confdir}/passenger.conf
-
+install -pm 0644 %{SOURCE12} %{buildroot}%{_httpd_modconfdir}/zpassenger.load
 
 # Install man pages into the proper location.
 %{__mkdir_p} %{buildroot}%{_mandir}/man1
@@ -439,10 +434,8 @@ rake test --trace ||:
 %{gem_instdir}/ext
 
 %files -n %{?scl_prefix}mod_passenger
-%if 0%{?rhel} >= 7
 %config(noreplace) %{_httpd_confdir}/*.conf
-%endif
-%config(noreplace) %{_httpd_modconfdir}/*.conf
+%config(noreplace) %{_httpd_modconfdir}/*.load
 %{_httpd_moddir}/mod_passenger.so
 %doc doc/Users?guide?Apache.txt
 

--- a/rubygem-passenger/zpassenger.load.in
+++ b/rubygem-passenger/zpassenger.load.in
@@ -1,0 +1,1 @@
+LoadModule passenger_module modules/mod_passenger.so


### PR DESCRIPTION
This is another attempt to fix [#14687](http://projects.theforeman.org/issues/14687). I do not think any changes regarding this problem will be accepted into puppetlabs-apache, since the module works as intended. The issue is rather a result of interaction between said module and our package.

puppetlabs-apache introduced `zpassenger.load` file that loads passenger module with lower priority as described [here](https://github.com/puppetlabs/puppetlabs-apache/pull/1072). Since we want our package to work when not managed by puppet, I moved the loading of a module from `passenger.conf` to `zpassenger.load`. This should remove the duplicated loading when managed by puppet and will work on its own as well.
