### PR TITLE
Use foreman-ruby to run bundler in plugin build scripts [deb]

### DIFF
--- a/plugins/ruby-foreman-azure/debian/rules
+++ b/plugins/ruby-foreman-azure/debian/rules
@@ -15,10 +15,10 @@ build:
 	cp cache/* /usr/share/foreman/vendor/cache/
 	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
 	cd /usr/share/foreman && ( \
-		bundle install --local && \
-		bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production \
+		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production \
 	)
-	GEM_PATH=$$(cd /usr/share/foreman && bundle show $(PLUGIN)) && \
+	GEM_PATH=$$(cd /usr/share/foreman && /usr/bin/foreman-ruby /usr/bin/bundle show $(PLUGIN)) && \
 		cp -rp $${GEM_PATH}/public/assets/$(PLUGIN) ./
 
 %:

--- a/plugins/ruby-foreman-bootdisk/debian/rules
+++ b/plugins/ruby-foreman-bootdisk/debian/rules
@@ -15,13 +15,13 @@ build:
 	cp cache/* /usr/share/foreman/vendor/cache/
 	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
 	cd /usr/share/foreman && ( \
-		bundle install --local && \
-		bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production && \
-		bundle exec rake db:migrate RAILS_ENV=development && \
-		bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
+		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake db:migrate RAILS_ENV=development && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
 			OUT=/var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) RAILS_ENV=development \
 	)
-	GEM_PATH=$$(cd /usr/share/foreman && bundle show $(PLUGIN)) && \
+	GEM_PATH=$$(cd /usr/share/foreman && /usr/bin/foreman-ruby /usr/bin/bundle show $(PLUGIN)) && \
 		cp -rp $${GEM_PATH}/public/assets/$(PLUGIN) ./
 	[ -e apipie-cache ] || mkdir apipie-cache/
 	cp -rp /var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) ./apipie-cache/

--- a/plugins/ruby-foreman-chef/debian/rules
+++ b/plugins/ruby-foreman-chef/debian/rules
@@ -15,10 +15,10 @@ build:
 	cp cache/* /usr/share/foreman/vendor/cache/
 	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
 	cd /usr/share/foreman && ( \
-		bundle install --local && \
-		bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production \
+		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production \
 	)
-	GEM_PATH=$$(cd /usr/share/foreman && bundle show $(PLUGIN)) && \
+	GEM_PATH=$$(cd /usr/share/foreman && /usr/bin/foreman-ruby /usr/bin/bundle show $(PLUGIN)) && \
 		cp -rp $${GEM_PATH}/public/assets/$(PLUGIN) ./
 
 %:

--- a/plugins/ruby-foreman-cockpit/debian/rules
+++ b/plugins/ruby-foreman-cockpit/debian/rules
@@ -15,10 +15,10 @@ build:
 	cp cache/* /usr/share/foreman/vendor/cache/
 	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
 	cd /usr/share/foreman && ( \
-		bundle install --local && \
-		bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production \
+		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production \
 	)
-	GEM_PATH=$$(cd /usr/share/foreman && bundle show $(PLUGIN)) && \
+	GEM_PATH=$$(cd /usr/share/foreman && /usr/bin/foreman-ruby /usr/bin/bundle show $(PLUGIN)) && \
 		cp -rp $${GEM_PATH}/public/assets/$(PLUGIN) ./
 
 %:

--- a/plugins/ruby-foreman-discovery/debian/rules
+++ b/plugins/ruby-foreman-discovery/debian/rules
@@ -15,9 +15,9 @@ build:
 	cp cache/* /usr/share/foreman/vendor/cache/
 	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
 	cd /usr/share/foreman && ( \
-		bundle install --local && \
-		bundle exec rake db:migrate RAILS_ENV=development && \
-		bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
+		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake db:migrate RAILS_ENV=development && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
 		OUT=/var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) RAILS_ENV=development \
 		)
 	[ -e apipie-cache ] || mkdir apipie-cache/

--- a/plugins/ruby-foreman-docker/debian/rules
+++ b/plugins/ruby-foreman-docker/debian/rules
@@ -15,13 +15,13 @@ build:
 	cp cache/* /usr/share/foreman/vendor/cache/
 	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
 	cd /usr/share/foreman && ( \
-		bundle install --local && \
-		bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production && \
-		bundle exec rake db:migrate RAILS_ENV=development && \
-		bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
+		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake db:migrate RAILS_ENV=development && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
 			OUT=/var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) RAILS_ENV=development \
 	)
-	GEM_PATH=$$(cd /usr/share/foreman && bundle show $(PLUGIN)) && \
+	GEM_PATH=$$(cd /usr/share/foreman && /usr/bin/foreman-ruby /usr/bin/bundle show $(PLUGIN)) && \
 		cp -rp $${GEM_PATH}/public/assets/$(PLUGIN) ./
 	[ -e apipie-cache ] || mkdir apipie-cache/
 	cp -rp /var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) ./apipie-cache/

--- a/plugins/ruby-foreman-remote-execution/debian/rules
+++ b/plugins/ruby-foreman-remote-execution/debian/rules
@@ -15,13 +15,13 @@ build:
 	cp cache/* /usr/share/foreman/vendor/cache/
 	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
 	cd /usr/share/foreman && ( \
-		bundle install --local && \
-		bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production && \
-		bundle exec rake db:migrate RAILS_ENV=development && \
-		bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
+		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake db:migrate RAILS_ENV=development && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
 			OUT=/var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) RAILS_ENV=development \
 	)
-	GEM_PATH=$$(cd /usr/share/foreman && bundle show $(PLUGIN)) && \
+	GEM_PATH=$$(cd /usr/share/foreman && /usr/bin/foreman-ruby /usr/bin/bundle show $(PLUGIN)) && \
 		cp -rp $${GEM_PATH}/public/assets/ ./
 	[ -e apipie-cache ] || mkdir apipie-cache/
 	cp -rp /var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) ./apipie-cache/

--- a/plugins/ruby-foreman-salt/debian/rules
+++ b/plugins/ruby-foreman-salt/debian/rules
@@ -15,13 +15,13 @@ build:
 	cp cache/* /usr/share/foreman/vendor/cache/
 	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
 	cd /usr/share/foreman && ( \
-		bundle install --local && \
-		bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production && \
-		bundle exec rake db:migrate RAILS_ENV=development && \
-		bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
+		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake db:migrate RAILS_ENV=development && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
 			OUT=/var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) RAILS_ENV=development \
 	)
-	GEM_PATH=$$(cd /usr/share/foreman && bundle show $(PLUGIN)) && \
+	GEM_PATH=$$(cd /usr/share/foreman && /usr/bin/foreman-ruby /usr/bin/bundle show $(PLUGIN)) && \
 		cp -rp $${GEM_PATH}/public/assets/$(PLUGIN) ./
 	[ -e apipie-cache ] || mkdir apipie-cache/
 	cp -rp /var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) ./apipie-cache/

--- a/plugins/ruby-foreman-setup/debian/rules
+++ b/plugins/ruby-foreman-setup/debian/rules
@@ -15,10 +15,10 @@ build:
 	cp cache/* /usr/share/foreman/vendor/cache/
 	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
 	cd /usr/share/foreman && ( \
-		bundle install --local && \
-		bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production \
+		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production \
 	)
-	GEM_PATH=$$(cd /usr/share/foreman && bundle show $(PLUGIN)) && \
+	GEM_PATH=$$(cd /usr/share/foreman && /usr/bin/foreman-ruby /usr/bin/bundle show $(PLUGIN)) && \
 		cp -rp $${GEM_PATH}/public/assets/$(PLUGIN) ./
 
 %:

--- a/plugins/ruby-foreman-tasks/debian/rules
+++ b/plugins/ruby-foreman-tasks/debian/rules
@@ -15,13 +15,13 @@ build:
 	cp cache/* /usr/share/foreman/vendor/cache/
 	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
 	cd /usr/share/foreman && ( \
-		bundle install --local && \
-		bundle exec rake plugin:assets:precompile[foreman_tasks] RAILS_ENV=production && \
-		bundle exec rake db:migrate RAILS_ENV=development && \
-		bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
+		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:assets:precompile[foreman_tasks] RAILS_ENV=production && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake db:migrate RAILS_ENV=development && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
 		OUT=/var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) RAILS_ENV=development \
         )
-	GEM_PATH=$$(cd /usr/share/foreman && bundle show $(PLUGIN)) && \
+	GEM_PATH=$$(cd /usr/share/foreman && /usr/bin/foreman-ruby /usr/bin/bundle show $(PLUGIN)) && \
 		cp -rp $${GEM_PATH}/public/assets ./
 	[ -e apipie-cache ] || mkdir apipie-cache/
 	cp -rp /var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) ./apipie-cache/


### PR DESCRIPTION
Fixes builds of plugins on OSes such as trusty where the default Ruby is
different to the foreman-ruby version, causing `foreman` installation
errors as gems are missing the correct `ruby-dev` package.

---

Should fix build errors such as http://ci.theforeman.org/job/packaging_build_deb_plugin/1096/arch=x86,label=debian,os=trusty/console:

<pre>
13:37:05 cd /usr/share/foreman && ( \
13:37:05 		bundle install --local && \
13:37:05 		bundle exec rake plugin:assets:precompile[foreman_azure] RAILS_ENV=production \
13:37:05 	)

13:37:11 Resolving dependencies...
13:37:11 Installing rake (11.1.2) 
13:37:11 Installing ace-rails-ap (4.0.2) 
13:37:12 Installing i18n (0.7.0) 
13:37:12 Installing json (1.8.3) 
13:37:12 Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.
13:37:12 
13:37:12         /usr/bin/ruby1.9.1 extconf.rb 
13:37:12 /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- mkmf (LoadError)
13:37:12 	from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
13:37:12 	from extconf.rb:1:in `<main>'
13:37:12 
13:37:12 
13:37:12 Gem files will remain installed in /usr/share/foreman/vendor/ruby/1.9.1/gems/json-1.8.3 for inspection.
</pre>