### PR TITLE
update chef-api to 0.6.0

### DIFF
--- a/dependencies/jessie/chef-api/changelog
+++ b/dependencies/jessie/chef-api/changelog
@@ -1,3 +1,9 @@
+ruby-chef-api (0.6.0-1) unstable; urgency=low
+
+  * Update to 0.6.0
+
+ -- Michael Moll <mmoll@mmoll.at>  Wed, 22 Jun 2016 13:07:23 +0200
+
 ruby-chef-api (0.5.0-1) unstable; urgency=low
 
   * Initial release for Debian/jessie

--- a/dependencies/jessie/chef-api/rules
+++ b/dependencies/jessie/chef-api/rules
@@ -13,3 +13,6 @@
 
 %:
 	dh $@ --buildsystem=ruby --with ruby
+
+override_dh_installchangelogs:
+	dh_installchangelogs CHANGELOG.md

--- a/dependencies/xenial/chef-api/changelog
+++ b/dependencies/xenial/chef-api/changelog
@@ -1,3 +1,9 @@
+ruby-chef-api (0.6.0-1) unstable; urgency=low
+
+  * Update to 0.6.0
+
+ -- Michael Moll <mmoll@mmoll.at>  Wed, 22 Jun 2016 13:07:23 +0200
+
 ruby-chef-api (0.5.0-1) stable; urgency=low
 
   * Initial release for Ubuntu/xenial

--- a/dependencies/xenial/chef-api/rules
+++ b/dependencies/xenial/chef-api/rules
@@ -13,3 +13,6 @@
 
 %:
 	dh $@ --buildsystem=ruby --with ruby
+
+override_dh_installchangelogs:
+	dh_installchangelogs CHANGELOG.md


### PR DESCRIPTION
for nightly only, please. As Ubuntu/trusty uses Ruby 1.9.3 for foreman-proxy, no changes here.