### PR TITLE
foreman-proxy: recommend ruby-libvirt (DEB)

### DIFF
--- a/debian/jessie/foreman-proxy/control
+++ b/debian/jessie/foreman-proxy/control
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/theforeman/smart-proxy
 Package: foreman-proxy
 Architecture: all
 Depends: ruby | ruby-interpreter, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext
-Recommends: sudo, wget, ping, ruby-gssapi, ruby-rubyipmi (>= 0.9.2), ruby-rkerberos (>= 0.1.1), foreman-debug
+Recommends: sudo, wget, ping, ruby-gssapi, ruby-rubyipmi (>= 0.9.2), ruby-rkerberos (>= 0.1.1), ruby-libvirt (>= 0.6.0), foreman-debug
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems
  like DNS, DHCP, TFTP, and Puppet.

--- a/debian/trusty/foreman-proxy/control
+++ b/debian/trusty/foreman-proxy/control
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/theforeman/smart-proxy
 Package: foreman-proxy
 Architecture: all
 Depends: ruby | ruby-interpreter, rake, ruby-sinatra, ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext
-Recommends: sudo, wget, ping, ruby-gssapi, ruby-rubyipmi (>= 0.9.2), ruby-rkerberos (>= 0.1.1), foreman-debug
+Recommends: sudo, wget, ping, ruby-gssapi, ruby-rubyipmi (>= 0.9.2), ruby-rkerberos (>= 0.1.1), ruby-libvirt (>= 0.6.0), foreman-debug
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems
  like DNS, DHCP, TFTP, and Puppet.

--- a/debian/xenial/foreman-proxy/control
+++ b/debian/xenial/foreman-proxy/control
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/theforeman/smart-proxy
 Package: foreman-proxy
 Architecture: all
 Depends: ruby | ruby-interpreter, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext
-Recommends: sudo, wget, ping, ruby-gssapi, ruby-rubyipmi (>= 0.9.2), ruby-rkerberos (>= 0.1.1), foreman-debug
+Recommends: sudo, wget, ping, ruby-gssapi, ruby-rubyipmi (>= 0.9.2), ruby-rkerberos (>= 0.1.1), ruby-libvirt (>= 0.6.0), foreman-debug
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems
  like DNS, DHCP, TFTP, and Puppet.


### PR DESCRIPTION
theforeman/smart-proxy@6798dc5 brought in ruby-libvirt and theforeman/smart-proxy@daeafa9 brought in the version constraint.

I'd like to see this also in 1.12.