### PR TITLE
Use default ruby instead of specific version

### DIFF
--- a/debian/jessie/foreman-proxy/control
+++ b/debian/jessie/foreman-proxy/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/theforeman/smart-proxy
 
 Package: foreman-proxy
 Architecture: all
-Depends: ruby2.1|ruby-interpreter, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext
+Depends: ruby | ruby-interpreter, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext
 Recommends: sudo, wget, ping, ruby-gssapi, ruby-rubyipmi (>= 0.9.2), ruby-rkerberos (>= 0.1.1), foreman-debug
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems

--- a/debian/trusty/foreman-proxy/control
+++ b/debian/trusty/foreman-proxy/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/theforeman/smart-proxy
 
 Package: foreman-proxy
 Architecture: all
-Depends: ruby1.9.1|ruby-interpreter, rake, ruby-sinatra, ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext
+Depends: ruby | ruby-interpreter, rake, ruby-sinatra, ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext
 Recommends: sudo, wget, ping, ruby-gssapi, ruby-rubyipmi (>= 0.9.2), ruby-rkerberos (>= 0.1.1), foreman-debug
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems

--- a/debian/xenial/foreman-proxy/control
+++ b/debian/xenial/foreman-proxy/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/theforeman/smart-proxy
 
 Package: foreman-proxy
 Architecture: all
-Depends: ruby2.3|ruby-interpreter, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext
+Depends: ruby | ruby-interpreter, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext
 Recommends: sudo, wget, ping, ruby-gssapi, ruby-rubyipmi (>= 0.9.2), ruby-rkerberos (>= 0.1.1), foreman-debug
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems


### PR DESCRIPTION
ruby-interpreter was used when Ruby packages were using alternatives, now the 'ruby' packages depends on the default version.