### PR TITLE
Add fast_gettext back to plugin repos

### DIFF
--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -48,6 +48,7 @@
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_tasks</packagereq>
       <packagereq type="default">tfm-rubygem-parse-cron</packagereq>
       <packagereq type="default">tfm-rubygem-puppetdb_foreman</packagereq>
+      <packagereq type="default">rubygem-fast_gettext</packagereq>
       <packagereq type="default">rubygem-foreman_scap_client</packagereq>
       <packagereq type="default">rubygem-newt</packagereq>
       <packagereq type="default">rubygem-smart_proxy_abrt</packagereq>
@@ -104,6 +105,7 @@
       <packagereq type="default">rubygem-concurrent-ruby-doc</packagereq>
       <packagereq type="default">rubygem-concurrent-ruby-edge-doc</packagereq>
       <packagereq type="default">rubygem-dynflow-doc</packagereq>
+      <packagereq type="default">rubygem-fast_gettext-doc</packagereq>
       <packagereq type="default">rubygem-foreman_scap_client-doc</packagereq>
       <packagereq type="default">rubygem-logify-doc</packagereq>
       <packagereq type="default">rubygem-mysql2-doc</packagereq>

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -536,6 +536,7 @@ whitelist = rubygem-algebrick
   rubygem-concurrent-ruby
   rubygem-concurrent-ruby-edge
   rubygem-dynflow
+  rubygem-fast_gettext
   rubygem-foreman_scap_client
   rubygem-logify
   rubygem-mysql2


### PR DESCRIPTION
This reverts commit d321020ac74551d32053fca6fc5c3e5ea8bcb1d2.

This gem is used in Foreman Discovery Image:
https://github.com/theforeman/foreman-discovery-image/pull/71 I mean it wasn't yet used but I would like to use this gem.