### PR TITLE
Update foreman_setup to 4.0.0 [deb]

### DIFF
--- a/plugins/ruby-foreman-setup/debian/changelog
+++ b/plugins/ruby-foreman-setup/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-setup (4.0.0-1) stable; urgency=low
+
+  * 4.0.0 released
+
+ -- Dominic Cleal <dominic@cleal.org>  Fri, 01 Jul 2016 12:41:21 +0100
+
 ruby-foreman-setup (3.1.1-1) stable; urgency=low
 
   * 3.1.1 released

--- a/plugins/ruby-foreman-setup/debian/control
+++ b/plugins/ruby-foreman-setup/debian/control
@@ -2,12 +2,12 @@ Source: ruby-foreman-setup
 Section: ruby
 Priority: extra
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
-Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.9.0~rc1), foreman-sqlite3 (>= 1.9.0~rc1)
+Build-Depends: debhelper (>= 8.0.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_setup
 
 Package: ruby-foreman-setup
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.9.0~rc1)
+Depends: ${misc:Depends}, bundler, foreman (>= 1.12.0~rc1)
 Description: Foreman Setup Plugin
  Plugin for Foreman that helps set up provisioning.

--- a/plugins/ruby-foreman-setup/debian/gem.list
+++ b/plugins/ruby-foreman-setup/debian/gem.list
@@ -1,2 +1,2 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_setup-3.1.1.gem"
+GEMS="https://rubygems.org/downloads/foreman_setup-4.0.0.gem"

--- a/plugins/ruby-foreman-setup/debian/install
+++ b/plugins/ruby-foreman-setup/debian/install
@@ -1,3 +1,2 @@
 foreman_setup.rb usr/share/foreman/bundler.d
 cache            usr/share/foreman/vendor
-foreman_setup    var/lib/foreman/public/assets

--- a/plugins/ruby-foreman-setup/debian/rules
+++ b/plugins/ruby-foreman-setup/debian/rules
@@ -9,17 +9,5 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
-PLUGIN = foreman_setup
-
-build:
-	cp cache/* /usr/share/foreman/vendor/cache/
-	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
-	cd /usr/share/foreman && ( \
-		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
-		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production \
-	)
-	GEM_PATH=$$(cd /usr/share/foreman && /usr/bin/foreman-ruby /usr/bin/bundle show $(PLUGIN)) && \
-		cp -rp $${GEM_PATH}/public/assets/$(PLUGIN) ./
-
 %:
 	dh $@ 

--- a/plugins/ruby-foreman-setup/foreman_setup.rb
+++ b/plugins/ruby-foreman-setup/foreman_setup.rb
@@ -1,1 +1,1 @@
-gem 'foreman_setup', '3.1.1'
+gem 'foreman_setup', '4.0.0'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.12
* [ ] 1.11
* [ ] 1.10

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

This version depends on 1.12.0, but also removes the asset that it used to precompile.