### PR TITLE
fixes #15641 - create migration_state file in correct dir [deb]

### DIFF
--- a/debian/jessie/foreman-proxy/rules
+++ b/debian/jessie/foreman-proxy/rules
@@ -12,7 +12,7 @@
 build:
 	cp -a config foreman-proxy # dh_install doesn't rename things
 	rename 's/.example//' foreman-proxy/* foreman-proxy/settings.d/*
-	touch config/migration_state
+	touch foreman-proxy/migration_state
 	mv Gemfile Gemfile.in
 	rm -f bundler.d/development.rb bundler.d/test.rb bundler.d/windows.rb
 	dh $@

--- a/debian/trusty/foreman-proxy/rules
+++ b/debian/trusty/foreman-proxy/rules
@@ -12,7 +12,7 @@
 build:
 	cp -a config foreman-proxy # dh_install doesn't rename things
 	rename 's/.example//' foreman-proxy/* foreman-proxy/settings.d/*
-	touch config/migration_state
+	touch foreman-proxy/migration_state
 	mv Gemfile Gemfile.in
 	rm -f bundler.d/development.rb bundler.d/test.rb bundler.d/windows.rb
 	dh $@

--- a/debian/xenial/foreman-proxy/rules
+++ b/debian/xenial/foreman-proxy/rules
@@ -12,7 +12,7 @@
 build:
 	cp -a config foreman-proxy # dh_install doesn't rename things
 	rename 's/.example//' foreman-proxy/* foreman-proxy/settings.d/*
-	touch config/migration_state
+	touch foreman-proxy/migration_state
 	mv Gemfile Gemfile.in
 	rm -f bundler.d/development.rb bundler.d/test.rb bundler.d/windows.rb
 	dh $@


### PR DESCRIPTION
The file's entirely missing from the package (/etc/foreman-proxy/migration_state) at the moment, since 38a2776.