### PR TITLE
Release foreman_remote_execution 1.0 (DEB)

### DIFF
--- a/plugins/ruby-foreman-remote-execution/debian/changelog
+++ b/plugins/ruby-foreman-remote-execution/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution (1.0.0-1) stable; urgency=low
+
+  * 1.0.0 released
+
+ -- Stephen Benjamin <stephen@redhat.com>  Mon, 18 Jul 2016 11:38:13 -0400
+
 ruby-foreman-remote-execution (0.3.2-1) stable; urgency=low
 
   * 0.3.2 released

--- a/plugins/ruby-foreman-remote-execution/debian/control
+++ b/plugins/ruby-foreman-remote-execution/debian/control
@@ -2,12 +2,12 @@ Source: ruby-foreman-remote-execution
 Section: ruby
 Priority: extra
 Maintainer: Stephen Benjamin <stephen@redhat.com>
-Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.11.0~rc1), foreman (>= 1.11.0~rc1), foreman-sqlite3 (>= 1.11.0~rc1), ruby-foreman-tasks (>= 0.7.11), ruby-foreman-tasks (<< 0.8.0), ruby-foreman-deface
+Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.12.0~rc1), foreman (>= 1.12.0~rc1), foreman-sqlite3 (>= 1.12.0~rc1), ruby-foreman-tasks (>= 0.7.11), ruby-foreman-tasks (<< 0.8.0), ruby-foreman-deface
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_remote_execution
 
 Package: ruby-foreman-remote-execution
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.11.0~rc1), ruby-foreman-tasks (>= 0.7.11), ruby-foreman-tasks (<< 0.8.0), ruby-foreman-deface
+Depends: ${misc:Depends}, bundler, foreman (>= 1.12.0~rc1), ruby-foreman-tasks (>= 0.7.11), ruby-foreman-tasks (<< 0.8.0), ruby-foreman-deface
 Description: Foreman Remote Execution Plugin
   A plugin bringing remote execution to the Foreman, completing the config management functionality with remote management functionality

--- a/plugins/ruby-foreman-remote-execution/debian/gem.list
+++ b/plugins/ruby-foreman-remote-execution/debian/gem.list
@@ -1,2 +1,2 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_remote_execution-0.3.2.gem"
+GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.0.0.gem"

--- a/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
+++ b/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
@@ -1,1 +1,1 @@
-gem 'foreman_remote_execution', '0.3.2'
+gem 'foreman_remote_execution', '1.0.0'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.12
* [ ] 1.11
* [ ] 1.10