### PR TITLE
adding qpid copr repo for el6 repoclosure

### DIFF
--- a/repoclosure/yum_el6.conf
+++ b/repoclosure/yum_el6.conf
@@ -82,3 +82,7 @@ baseurl=http://yum.theforeman.org/releases/1.5/el6/$basearch
 [el6-foreman-1.6]
 name=Foreman 1.6 EL6
 baseurl=http://yum.theforeman.org/releases/1.6/el6/$basearch
+
+[el6-copr-qpid]
+name=Copr Qpid EL6
+baseurl=https://copr-be.cloud.fedoraproject.org/results/@qpid/qpid/epel-6-$basearch/


### PR DESCRIPTION
we are now able to use qpid from upstream in epel for el7
and from this copr repo for el6, so we are switching over to it