### PR TITLE
Link foreman-ruby to specific ruby version [deb]

### DIFF
--- a/debian/jessie/foreman/links
+++ b/debian/jessie/foreman/links
@@ -8,4 +8,4 @@ var/cache/foreman		usr/share/foreman/tmp
 var/lib/foreman/db		usr/share/foreman/db
 var/log/foreman			usr/share/foreman/log
 var/lib/foreman/public		usr/share/foreman/public
-usr/bin/ruby		usr/bin/foreman-ruby
+usr/bin/ruby2.1		usr/bin/foreman-ruby

--- a/debian/xenial/foreman/links
+++ b/debian/xenial/foreman/links
@@ -8,4 +8,4 @@ var/cache/foreman		usr/share/foreman/tmp
 var/lib/foreman/db		usr/share/foreman/db
 var/log/foreman			usr/share/foreman/log
 var/lib/foreman/public		usr/share/foreman/public
-usr/bin/ruby		usr/bin/foreman-ruby
+usr/bin/ruby2.3		usr/bin/foreman-ruby


### PR DESCRIPTION
When building a plugin that has a build-dep on `foreman`, or just
installing the package, the foreman-ruby symlink used in
foreman.postinst will be non-functional as it points to /usr/bin/ruby on
on jessie/xenial. This only exists when the `ruby` package is installed,
but `foreman` depends on a specific `rubyX.Y` package.

---

Should fix build failures such as http://ci.theforeman.org/job/packaging_build_deb_plugin/1095/arch=x86,label=debian,os=jessie/console

<pre>
13:17:44 Setting up ruby2.1 (2.1.5-2+deb8u2) ...
[..]
13:17:44 Setting up ruby2.1-dev:amd64 (2.1.5-2+deb8u2) ...
13:17:44 Setting up foreman (9999-jessie+scratchbuild+201606031407) ...
13:17:44 /var/lib/dpkg/info/foreman.postinst: 48: /var/lib/dpkg/info/foreman.postinst: /usr/bin/foreman-ruby: not found
</pre>