### PR TITLE
Add tfm-rubygem-ovirt_provision_plugin-doc on el7 comps

### DIFF
--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -93,7 +93,6 @@
       <packagereq type="default">tfm-rubygem-net-ssh-gateway</packagereq>
       <packagereq type="default">tfm-rubygem-net-ssh-multi</packagereq>
       <packagereq type="default">tfm-rubygem-opennebula</packagereq>
-      <packagereq type="default">tfm-rubygem-ovirt_provision_plugin-doc</packagereq>
       <packagereq type="default">tfm-rubygem-safe_yaml</packagereq>
       <packagereq type="default">tfm-rubygem-systemu</packagereq>
       <packagereq type="default">tfm-rubygem-uuid</packagereq>
@@ -203,6 +202,7 @@
       <packagereq type="default">tfm-rubygem-net-ssh-gateway-doc</packagereq>
       <packagereq type="default">tfm-rubygem-net-ssh-multi-doc</packagereq>
       <packagereq type="default">tfm-rubygem-opennebula-doc</packagereq>
+      <packagereq type="default">tfm-rubygem-ovirt_provision_plugin-doc</packagereq>
       <packagereq type="default">tfm-rubygem-parse-cron-doc</packagereq>
       <packagereq type="default">tfm-rubygem-safe_yaml-doc</packagereq>
       <packagereq type="default">tfm-rubygem-smart_proxy_dynflow_core-doc</packagereq>


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.12
* [x] 1.11
* [x] 1.10