### PR TITLE
Add gem2rpm templates (RPM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,16 @@ related projects (mostly rubygems).
 
 If you're just submitting a fix, you don't need anything special.
 
-If you're just submitting a patch which changes a source file, you will need:
+If you're submitting a patch which adds/updates packages, you will need:
 
-* [git-annex](http://git-annex.branchable.com/)
+* [gem2rpm](https://rubygems.org/gems/gem2rpm) or rubygem-gem2rpm
 * [gem-compare](https://rubygems.org/gems/gem-compare)
+* [git-annex](http://git-annex.branchable.com/)
 
-However to release RPMs from this repo, you also require:
+To build locally or release RPMs from this repo, you also require:
 
-* koji client and an account (certificate) on koji.katello.org
 * [tito](https://github.com/dgoodwin/tito) 0.6.1 or higher
+* [mock](http://fedoraproject.org/wiki/Projects/Mock) or koji client and an account (certificate) on koji.katello.org
 
 ## HOWTO: checkout
 
@@ -105,12 +106,16 @@ You'll also need an alias `kojikat` to point to:
   * http://www.isitfedoraruby.com/fedorarpms/NAME
   * If only building non-SCL and it's in both Fedora and EPEL, stop now
 1. If available in Fedora, copy the spec from the SCM link on the left
-1. Copy the template/ directory
-  1. rename the spec file, don't use an SCL prefix
-  1. update gem\_name, version, ensure "Release" is 1
-  1. empty the %changelog section
-  1. express all gem dependencies as identical `Requires` in the spec file
-1. Download the source file (e.g. the .gem) into the spec directory and run
+1. Choose a template from gem2rpm that's suitable for the type of package and
+   run:
+  * `mkdir rubygem-example` (no SCL prefix)
+  * `cd rubygem-example`
+  * `gem2rpm -o rubygem-example.spec --fetch example -t ../gem2rpm/template.spec.erb`
+1. Improve the spec file to a reasonable standard, tidying up any gem2rpm
+   weirdness.  In particular, look for:
+  * Convert SPDX licences to [Fedora short names](https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing#Software_License_List)
+  * Ensure summary is under 72 characters
+1. Ensure the source file (e.g. the .gem) is in the spec directory and run
    `git annex add foo.gem`
 1. Update rel-eng/tito.props and add to the appropriate whitelists
 1. Update comps/comps-foreman-\*.xml

--- a/gem2rpm/foreman_plugin.spec.erb
+++ b/gem2rpm/foreman_plugin.spec.erb
@@ -1,0 +1,184 @@
+# FIXME:
+#   1. Change scl_prefix to _ruby or _ror for Requires/BuildRequires that are
+#      in Ruby or Rails software collections (not Foreman's)
+#   2. Edit foreman requirement(s) and specify minimum version
+#   3. Delete these lines
+#
+# Generated from <%= package.spec.file_name %> by gem2rpm -*- rpm-spec -*-
+%{?scl:%scl_package rubygem-%{gem_name}}
+%{!?scl:%global pkg_name %{name}}
+
+%global gem_name <%= spec.name %>
+%global plugin_name <%= spec.name.sub(/\Aforeman_/, '') %>
+<%
+has_assets = spec.files.any? { |f| f.start_with?('app/assets/') }
+has_apidoc = spec.files.any? { |f| f =~ %r{\Aapp/controllers/?.*/api/} }
+has_db_migrations = spec.files.any? { |f| f.start_with?('db/migrate/') }
+has_db_seeds = spec.files.any? { |f| f.start_with?('db/seeds.d/') }
+
+precompile_flags = ''
+precompile_flags << ' -a' if has_apidoc
+precompile_flags << ' -s' if has_assets
+
+config.rules[:doc] << /\/?CHANGES/
+config.rules[:ignore] << /.tx(\/.*)?/
+-%>
+
+Name: %{?scl_prefix}rubygem-%{gem_name}
+Version: <%= spec.version %>
+Release: 1%{?foremandist}%{?dist}
+Summary: <%= spec.summary.gsub(/\.$/, "") %>
+Group: Applications/Systems
+License: <%= spec.licenses.join(" and ") %>
+<% if spec.homepage -%>
+URL: <%= spec.homepage %>
+<% end -%>
+Source0: <%= download_path.sub('https:', 'http:') %>%{gem_name}-%{version}.gem
+Requires: foreman >= FIXME
+Requires: %{?scl_prefix_ruby}ruby(release)
+<% for req in spec.required_ruby_version -%>
+Requires: %{?scl_prefix_ruby}ruby <%= req %>
+<% end -%>
+<% for req in spec.required_rubygems_version -%>
+Requires: %{?scl_prefix_ruby}ruby(rubygems) <%= req %>
+<% end -%>
+<% for d in spec.runtime_dependencies -%>
+<% for req in d.requirement -%>
+Requires: %{?scl_prefix}rubygem(<%= d.name %>) <%= req  %>
+<% end -%>
+<% end -%>
+<% if has_assets -%>
+BuildRequires: foreman-assets
+<% end -%>
+BuildRequires: foreman-plugin >= FIXME
+<% if has_assets || has_apidoc -%>
+<% for d in spec.runtime_dependencies -%>
+<% for req in d.requirement -%>
+BuildRequires: %{?scl_prefix}rubygem(<%= d.name %>) <%= req  %>
+<% end -%>
+<% end -%>
+<% end -%>
+BuildRequires: %{?scl_prefix_ruby}ruby(release)
+<% for req in spec.required_ruby_version -%>
+BuildRequires: %{?scl_prefix_ruby}ruby<%= "-devel" unless spec.extensions.empty? %> <%= req %>
+<% end -%>
+<% for req in spec.required_rubygems_version -%>
+BuildRequires: %{?scl_prefix_ruby}rubygems-devel <%= req %>
+<% end -%>
+<% if spec.extensions.empty? -%>
+BuildArch: noarch
+<% end -%>
+Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
+Provides: foreman-plugin-%{plugin_name}
+
+%description
+<%= spec.description %>
+
+<% if doc_subpackage -%>
+%package doc
+Summary: Documentation for %{pkg_name}
+Group: Documentation
+Requires: %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+BuildArch: noarch
+
+%description doc
+Documentation for %{pkg_name}.
+<% end # if doc_subpackage -%>
+
+%prep
+%{?scl:scl enable %{scl} - << \EOF}
+gem unpack %{SOURCE0}
+%{?scl:EOF}
+
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+%{?scl:scl enable %{scl} - << \EOF}
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
+%{?scl:EOF}
+
+%build
+# Create the gem as gem install only works on a gem file
+%{?scl:scl enable %{scl} - << \EOF}
+gem build %{gem_name}.gemspec
+%{?scl:EOF}
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%{?scl:scl enable %{scl} - << \EOF}
+%gem_install
+%{?scl:EOF}
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -pa .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+<% unless spec.extensions.empty? -%>
+mkdir -p %{buildroot}%{gem_extdir_mri}
+cp -a .%{gem_extdir_mri}/{gem.build_complete,*.so} %{buildroot}%{gem_extdir_mri}/
+
+<% for ext in spec.extensions -%>
+# Prevent dangling symlink in -debuginfo (rhbz#878863).
+rm -rf %{buildroot}%{gem_instdir}/<%= ext.split(File::SEPARATOR).first %>/
+<% end -%>
+
+<% end -%>
+<% unless spec.executables.nil? or spec.executables.empty? -%>
+mkdir -p %{buildroot}%{_bindir}
+cp -pa .%{_bindir}/* \
+        %{buildroot}%{_bindir}/
+find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
+
+<% end -%>
+%foreman_bundlerd_file
+<% unless precompile_flags.strip.empty? -%>
+%foreman_precompile_plugin <%= precompile_flags.strip %>
+<% end -%>
+
+%files
+%dir %{gem_instdir}
+<% unless spec.executables.nil? or spec.executables.empty? -%>
+<% for f in spec.executables -%>
+%{_bindir}/<%= f %>
+<% end -%>
+<% end -%>
+<% unless spec.extensions.empty? -%>
+%exclude %{gem_instdir}/ext
+%{gem_extdir_mri}
+<% end -%>
+<%= main_file_entries(spec).gsub(/^%license/, '%doc') %>
+<% unless doc_subpackage -%>
+%doc %{gem_docdir}
+<%= doc_file_entries(spec) %>
+<% end -%>
+%exclude %{gem_cache}
+%{gem_spec}
+%{foreman_bundlerd_plugin}
+<% if has_apidoc -%>
+%{foreman_apipie_cache_foreman}
+%{foreman_apipie_cache_plugin}
+<% end -%>
+<% if has_assets -%>
+%{foreman_assets_plugin}
+<% end -%>
+
+<% if doc_subpackage -%>
+%files doc
+%doc %{gem_docdir}
+<%= doc_file_entries(spec) %>
+<% end # if doc_subpackage -%>
+
+%posttrans
+<% if has_db_migrations -%>
+%{foreman_db_migrate}
+<% end -%>
+<% if has_db_seeds -%>
+%{foreman_db_seed}
+<% end -%>
+<% if has_apidoc -%>
+%{foreman_apipie_cache}
+<% end -%>
+%{foreman_restart}
+exit 0
+
+%changelog

--- a/gem2rpm/hammer_plugin.spec.erb
+++ b/gem2rpm/hammer_plugin.spec.erb
@@ -1,0 +1,140 @@
+# FIXME:
+#   1. Change scl_prefix to _ruby or _ror for Requires/BuildRequires that are
+#      in Ruby or Rails software collections (not Foreman's)
+#   2. Delete these lines
+#
+# Generated from <%= package.spec.file_name %> by gem2rpm -*- rpm-spec -*-
+<% config.rules[:doc] << /\/?config(\/.*)?/ -%>
+%{?scl:%scl_package rubygem-%{gem_name}}
+%{!?scl:%global pkg_name %{name}}
+
+%global gem_name <%= spec.name %>
+%global plugin_name <%= spec.name.sub(/\Ahammer_cli_/, '') %>
+
+%{!?_root_sysconfdir:%global _root_sysconfdir %{_sysconfdir}}
+%global hammer_confdir %{_root_sysconfdir}/hammer
+
+Name: %{?scl_prefix}rubygem-%{gem_name}
+Version: <%= spec.version %>
+Release: 1%{?foremandist}%{?dist}
+Summary: <%= spec.summary.gsub(/\.$/, "") %>
+Group: Development/Languages
+License: <%= spec.licenses.join(" and ") %>
+<% if spec.homepage -%>
+URL: <%= spec.homepage %>
+<% end -%>
+Source0: <%= download_path.sub('https:', 'http:') %>%{gem_name}-%{version}.gem
+Requires: %{?scl_prefix_ruby}ruby(release)
+<% for req in spec.required_ruby_version -%>
+Requires: %{?scl_prefix_ruby}ruby <%= req %>
+<% end -%>
+<% for req in spec.required_rubygems_version -%>
+Requires: %{?scl_prefix_ruby}ruby(rubygems) <%= req %>
+<% end -%>
+<% for d in spec.runtime_dependencies -%>
+<% for req in d.requirement -%>
+Requires: %{?scl_prefix}rubygem(<%= d.name %>) <%= req  %>
+<% end -%>
+<% end -%>
+BuildRequires: %{?scl_prefix_ruby}ruby(release)
+<% for req in spec.required_ruby_version -%>
+BuildRequires: %{?scl_prefix_ruby}ruby<%= "-devel" unless spec.extensions.empty? %> <%= req %>
+<% end -%>
+<% for req in spec.required_rubygems_version -%>
+BuildRequires: %{?scl_prefix_ruby}rubygems-devel <%= req %>
+<% end -%>
+<% if spec.extensions.empty? -%>
+BuildArch: noarch
+<% end -%>
+Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
+
+%description
+<%= spec.description %>
+
+<% if doc_subpackage -%>
+%package doc
+Summary: Documentation for %{pkg_name}
+Group: Documentation
+Requires: %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+BuildArch: noarch
+
+%description doc
+Documentation for %{pkg_name}.
+<% end # if doc_subpackage -%>
+
+%prep
+%{?scl:scl enable %{scl} - << \EOF}
+gem unpack %{SOURCE0}
+%{?scl:EOF}
+
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+%{?scl:scl enable %{scl} - << \EOF}
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
+%{?scl:EOF}
+
+%build
+# Create the gem as gem install only works on a gem file
+%{?scl:scl enable %{scl} - << \EOF}
+gem build %{gem_name}.gemspec
+%{?scl:EOF}
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%{?scl:scl enable %{scl} - << \EOF}
+%gem_install
+%{?scl:EOF}
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -pa .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+<% unless spec.extensions.empty? -%>
+mkdir -p %{buildroot}%{gem_extdir_mri}
+cp -a .%{gem_extdir_mri}/{gem.build_complete,*.so} %{buildroot}%{gem_extdir_mri}/
+
+<% for ext in spec.extensions -%>
+# Prevent dangling symlink in -debuginfo (rhbz#878863).
+rm -rf %{buildroot}%{gem_instdir}/<%= ext.split(File::SEPARATOR).first %>/
+<% end -%>
+
+<% end -%>
+<% unless spec.executables.nil? or spec.executables.empty? -%>
+mkdir -p %{buildroot}%{_bindir}
+cp -pa .%{_bindir}/* \
+        %{buildroot}%{_bindir}/
+find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
+
+<% end -%>
+mkdir -p %{buildroot}%{hammer_confdir}/cli.modules.d
+install -m 0644 .%{gem_instdir}/config/%{plugin_name}.yml \
+                %{buildroot}%{hammer_confdir}/cli.modules.d/%{plugin_name}.yml
+
+%files
+%dir %{gem_instdir}
+<% unless spec.executables.nil? or spec.executables.empty? -%>
+<% for f in spec.executables -%>
+%{_bindir}/<%= f %>
+<% end -%>
+<% end -%>
+<% unless spec.extensions.empty? -%>
+%exclude %{gem_instdir}/ext
+%{gem_extdir_mri}
+<% end -%>
+<%= main_file_entries(spec).gsub(/^%license/, '%doc') %>
+<% unless doc_subpackage -%>
+%doc %{gem_docdir}
+<%= doc_file_entries(spec) %>
+<% end -%>
+%exclude %{gem_cache}
+%{gem_spec}
+%config %{hammer_confdir}/cli.modules.d/%{plugin_name}.yml
+
+<% if doc_subpackage -%>
+%files doc
+%doc %{gem_docdir}
+<%= doc_file_entries(spec) %>
+<% end # if doc_subpackage -%>
+
+%changelog

--- a/gem2rpm/nonscl.spec.erb
+++ b/gem2rpm/nonscl.spec.erb
@@ -1,0 +1,121 @@
+# Generated from <%= package.spec.file_name %> by gem2rpm -*- rpm-spec -*-
+%global gem_name <%= spec.name %>
+
+Name: rubygem-%{gem_name}
+Version: <%= spec.version %>
+Release: 1%{?dist}
+Summary: <%= spec.summary.gsub(/\.$/, "") %>
+Group: Development/Languages
+License: <%= spec.licenses.join(" and ") %>
+<% if spec.homepage -%>
+URL: <%= spec.homepage %>
+<% end -%>
+Source0: <%= download_path %>%{gem_name}-%{version}.gem
+%if 0%{?rhel} == 6
+Requires: ruby(abi)
+%else
+Requires: ruby(release)
+%endif
+<% for req in spec.required_ruby_version -%>
+Requires: ruby <%= req %>
+<% end -%>
+<% for req in spec.required_rubygems_version -%>
+Requires: ruby(rubygems) <%= req %>
+<% end -%>
+<% for d in spec.runtime_dependencies -%>
+<% for req in d.requirement -%>
+Requires: rubygem(<%= d.name %>) <%= req  %>
+<% end -%>
+<% end -%>
+%if 0%{?rhel} == 6
+BuildRequires: ruby(abi)
+%else
+BuildRequires: ruby(release)
+%endif
+<% for req in spec.required_ruby_version -%>
+BuildRequires: ruby<%= "-devel" unless spec.extensions.empty? %> <%= req %>
+<% end -%>
+<% for req in spec.required_rubygems_version -%>
+BuildRequires: rubygems-devel <%= req %>
+<% end -%>
+<% if spec.extensions.empty? -%>
+BuildArch: noarch
+<% end -%>
+Provides: rubygem(%{gem_name}) = %{version}
+
+%description
+<%= spec.description %>
+
+<% if doc_subpackage -%>
+%package doc
+Summary: Documentation for %{name}
+Group: Documentation
+Requires: %{name} = %{version}-%{release}
+BuildArch: noarch
+
+%description doc
+Documentation for %{name}.
+<% end # if doc_subpackage -%>
+
+%prep
+gem unpack %{SOURCE0}
+
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
+
+%build
+# Create the gem as gem install only works on a gem file
+gem build %{gem_name}.gemspec
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%gem_install
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -a .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+<% unless spec.extensions.empty? -%>
+mkdir -p %{buildroot}%{gem_extdir_mri}
+cp -a .%{gem_extdir_mri}/{gem.build_complete,*.so} %{buildroot}%{gem_extdir_mri}/
+
+<% for ext in spec.extensions -%>
+# Prevent dangling symlink in -debuginfo (rhbz#878863).
+rm -rf %{buildroot}%{gem_instdir}/<%= ext.split(File::SEPARATOR).first %>/
+<% end -%>
+
+<% end -%>
+<% unless spec.executables.nil? or spec.executables.empty? -%>
+mkdir -p %{buildroot}%{_bindir}
+cp -pa .%{_bindir}/* \
+        %{buildroot}%{_bindir}/
+find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
+
+<% end -%>
+%files
+%dir %{gem_instdir}
+<% unless spec.executables.nil? or spec.executables.empty? -%>
+<% for f in spec.executables -%>
+%{_bindir}/<%= f %>
+<% end -%>
+<% end -%>
+<% unless spec.extensions.empty? -%>
+%{gem_extdir_mri}
+<% end -%>
+<%= main_file_entries(spec).gsub(/^%license/, '%doc') %>
+<% unless doc_subpackage -%>
+%doc %{gem_docdir}
+<%= doc_file_entries(spec) -%>
+<% end -%>
+%exclude %{gem_cache}
+%{gem_spec}
+
+<% if doc_subpackage -%>
+%files doc
+%doc %{gem_docdir}
+<%= doc_file_entries(spec) %>
+<% end # if doc_subpackage -%>
+
+%changelog

--- a/gem2rpm/scl.spec.erb
+++ b/gem2rpm/scl.spec.erb
@@ -1,0 +1,130 @@
+# FIXME:
+#   1. Change scl_prefix to _ruby or _ror for Requires/BuildRequires that are
+#      in Ruby or Rails software collections (not Foreman's)
+#   2. Delete these lines
+#
+# Generated from <%= package.spec.file_name %> by gem2rpm -*- rpm-spec -*-
+%{?scl:%scl_package rubygem-%{gem_name}}
+%{!?scl:%global pkg_name %{name}}
+
+%global gem_name <%= spec.name %>
+
+Name: %{?scl_prefix}rubygem-%{gem_name}
+Version: <%= spec.version %>
+Release: 1%{?dist}
+Summary: <%= spec.summary.gsub(/\.$/, "") %>
+Group: Development/Languages
+License: <%= spec.licenses.join(" and ") %>
+<% if spec.homepage -%>
+URL: <%= spec.homepage %>
+<% end -%>
+Source0: <%= download_path.sub('https:', 'http:') %>%{gem_name}-%{version}.gem
+Requires: %{?scl_prefix_ruby}ruby(release)
+<% for req in spec.required_ruby_version -%>
+Requires: %{?scl_prefix_ruby}ruby <%= req %>
+<% end -%>
+<% for req in spec.required_rubygems_version -%>
+Requires: %{?scl_prefix_ruby}ruby(rubygems) <%= req %>
+<% end -%>
+<% for d in spec.runtime_dependencies -%>
+<% for req in d.requirement -%>
+Requires: %{?scl_prefix}rubygem(<%= d.name %>) <%= req  %>
+<% end -%>
+<% end -%>
+BuildRequires: %{?scl_prefix_ruby}ruby(release)
+<% for req in spec.required_ruby_version -%>
+BuildRequires: %{?scl_prefix_ruby}ruby<%= "-devel" unless spec.extensions.empty? %> <%= req %>
+<% end -%>
+<% for req in spec.required_rubygems_version -%>
+BuildRequires: %{?scl_prefix_ruby}rubygems-devel <%= req %>
+<% end -%>
+<% if spec.extensions.empty? -%>
+BuildArch: noarch
+<% end -%>
+Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
+
+%description
+<%= spec.description %>
+
+<% if doc_subpackage -%>
+%package doc
+Summary: Documentation for %{pkg_name}
+Group: Documentation
+Requires: %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+BuildArch: noarch
+
+%description doc
+Documentation for %{pkg_name}.
+<% end # if doc_subpackage -%>
+
+%prep
+%{?scl:scl enable %{scl} - << \EOF}
+gem unpack %{SOURCE0}
+%{?scl:EOF}
+
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+%{?scl:scl enable %{scl} - << \EOF}
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
+%{?scl:EOF}
+
+%build
+# Create the gem as gem install only works on a gem file
+%{?scl:scl enable %{scl} - << \EOF}
+gem build %{gem_name}.gemspec
+%{?scl:EOF}
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%{?scl:scl enable %{scl} - << \EOF}
+%gem_install
+%{?scl:EOF}
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -pa .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+<% unless spec.extensions.empty? -%>
+mkdir -p %{buildroot}%{gem_extdir_mri}
+cp -a .%{gem_extdir_mri}/{gem.build_complete,*.so} %{buildroot}%{gem_extdir_mri}/
+
+<% for ext in spec.extensions -%>
+# Prevent dangling symlink in -debuginfo (rhbz#878863).
+rm -rf %{buildroot}%{gem_instdir}/<%= ext.split(File::SEPARATOR).first %>/
+<% end -%>
+
+<% end -%>
+<% unless spec.executables.nil? or spec.executables.empty? -%>
+mkdir -p %{buildroot}%{_bindir}
+cp -pa .%{_bindir}/* \
+        %{buildroot}%{_bindir}/
+find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
+
+<% end -%>
+%files
+%dir %{gem_instdir}
+<% unless spec.executables.nil? or spec.executables.empty? -%>
+<% for f in spec.executables -%>
+%{_bindir}/<%= f %>
+<% end -%>
+<% end -%>
+<% unless spec.extensions.empty? -%>
+%exclude %{gem_instdir}/ext
+%{gem_extdir_mri}
+<% end -%>
+<%= main_file_entries(spec).gsub(/^%license/, '%doc') %>
+<% unless doc_subpackage -%>
+%doc %{gem_docdir}
+<%= doc_file_entries(spec) %>
+<% end -%>
+%exclude %{gem_cache}
+%{gem_spec}
+
+<% if doc_subpackage -%>
+%files doc
+%doc %{gem_docdir}
+<%= doc_file_entries(spec) %>
+<% end # if doc_subpackage -%>
+
+%changelog

--- a/gem2rpm/smart_proxy_plugin.spec.erb
+++ b/gem2rpm/smart_proxy_plugin.spec.erb
@@ -1,0 +1,144 @@
+# FIXME:
+#   1. Edit foreman-proxy requirement and specify minimum version
+#   2. Delete these lines
+#
+# Generated from <%= package.spec.file_name %> by gem2rpm -*- rpm-spec -*-
+%global gem_name <%= spec.name %>
+%global plugin_name <%= spec.name.sub(/\Asmart_proxy_/, '') %>
+
+%global foreman_proxy_dir %{_datarootdir}/foreman-proxy
+%global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
+%global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
+
+Name: rubygem-%{gem_name}
+Version: <%= spec.version %>
+Release: 1%{?foremandist}%{?dist}
+Summary: <%= spec.summary.gsub(/\.$/, "") %>
+Group: Applications/Internet
+License: <%= spec.licenses.join(" and ") %>
+<% if spec.homepage -%>
+URL: <%= spec.homepage %>
+<% end -%>
+Source0: <%= download_path %>%{gem_name}-%{version}.gem
+Requires: foreman-proxy >= FIXME
+%if 0%{?rhel} == 6
+Requires: ruby(abi)
+%else
+Requires: ruby(release)
+%endif
+<% for req in spec.required_ruby_version -%>
+Requires: ruby <%= req %>
+<% end -%>
+<% for req in spec.required_rubygems_version -%>
+Requires: ruby(rubygems) <%= req %>
+<% end -%>
+<% for d in spec.runtime_dependencies -%>
+<% for req in d.requirement -%>
+Requires: rubygem(<%= d.name %>) <%= req  %>
+<% end -%>
+<% end -%>
+%if 0%{?rhel} == 6
+BuildRequires: ruby(abi)
+%else
+BuildRequires: ruby(release)
+%endif
+<% for req in spec.required_ruby_version -%>
+BuildRequires: ruby<%= "-devel" unless spec.extensions.empty? %> <%= req %>
+<% end -%>
+<% for req in spec.required_rubygems_version -%>
+BuildRequires: rubygems-devel <%= req %>
+<% end -%>
+<% if spec.extensions.empty? -%>
+BuildArch: noarch
+<% end -%>
+Provides: rubygem(%{gem_name}) = %{version}
+Provides: foreman-proxy-plugin-%{plugin_name}
+
+%description
+<%= spec.description %>
+
+<% if doc_subpackage -%>
+%package doc
+Summary: Documentation for %{name}
+Group: Documentation
+Requires: %{name} = %{version}-%{release}
+BuildArch: noarch
+
+%description doc
+Documentation for %{name}.
+<% end # if doc_subpackage -%>
+
+%prep
+gem unpack %{SOURCE0}
+
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
+
+%build
+# Create the gem as gem install only works on a gem file
+gem build %{gem_name}.gemspec
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%gem_install
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -a .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+<% unless spec.extensions.empty? -%>
+mkdir -p %{buildroot}%{gem_extdir_mri}
+cp -a .%{gem_extdir_mri}/{gem.build_complete,*.so} %{buildroot}%{gem_extdir_mri}/
+
+<% for ext in spec.extensions -%>
+# Prevent dangling symlink in -debuginfo (rhbz#878863).
+rm -rf %{buildroot}%{gem_instdir}/<%= ext.split(File::SEPARATOR).first %>/
+<% end -%>
+
+<% end -%>
+<% unless spec.executables.nil? or spec.executables.empty? -%>
+mkdir -p %{buildroot}%{_bindir}
+cp -pa .%{_bindir}/* \
+        %{buildroot}%{_bindir}/
+find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
+
+<% end -%>
+# bundler file
+mkdir -p %{buildroot}%{foreman_proxy_bundlerd_dir}
+mv %{buildroot}%{gem_instdir}/bundler.d/%{plugin_name}.rb \
+   %{buildroot}%{foreman_proxy_bundlerd_dir}
+
+# sample config
+mkdir -p %{buildroot}%{foreman_proxy_settingsd_dir}
+mv %{buildroot}%{gem_instdir}/settings.d/%{plugin_name}.yml.example \
+   %{buildroot}%{foreman_proxy_settingsd_dir}/%{plugin_name}.yml
+
+%files
+%dir %{gem_instdir}
+<% unless spec.executables.nil? or spec.executables.empty? -%>
+<% for f in spec.executables -%>
+%{_bindir}/<%= f %>
+<% end -%>
+<% end -%>
+<% unless spec.extensions.empty? -%>
+%{gem_extdir_mri}
+<% end -%>
+<%= main_file_entries(spec).gsub(/^%license/, '%doc') %>
+<% unless doc_subpackage -%>
+%doc %{gem_docdir}
+<%= doc_file_entries(spec) -%>
+<% end -%>
+%{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
+%config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/%{plugin_name}.yml
+%exclude %{gem_cache}
+%{gem_spec}
+
+<% if doc_subpackage -%>
+%files doc
+%doc %{gem_docdir}
+<%= doc_file_entries(spec) %>
+<% end # if doc_subpackage -%>
+
+%changelog


### PR DESCRIPTION
Includes templates for common rubygem types:

- SCL-only RPMs
- Non-SCL only RPMs
- Foreman plugins
- Smart proxy plugins
- Hammer CLI plugins

This won't work 100% for _everything_, as there are a handful of assumptions about what's in a gem or how plugins are laid out (particularly what config/bundler files are called in hammer/smart proxy gems), but it ought to cover a good 80% of cases.

The templates are using the Fedora gem2rpm default, which use the modern gem unpack/build/install style, but with additions for SCL macros, our config file locations, dependencies and so on.