### PR TITLE
plugins:foreman_ansible - Release 1.0 (DEB)

### DIFF
--- a/plugins/ruby-foreman-ansible/debian/changelog
+++ b/plugins/ruby-foreman-ansible/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-ansible (1.0-1) stable; urgency=low
+
+  * 1.0 released
+
+ -- Daniel Lobato <elobatocs@gmail.com>  Thu, 07 Jul 2016 14:23:08 +0200
+
 ruby-foreman-ansible (0.3-1) stable; urgency=low
 
   * 0.3 released

--- a/plugins/ruby-foreman-ansible/debian/control
+++ b/plugins/ruby-foreman-ansible/debian/control
@@ -2,12 +2,12 @@ Source: ruby-foreman-ansible
 Section: ruby
 Priority: extra
 Maintainer: Daniel Lobato Garcia <elobatocs@gmail.com>
-Build-Depends: debhelper, foreman (>= 1.9.0), ruby-foreman-deface (<<2.0.0)
+Build-Depends: debhelper, foreman (>= 1.12.0~rc1), ruby-foreman-deface (<<2.0.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_ansible
 
 Package: ruby-foreman-ansible
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.9.0), ruby-foreman-deface (<<2.0.0)
+Depends: ${misc:Depends}, bundler, foreman (>= 1.12.0~rc1), ruby-foreman-deface (<<2.0.0)
 Description: Foreman Ansible plugin
  Integration with Ansible in Foreman.

--- a/plugins/ruby-foreman-ansible/debian/gem.list
+++ b/plugins/ruby-foreman-ansible/debian/gem.list
@@ -1,2 +1,2 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_ansible-0.3.gem"
+GEMS="https://rubygems.org/downloads/foreman_ansible-1.0.gem"

--- a/plugins/ruby-foreman-ansible/debian/postinst
+++ b/plugins/ruby-foreman-ansible/debian/postinst
@@ -38,6 +38,17 @@ else
   fi
 fi
 
+# DB migrate/seed after install
+if [ -f /usr/share/foreman/config/database.yml ]; then
+  if [ ! -z "${DEBUG}" ]; then
+    /usr/sbin/foreman-rake db:migrate || true
+    /usr/sbin/foreman-rake db:seed || true
+  else
+    /usr/sbin/foreman-rake db:migrate >> $LOGFILE 2>&1 || true
+    /usr/sbin/foreman-rake db:seed >> $LOGFILE 2>&1 || true
+  fi
+fi
+
 # Own all the core files
 chown -Rf foreman:foreman '/usr/share/foreman'
 

--- a/plugins/ruby-foreman-ansible/foreman_ansible.rb
+++ b/plugins/ruby-foreman-ansible/foreman_ansible.rb
@@ -1,1 +1,1 @@
-gem 'foreman_ansible', '0.3'
+gem 'foreman_ansible', '1.0'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.12
* [ ] 1.11
* [ ] 1.10

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

This requires ActiveJob so 1.12 at least. To be merged after https://github.com/theforeman/foreman_ansible/pull/22 is released as a gem, I'll leave a comment when that happens.