### PR TITLE
core package: recommend python-minimal (DEB)

### DIFF
--- a/debian/jessie/foreman/control
+++ b/debian/jessie/foreman/control
@@ -15,7 +15,7 @@ Priority: extra
 Depends: ruby2.1, bundler (>= 1.3), zlib1g-dev,
          ruby2.1-dev, build-essential,
          rake (>=0.8.4), ${misc:Depends}
-Recommends: foreman-proxy, foreman-debug
+Recommends: foreman-proxy, foreman-debug, python-minimal
 Conflicts: ruby-activerecord-deprecated-finders
 Description: Systems management web interface
  Foreman is aimed to be a single address for all machines life cycle management.

--- a/debian/trusty/foreman/control
+++ b/debian/trusty/foreman/control
@@ -15,7 +15,7 @@ Priority: extra
 Depends: ruby2.0, bundler (>= 1.3), ruby2.0-dev,
          zlib1g-dev, build-essential,
          rake (>=0.8.4), ${misc:Depends}
-Recommends: foreman-proxy, foreman-debug
+Recommends: foreman-proxy, foreman-debug, python-minimal
 Description: Systems management web interface
  Foreman is aimed to be a single address for all machines life cycle management.
  .

--- a/debian/xenial/foreman/control
+++ b/debian/xenial/foreman/control
@@ -15,7 +15,7 @@ Priority: extra
 Depends: ruby2.3, bundler (>= 1.3), zlib1g-dev,
          ruby2.3-dev, build-essential,
          rake (>=0.8.4), ${misc:Depends}
-Recommends: foreman-proxy, foreman-debug
+Recommends: foreman-proxy, foreman-debug, python-minimal
 Conflicts: ruby-activerecord-deprecated-finders
 Description: Systems management web interface
  Foreman is aimed to be a single address for all machines life cycle management.


### PR DESCRIPTION
otherwise opening a VM console will fail, as the web socket opening is python based:
```
root@xxx:~# cat /usr/share/foreman/extras/noVNC/websockify.py
#!/usr/bin/python

import websockify

websockify.websocketproxy.websockify_init()
```
I'd like to see this also in 1.12.