### PR TITLE
add_npm_package script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 rel-eng/custom/*.pyc
 rel-eng/custom/__pycache__
 mock/site-defaults.cfg
+node_modules

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ You'll also need an alias `kojikat` to point to:
 1. Ensure the source file (e.g. the .gem) is in the spec directory and run
    `git annex add foo.gem`
 1. Update rel-eng/tito.props and add to the appropriate whitelists
-1. Update comps/comps-foreman-\*.xml
-2. Run ./comps_doc.sh to automatically add docs
+1. Update comps/comps-foreman-\*.xml by running `./add_to_comps.rb comps/compsfile.xml rubygem-example`
+2. Run `./comps_doc.sh` to automatically add doc packages
 1. Commit the changes
   1. `git add -A`
   1. `git commit -m "Add NAME package"`
@@ -143,29 +143,17 @@ Otherwise we will bundle the dependencies. You can read an explanation of how we
 
 In both cases:
 
-1. Install npm2rpm: `npm install -g npm2rpm`
-1. Checkout a branch 'rpm/example-version' or similar (the rpm/ part is important)
-  * `mkdir nodejs-example`
-  * `cd nodejs-example`
 1. Generate the spec and download the sources automatically with npm2rpm.
-  * For packages without dependencies - `npm2rpm -n example -v version -s single`
-  * For packages that bundle dependencies - `npm2rpm -n example -v version -s bundle`
-1. This should have created two directories npm2rpm/SPECS and npm2rpm/SOURCES.
-   Move the content of them both to your nodejs-example directory and remove the npm2rpm folder.
-  * mv npm2rpm/SPECS/\* .
-  * mv npm2rpm/SOURCES/\* .
-  * rm -r npm2rpm
-1. If building a package with bundled dependencies, add the binary with the npm cache directly to git.
-  * `git add example-version-registry.npmjs.org.tgz`
-1. `git-annex` the rest of the sources
-  * `git annex add *.tgz`
-1. Update rel-eng/tito.props and add to the whitelists (nonscl and Fedora)
-1. Update comps/comps-foreman-\*.xml
+  * For packages without dependencies - `./add_npm_package.sh example version single`
+  * For packages that bundle dependencies - `./add_npm_package.sh example version bundle`
+1. This should have created a nodejs-example directory with the packages needed, the spec,
+and the cache if it's a bundled package. It should have modified tito.props, comps and
+added everything to git.
+1. Update the spec if needed (e.g: for peer dependencies)
 1. Commit the changes
-  1. `git add -A`
   1. `git commit -m "Add NAME package"`
-1. Follow the "test a package" section above until it builds for all
-   targeted platforms and required non-SCL modes.
+1. Follow the "test a package" section above until it builds for all targeted platforms and
+required non-SCL modes.
 1. Submit a pull request against `rpm/develop`
 
 ## HOWTO: update a package

--- a/add_npm_package.sh
+++ b/add_npm_package.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+display_usage() {
+  echo "This script adds a new npm package based on the module found on npmjs.org"
+  echo -e "\nUsage:\n$0 NPM_MODULE_NAME VERSION STRATEGY \n"
+  exit 1
+}
+
+if [ $# -ne 3 ]; then
+  display_usage
+fi
+
+program_exists() {
+  which "$@" &> /dev/null;
+}
+
+if !(program_exists crudini); then
+  echo "crudini is not installed - you can install it with"
+  echo "sudo yum install crudini"
+  exit 1
+fi
+
+if !(program_exists npm2rpm); then
+  echo "npm2rpm is not installed - you can install it with:"
+  echo "sudo npm install npm2rpm"
+  exit 1
+fi
+
+echo -n "Making directory..."
+mkdir nodejs-$1
+echo "FINISHED"
+echo -n "Creating specs and downloading sources..."
+npm2rpm -n $1 -v $2 -s $3
+echo "FINISHED"
+echo -n "Copying specs..."
+cp npm2rpm/SPECS/* nodejs-$1
+echo "FINISHED"
+echo -n "Copying sources..."
+cp npm2rpm/SOURCES/* nodejs-$1
+echo "FINISHED"
+rm -r npm2rpm
+echo -n "Setting tito props..."
+# Get tito.props whitelists and add node package
+original_locale=$LC_COLLATE
+export LC_COLLATE=en_GB
+el7whitelist=$(crudini --get rel-eng/tito.props foreman-nightly-nonscl-rhel7 whitelist)
+el7whitelist=$(echo "$el7whitelist nodejs-$1" | tr " " "\n" | sort)
+f24whitelist=$(crudini --get rel-eng/tito.props foreman-nightly-fedora24 whitelist)
+f24whitelist=$(echo "$f24whitelist nodejs-$1" | tr " " "\n" | sort)
+crudini --set rel-eng/tito.props foreman-nightly-nonscl-rhel7 whitelist "$el7whitelist"
+crudini --set rel-eng/tito.props foreman-nightly-fedora24 whitelist "$f24whitelist"
+export LC_COLLATE=$original_locale
+git add rel-eng/tito.props
+echo "FINISHED"
+cd nodejs-$1
+if [ "$3" = "bundle" ]; then
+  echo -e "Adding npmjs cache binary... - "
+  git add *-registry.npmjs.org.tgz
+  echo "FINISHED"
+fi
+echo -e "Annexing sources... - "
+git annex add *.tgz
+echo "FINISHED"
+echo -e "Adding spec to git... - "
+git add *.spec
+echo "FINISHED"
+echo -e "Updating comps... - "
+cd ..
+./add_to_comps.rb comps/comps-foreman-fedora24.xml nodejs-$1
+./add_to_comps.rb comps/comps-foreman-rhel7.xml nodejs-$1 nonscl
+./comps_doc.sh
+git add comps/
+echo "FINISHED"
+echo "Done! Now commit and send your pull request."

--- a/add_to_comps.rb
+++ b/add_to_comps.rb
@@ -1,0 +1,83 @@
+#!/usr/bin/env ruby
+require 'nokogiri'
+
+def print_usage
+  usage = <<-USAGE
+add_to_comps - adds packagereqs for a package to a comps xml file
+
+Usage ./add_to_comps.rb comps-file package-name [nonscl]
+
+Examples:
+  ./add_to_comps.rb comps/comps-foreman-rhel7.xml nodejs-example
+  ./add_to_comps.rb comps/comps-foreman-rhel7.xml nodejs-example nonscl
+
+Return codes:
+
+  0 - successfully added
+  1 - package is already present
+  2 - wrong arguments
+USAGE
+  puts usage
+end
+
+def find_packagereq(comps, package_name)
+  comps.xpath('//packagelist/packagereq').select { |s| s.text == package_name }
+end
+
+# Gets subset of packagereqs that are not -docs nor comments
+def get_packagereqs(packagelist)
+  relevant = []
+  packagelist.children.each do |packagereq|
+    # Break as soon as you find a comment which means start
+    # of nonscl packages or start of -doc packages
+    break if packagereq.class == Nokogiri::XML::Comment
+    relevant << packagereq
+    packagereq.unlink
+  end
+  relevant
+end
+
+def remove_nonscl_comment(packagelist)
+  nonscl_comment = packagelist.children.first
+  nonscl_comment.unlink
+  nonscl_comment
+end
+
+def prepend_packagereqs(packagelist, packagereqs)
+  packagereqs.each do |packagereq|
+    packagelist.children.before(packagereq)
+  end
+end
+
+if ![2, 3].include?(ARGV.length) ||
+    ARGV.length == 3 && ARGV[2] != 'nonscl'
+  print_usage
+  exit(2)
+end
+
+comps = Nokogiri::XML(File.open(ARGV[0])) { |config| config.noblanks }
+exit(1) unless find_packagereq(comps, ARGV[1]) == []
+packagelist = comps.xpath("//packagelist").first
+new_packagereq = Nokogiri::XML(
+  "<packagereq type='default'>#{ARGV[1]}</packagereq>"
+).children.first
+if ARGV[2] == 'nonscl'
+  scl_packagereqs = get_packagereqs(packagelist)
+  scl_packagereqs.sort! { |x,y| y.text <=> x.text }
+  nonscl_comment = remove_nonscl_comment(packagelist)
+  nonscl_packagereqs = get_packagereqs(packagelist)
+  # At this point, only -doc packages remain
+  nonscl_packagereqs << new_packagereq
+  nonscl_packagereqs.sort! { |x,y| y.text <=> x.text }
+  prepend_packagereqs(packagelist, nonscl_packagereqs)
+  packagelist.children.before(nonscl_comment)
+  prepend_packagereqs(packagelist, scl_packagereqs)
+else
+  packagereqs = get_packagereqs(packagelist)
+  packagereqs << new_packagereq
+  packagereqs.sort! { |x,y| y.text <=> x.text }
+  prepend_packagereqs(packagelist, packagereqs)
+end
+
+File.write(ARGV[0], comps.to_xml)
+exit 0

--- a/comps/comps-foreman-fedora24.xml
+++ b/comps/comps-foreman-fedora24.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE comps PUBLIC "-//Red Hat, Inc.//DTD Comps info//EN" "comps.dtd">
-
 <comps>
   <group>
     <id>foreman</id>
@@ -16,6 +15,7 @@
       <packagereq type="default">foreman-debug</packagereq>
       <packagereq type="default">foreman-ec2</packagereq>
       <packagereq type="default">foreman-gce</packagereq>
+      <packagereq type="default">foreman-installer</packagereq>
       <packagereq type="default">foreman-libvirt</packagereq>
       <packagereq type="default">foreman-mysql2</packagereq>
       <packagereq type="default">foreman-openstack</packagereq>
@@ -23,16 +23,12 @@
       <packagereq type="default">foreman-plugin</packagereq>
       <packagereq type="default">foreman-postgresql</packagereq>
       <packagereq type="default">foreman-proxy</packagereq>
+      <packagereq type="default">foreman-proxy-selinux</packagereq>
       <packagereq type="default">foreman-rackspace</packagereq>
       <packagereq type="default">foreman-release</packagereq>
       <packagereq type="default">foreman-selinux</packagereq>
-      <packagereq type="default">foreman-proxy-selinux</packagereq>
       <packagereq type="default">foreman-sqlite</packagereq>
       <packagereq type="default">foreman-vmware</packagereq>
-
-      <packagereq type="default">foreman-installer</packagereq>
-      <packagereq type="default">rubygem-puppet-strings</packagereq>
-
       <packagereq type="default">nodejs-babel-core</packagereq>
       <packagereq type="default">nodejs-babel-loader</packagereq>
       <packagereq type="default">nodejs-babel-preset-es2015</packagereq>
@@ -45,10 +41,10 @@
       <packagereq type="default">nodejs-extract-text-webpack-plugin</packagereq>
       <packagereq type="default">nodejs-file-loader</packagereq>
       <packagereq type="default">nodejs-ipaddr.js</packagereq>
+      <packagereq type="default">nodejs-jquery</packagereq>
       <packagereq type="default">nodejs-jquery-flot</packagereq>
       <packagereq type="default">nodejs-jquery-ujs</packagereq>
       <packagereq type="default">nodejs-jquery.cookie</packagereq>
-      <packagereq type="default">nodejs-jquery</packagereq>
       <packagereq type="default">nodejs-jstz</packagereq>
       <packagereq type="default">nodejs-lodash</packagereq>
       <packagereq type="default">nodejs-select2</packagereq>
@@ -56,7 +52,6 @@
       <packagereq type="default">nodejs-style-loader</packagereq>
       <packagereq type="default">nodejs-url-loader</packagereq>
       <packagereq type="default">nodejs-webpack</packagereq>
-
       <packagereq type="default">rubygem-ace-rails-ap</packagereq>
       <packagereq type="default">rubygem-activerecord-session_store</packagereq>
       <packagereq type="default">rubygem-apipie-bindings</packagereq>
@@ -84,11 +79,11 @@
       <packagereq type="default">rubygem-gridster-rails</packagereq>
       <packagereq type="default">rubygem-hammer_cli</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman</packagereq>
-      <packagereq type="default">rubygem-hirb-unicode-steakknife</packagereq>
       <packagereq type="default">rubygem-hirb</packagereq>
-      <packagereq type="default">rubygem-jquery_pwstrength_bootstrap_4</packagereq>
+      <packagereq type="default">rubygem-hirb-unicode-steakknife</packagereq>
       <packagereq type="default">rubygem-jquery-turbolinks</packagereq>
       <packagereq type="default">rubygem-jquery-ui-rails</packagereq>
+      <packagereq type="default">rubygem-jquery_pwstrength_bootstrap_4</packagereq>
       <packagereq type="default">rubygem-jwt</packagereq>
       <packagereq type="default">rubygem-kafo</packagereq>
       <packagereq type="default">rubygem-kafo_parsers</packagereq>
@@ -99,6 +94,7 @@
       <packagereq type="default">rubygem-po_to_json</packagereq>
       <packagereq type="default">rubygem-powerbar</packagereq>
       <packagereq type="default">rubygem-protected_attributes</packagereq>
+      <packagereq type="default">rubygem-puppet-strings</packagereq>
       <packagereq type="default">rubygem-quiet_assets</packagereq>
       <packagereq type="default">rubygem-rack-jsonp</packagereq>
       <packagereq type="default">rubygem-rails-i18n</packagereq>
@@ -117,7 +113,6 @@
       <packagereq type="default">rubygem-validates_lengths_from_database</packagereq>
       <packagereq type="default">rubygem-webpack-rails</packagereq>
       <packagereq type="default">rubygem-x-editable-rails</packagereq>
-
       <!--
         Do not edit this section manually and use ./comps_doc.sh script
       -->
@@ -204,7 +199,6 @@
       <packagereq type="default">rubygem-webpack-rails-doc</packagereq>
       <packagereq type="default">rubygem-x-editable-rails-doc</packagereq>
       <!--RGD-END-->
-
     </packagelist>
   </group>
 </comps>

--- a/comps/comps-foreman-plugins-fedora24.xml
+++ b/comps/comps-foreman-plugins-fedora24.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE comps PUBLIC "-//Red Hat, Inc.//DTD Comps info//EN" "comps.dtd">
-
 <comps>
   <group>
     <id>foreman-plugins</id>
@@ -8,8 +7,25 @@
     <description>Plugin packages for the Foreman</description>
     <uservisible>true</uservisible>
     <packagelist>
+      <packagereq type="default">rubygem-algebrick</packagereq>
+      <packagereq type="default">rubygem-angular-rails-templates</packagereq>
+      <packagereq type="default">rubygem-apipie-params</packagereq>
+      <packagereq type="default">rubygem-azure</packagereq>
+      <packagereq type="default">rubygem-azure-core</packagereq>
       <packagereq type="default">rubygem-bastion</packagereq>
       <packagereq type="default">rubygem-bastion-devel</packagereq>
+      <packagereq type="default">rubygem-bootstrap-datepicker-rails</packagereq>
+      <packagereq type="default">rubygem-chef-api</packagereq>
+      <packagereq type="default">rubygem-colorize</packagereq>
+      <packagereq type="default">rubygem-commonjs</packagereq>
+      <packagereq type="default">rubygem-concurrent-ruby-edge</packagereq>
+      <packagereq type="default">rubygem-deface</packagereq>
+      <packagereq type="default">rubygem-docker-api</packagereq>
+      <packagereq type="default">rubygem-dynflow</packagereq>
+      <packagereq type="default">rubygem-faraday_middleware</packagereq>
+      <packagereq type="default">rubygem-fog-azure</packagereq>
+      <packagereq type="default">rubygem-foreman-tasks</packagereq>
+      <packagereq type="default">rubygem-foreman-tasks-core</packagereq>
       <packagereq type="default">rubygem-foreman_abrt</packagereq>
       <packagereq type="default">rubygem-foreman_ansible</packagereq>
       <packagereq type="default">rubygem-foreman_azure</packagereq>
@@ -19,13 +35,11 @@
       <packagereq type="default">rubygem-foreman_column_view</packagereq>
       <packagereq type="default">rubygem-foreman_custom_parameters</packagereq>
       <packagereq type="default">rubygem-foreman_default_hostgroup</packagereq>
-      <packagereq type="default">rubygem-foreman_discovery</packagereq>
       <packagereq type="default">rubygem-foreman_dhcp_browser</packagereq>
       <packagereq type="default">rubygem-foreman_digitalocean</packagereq>
+      <packagereq type="default">rubygem-foreman_discovery</packagereq>
       <packagereq type="default">rubygem-foreman_docker</packagereq>
       <packagereq type="default">rubygem-foreman_expire_hosts</packagereq>
-      <packagereq type="default">rubygem-foreman-tasks</packagereq>
-      <packagereq type="default">rubygem-foreman-tasks-core</packagereq>
       <packagereq type="default">rubygem-foreman_graphite</packagereq>
       <packagereq type="default">rubygem-foreman_hooks</packagereq>
       <packagereq type="default">rubygem-foreman_host_extra_validator</packagereq>
@@ -45,6 +59,7 @@
       <packagereq type="default">rubygem-foreman_snapshot</packagereq>
       <packagereq type="default">rubygem-foreman_templates</packagereq>
       <packagereq type="default">rubygem-foreman_xen</packagereq>
+      <packagereq type="default">rubygem-graphite-api</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_admin</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_bootdisk</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_discovery</packagereq>
@@ -52,9 +67,15 @@
       <packagereq type="default">rubygem-hammer_cli_foreman_openscap</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_remote_execution</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_salt</packagereq>
+      <packagereq type="default">rubygem-hammer_cli_foreman_ssh</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_tasks</packagereq>
+      <packagereq type="default">rubygem-infoblox</packagereq>
+      <packagereq type="default">rubygem-logify</packagereq>
+      <packagereq type="default">rubygem-newt</packagereq>
       <packagereq type="default">rubygem-ovirt_provision_plugin</packagereq>
       <packagereq type="default">rubygem-puppetdb_foreman</packagereq>
+      <packagereq type="default">rubygem-route53</packagereq>
+      <packagereq type="default">rubygem-satyr</packagereq>
       <packagereq type="default">rubygem-smart_proxy_abrt</packagereq>
       <packagereq type="default">rubygem-smart_proxy_chef</packagereq>
       <packagereq type="default">rubygem-smart_proxy_dhcp_infoblox</packagereq>
@@ -70,33 +91,8 @@
       <packagereq type="default">rubygem-smart_proxy_pulp</packagereq>
       <packagereq type="default">rubygem-smart_proxy_remote_execution_ssh</packagereq>
       <packagereq type="default">rubygem-smart_proxy_salt</packagereq>
-
-      <packagereq type="default">rubygem-algebrick</packagereq>
-      <packagereq type="default">rubygem-angular-rails-templates</packagereq>
-      <packagereq type="default">rubygem-apipie-params</packagereq>
-      <packagereq type="default">rubygem-azure</packagereq>
-      <packagereq type="default">rubygem-azure-core</packagereq>
-      <packagereq type="default">rubygem-bootstrap-datepicker-rails</packagereq>
-      <packagereq type="default">rubygem-chef-api</packagereq>
-      <packagereq type="default">rubygem-colorize</packagereq>
-      <packagereq type="default">rubygem-commonjs</packagereq>
-      <packagereq type="default">rubygem-concurrent-ruby-edge</packagereq>
-      <packagereq type="default">rubygem-deface</packagereq>
-      <packagereq type="default">rubygem-docker-api</packagereq>
-      <packagereq type="default">rubygem-dynflow</packagereq>
-      <packagereq type="default">rubygem-faraday_middleware</packagereq>
-      <packagereq type="default">rubygem-fog-azure</packagereq>
-      <packagereq type="default">rubygem-graphite-api</packagereq>
-      <packagereq type="default">rubygem-hammer_cli_foreman_ssh</packagereq>
-      <packagereq type="default">rubygem-infoblox</packagereq>
-      <packagereq type="default">rubygem-logify</packagereq>
-      <packagereq type="default">rubygem-newt</packagereq>
-      <packagereq type="default">rubygem-route53</packagereq>
-      <packagereq type="default">rubygem-satyr</packagereq>
       <packagereq type="default">rubygem-wicked</packagereq>
       <packagereq type="default">rubygem-zscheduler</packagereq>
-
-
       <!--
         Do not edit this section manually and use ./comps_doc.sh script
       -->
@@ -186,7 +182,6 @@
       <packagereq type="default">rubygem-wicked-doc</packagereq>
       <packagereq type="default">rubygem-zscheduler-doc</packagereq>
       <!--RGD-END-->
-
     </packagelist>
   </group>
 </comps>

--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE comps PUBLIC "-//Red Hat, Inc.//DTD Comps info//EN" "comps.dtd">
-
 <comps>
   <group>
     <id>foreman-plugins</id>
@@ -8,8 +7,61 @@
     <description>Plugin packages for the Foreman</description>
     <uservisible>true</uservisible>
     <packagelist>
+      <packagereq type="default">ipxe-bootimgs</packagereq>
+      <packagereq type="default">rubygem-algebrick</packagereq>
+      <packagereq type="default">rubygem-apipie-params</packagereq>
+      <packagereq type="default">rubygem-chef-api</packagereq>
+      <packagereq type="default">rubygem-concurrent-ruby</packagereq>
+      <packagereq type="default">rubygem-concurrent-ruby-edge</packagereq>
+      <packagereq type="default">rubygem-dynflow</packagereq>
+      <packagereq type="default">rubygem-faraday</packagereq>
+      <packagereq type="default">rubygem-faraday_middleware</packagereq>
+      <packagereq type="default">rubygem-fast_gettext</packagereq>
+      <packagereq type="default">rubygem-foreman_scap_client</packagereq>
+      <packagereq type="default">rubygem-infoblox</packagereq>
+      <packagereq type="default">rubygem-logify</packagereq>
+      <packagereq type="default">rubygem-multipart-post</packagereq>
+      <packagereq type="default">rubygem-mysql2</packagereq>
+      <packagereq type="default">rubygem-newt</packagereq>
+      <packagereq type="default">rubygem-openscap</packagereq>
+      <packagereq type="default">rubygem-route53</packagereq>
+      <packagereq type="default">rubygem-ruby-hmac</packagereq>
+      <packagereq type="default">rubygem-satyr</packagereq>
+      <packagereq type="default">rubygem-sequel</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_abrt</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_chef</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_dhcp_infoblox</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_discovery</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_discovery_image</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_dns_infoblox</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_dns_powerdns</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_dns_route53</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_dynflow</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_monitoring</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_openscap</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_pulp</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_remote_execution_ssh</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_salt</packagereq>
+      <packagereq type="default">tfm-rubygem-algebrick</packagereq>
+      <packagereq type="default">tfm-rubygem-angular-rails-templates</packagereq>
+      <packagereq type="default">tfm-rubygem-apipie-params</packagereq>
+      <packagereq type="default">tfm-rubygem-azure</packagereq>
+      <packagereq type="default">tfm-rubygem-azure-core</packagereq>
       <packagereq type="default">tfm-rubygem-bastion</packagereq>
       <packagereq type="default">tfm-rubygem-bastion-devel</packagereq>
+      <packagereq type="default">tfm-rubygem-bootstrap-datepicker-rails</packagereq>
+      <packagereq type="default">tfm-rubygem-colorize</packagereq>
+      <packagereq type="default">tfm-rubygem-commonjs</packagereq>
+      <packagereq type="default">tfm-rubygem-concurrent-ruby-edge</packagereq>
+      <packagereq type="default">tfm-rubygem-deface</packagereq>
+      <packagereq type="default">tfm-rubygem-diffy</packagereq>
+      <packagereq type="default">tfm-rubygem-docker-api</packagereq>
+      <packagereq type="default">tfm-rubygem-dynflow</packagereq>
+      <packagereq type="default">tfm-rubygem-faraday_middleware</packagereq>
+      <packagereq type="default">tfm-rubygem-ffi</packagereq>
+      <packagereq type="default">tfm-rubygem-fog-azure</packagereq>
+      <packagereq type="default">tfm-rubygem-foreman-tasks</packagereq>
+      <packagereq type="default">tfm-rubygem-foreman-tasks-core</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_abrt</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_ansible</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_azure</packagereq>
@@ -40,10 +92,10 @@
       <packagereq type="default">tfm-rubygem-foreman_salt</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_setup</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_snapshot</packagereq>
-      <packagereq type="default">tfm-rubygem-foreman-tasks</packagereq>
-      <packagereq type="default">tfm-rubygem-foreman-tasks-core</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_templates</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_xen</packagereq>
+      <packagereq type="default">tfm-rubygem-git</packagereq>
+      <packagereq type="default">tfm-rubygem-graphite-api</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_admin</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_bootdisk</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_discovery</packagereq>
@@ -53,75 +105,20 @@
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_salt</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_ssh</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_tasks</packagereq>
-      <packagereq type="default">tfm-rubygem-ovirt_provision_plugin</packagereq>
-      <packagereq type="default">tfm-rubygem-parse-cron</packagereq>
-      <packagereq type="default">tfm-rubygem-puppetdb_foreman</packagereq>
-      <packagereq type="default">tfm-rubygem-smart_proxy_dynflow_core</packagereq>
-      <packagereq type="default">rubygem-fast_gettext</packagereq>
-      <packagereq type="default">rubygem-foreman_scap_client</packagereq>
-      <packagereq type="default">rubygem-newt</packagereq>
-      <packagereq type="default">rubygem-smart_proxy_abrt</packagereq>
-      <packagereq type="default">rubygem-smart_proxy_chef</packagereq>
-      <packagereq type="default">rubygem-smart_proxy_dhcp_infoblox</packagereq>
-      <packagereq type="default">rubygem-smart_proxy_discovery</packagereq>
-      <packagereq type="default">rubygem-smart_proxy_discovery_image</packagereq>
-      <packagereq type="default">rubygem-smart_proxy_dns_infoblox</packagereq>
-      <packagereq type="default">rubygem-smart_proxy_dns_powerdns</packagereq>
-      <packagereq type="default">rubygem-smart_proxy_dns_route53</packagereq>
-      <packagereq type="default">rubygem-smart_proxy_dynflow</packagereq>
-      <packagereq type="default">rubygem-smart_proxy_monitoring</packagereq>
-      <packagereq type="default">rubygem-smart_proxy_openscap</packagereq>
-      <packagereq type="default">rubygem-smart_proxy_pulp</packagereq>
-      <packagereq type="default">rubygem-smart_proxy_remote_execution_ssh</packagereq>
-      <packagereq type="default">rubygem-smart_proxy_salt</packagereq>
-
-      <packagereq type="default">ipxe-bootimgs</packagereq>
-      <packagereq type="default">tfm-rubygem-algebrick</packagereq>
-      <packagereq type="default">tfm-rubygem-azure</packagereq>
-      <packagereq type="default">tfm-rubygem-azure-core</packagereq>
-      <packagereq type="default">tfm-rubygem-angular-rails-templates</packagereq>
-      <packagereq type="default">tfm-rubygem-apipie-params</packagereq>
-      <packagereq type="default">tfm-rubygem-bootstrap-datepicker-rails</packagereq>
-      <packagereq type="default">tfm-rubygem-colorize</packagereq>
-      <packagereq type="default">tfm-rubygem-commonjs</packagereq>
-      <packagereq type="default">tfm-rubygem-concurrent-ruby-edge</packagereq>
-      <packagereq type="default">tfm-rubygem-deface</packagereq>
-      <packagereq type="default">tfm-rubygem-diffy</packagereq>
-      <packagereq type="default">tfm-rubygem-docker-api</packagereq>
-      <packagereq type="default">tfm-rubygem-dynflow</packagereq>
-      <packagereq type="default">tfm-rubygem-faraday_middleware</packagereq>
-      <packagereq type="default">tfm-rubygem-fog-azure</packagereq>
-      <packagereq type="default">tfm-rubygem-ffi</packagereq>
-      <packagereq type="default">tfm-rubygem-git</packagereq>
-      <packagereq type="default">tfm-rubygem-graphite-api</packagereq>
       <packagereq type="default">tfm-rubygem-jgrep</packagereq>
       <packagereq type="default">tfm-rubygem-macaddr</packagereq>
       <packagereq type="default">tfm-rubygem-net-ssh-gateway</packagereq>
       <packagereq type="default">tfm-rubygem-net-ssh-multi</packagereq>
       <packagereq type="default">tfm-rubygem-opennebula</packagereq>
+      <packagereq type="default">tfm-rubygem-ovirt_provision_plugin</packagereq>
+      <packagereq type="default">tfm-rubygem-parse-cron</packagereq>
+      <packagereq type="default">tfm-rubygem-puppetdb_foreman</packagereq>
       <packagereq type="default">tfm-rubygem-safe_yaml</packagereq>
+      <packagereq type="default">tfm-rubygem-smart_proxy_dynflow_core</packagereq>
       <packagereq type="default">tfm-rubygem-systemu</packagereq>
       <packagereq type="default">tfm-rubygem-uuid</packagereq>
       <packagereq type="default">tfm-rubygem-wicked</packagereq>
       <packagereq type="default">tfm-rubygem-zscheduler</packagereq>
-      <packagereq type="default">rubygem-algebrick</packagereq>
-      <packagereq type="default">rubygem-apipie-params</packagereq>
-      <packagereq type="default">rubygem-chef-api</packagereq>
-      <packagereq type="default">rubygem-concurrent-ruby</packagereq>
-      <packagereq type="default">rubygem-concurrent-ruby-edge</packagereq>
-      <packagereq type="default">rubygem-dynflow</packagereq>
-      <packagereq type="default">rubygem-faraday</packagereq>
-      <packagereq type="default">rubygem-faraday_middleware</packagereq>
-      <packagereq type="default">rubygem-infoblox</packagereq>
-      <packagereq type="default">rubygem-logify</packagereq>
-      <packagereq type="default">rubygem-multipart-post</packagereq>
-      <packagereq type="default">rubygem-mysql2</packagereq>
-      <packagereq type="default">rubygem-openscap</packagereq>
-      <packagereq type="default">rubygem-route53</packagereq>
-      <packagereq type="default">rubygem-ruby-hmac</packagereq>
-      <packagereq type="default">rubygem-satyr</packagereq>
-      <packagereq type="default">rubygem-sequel</packagereq>
-
       <!--
         Do not edit this section manually and use ./comps_doc.sh script
       -->
@@ -233,7 +230,6 @@
       <packagereq type="default">tfm-rubygem-wicked-doc</packagereq>
       <packagereq type="default">tfm-rubygem-zscheduler-doc</packagereq>
       <!--RGD-END-->
-
     </packagelist>
   </group>
 </comps>

--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE comps PUBLIC "-//Red Hat, Inc.//DTD Comps info//EN" "comps.dtd">
-
 <comps>
   <group>
     <id>foreman</id>
@@ -8,6 +7,8 @@
     <description>Packages for the Foreman</description>
     <uservisible>true</uservisible>
     <packagelist>
+      <packagereq type="default">centos-release-scl</packagereq>
+      <packagereq type="default">centos-release-scl-rh</packagereq>
       <packagereq type="default">foreman</packagereq>
       <packagereq type="default">foreman-assets</packagereq>
       <packagereq type="default">foreman-cli</packagereq>
@@ -23,33 +24,24 @@
       <packagereq type="default">foreman-plugin</packagereq>
       <packagereq type="default">foreman-postgresql</packagereq>
       <packagereq type="default">foreman-proxy</packagereq>
+      <packagereq type="default">foreman-proxy-selinux</packagereq>
       <packagereq type="default">foreman-rackspace</packagereq>
       <packagereq type="default">foreman-release</packagereq>
       <packagereq type="default">foreman-release-scl</packagereq>
       <packagereq type="default">foreman-selinux</packagereq>
-      <packagereq type="default">foreman-proxy-selinux</packagereq>
       <packagereq type="default">foreman-sqlite</packagereq>
       <packagereq type="default">foreman-vmware</packagereq>
-
       <packagereq type="default">tfm</packagereq>
       <packagereq type="default">tfm-build</packagereq>
-      <packagereq type="default">tfm-runtime</packagereq>
-      <packagereq type="default">tfm-runtime-assets</packagereq>
-      <packagereq type="default">tfm-scldevel</packagereq>
-
-      <packagereq type="default">centos-release-scl</packagereq>
-      <packagereq type="default">centos-release-scl-rh</packagereq>
-
       <packagereq type="default">tfm-mod_passenger</packagereq>
-
       <packagereq type="default">tfm-rubygem-ace-rails-ap</packagereq>
       <packagereq type="default">tfm-rubygem-activerecord-session_store</packagereq>
       <packagereq type="default">tfm-rubygem-addressable</packagereq>
       <packagereq type="default">tfm-rubygem-ancestry</packagereq>
       <packagereq type="default">tfm-rubygem-apipie-bindings</packagereq>
       <packagereq type="default">tfm-rubygem-apipie-rails</packagereq>
-      <packagereq type="default">tfm-rubygem-audited-activerecord</packagereq>
       <packagereq type="default">tfm-rubygem-audited</packagereq>
+      <packagereq type="default">tfm-rubygem-audited-activerecord</packagereq>
       <packagereq type="default">tfm-rubygem-autoparse</packagereq>
       <packagereq type="default">tfm-rubygem-autoprefixer-rails</packagereq>
       <packagereq type="default">tfm-rubygem-awesome_print</packagereq>
@@ -90,32 +82,32 @@
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman</packagereq>
       <packagereq type="default">tfm-rubygem-hashie</packagereq>
       <packagereq type="default">tfm-rubygem-highline</packagereq>
-      <packagereq type="default">tfm-rubygem-hirb-unicode-steakknife</packagereq>
       <packagereq type="default">tfm-rubygem-hirb</packagereq>
+      <packagereq type="default">tfm-rubygem-hirb-unicode-steakknife</packagereq>
       <packagereq type="default">tfm-rubygem-hoe</packagereq>
       <packagereq type="default">tfm-rubygem-http-cookie</packagereq>
       <packagereq type="default">tfm-rubygem-ipaddress</packagereq>
-      <packagereq type="default">tfm-rubygem-jquery_pwstrength_bootstrap_4</packagereq>
       <packagereq type="default">tfm-rubygem-jquery-turbolinks</packagereq>
       <packagereq type="default">tfm-rubygem-jquery-ui-rails</packagereq>
+      <packagereq type="default">tfm-rubygem-jquery_pwstrength_bootstrap_4</packagereq>
       <packagereq type="default">tfm-rubygem-jwt</packagereq>
       <packagereq type="default">tfm-rubygem-launchy</packagereq>
       <packagereq type="default">tfm-rubygem-ldap_fluff</packagereq>
       <packagereq type="default">tfm-rubygem-little-plugger</packagereq>
       <packagereq type="default">tfm-rubygem-locale</packagereq>
       <packagereq type="default">tfm-rubygem-logging</packagereq>
-      <packagereq type="default">tfm-rubygem-multipart-post</packagereq>
       <packagereq type="default">tfm-rubygem-multi-select-rails</packagereq>
+      <packagereq type="default">tfm-rubygem-multipart-post</packagereq>
       <packagereq type="default">tfm-rubygem-mysql2</packagereq>
-      <packagereq type="default">tfm-rubygem-netrc</packagereq>
       <packagereq type="default">tfm-rubygem-net-ldap</packagereq>
       <packagereq type="default">tfm-rubygem-net-scp</packagereq>
       <packagereq type="default">tfm-rubygem-net-ssh</packagereq>
+      <packagereq type="default">tfm-rubygem-netrc</packagereq>
       <packagereq type="default">tfm-rubygem-oauth</packagereq>
       <packagereq type="default">tfm-rubygem-paint</packagereq>
-      <packagereq type="default">tfm-rubygem-passenger-native-libs</packagereq>
-      <packagereq type="default">tfm-rubygem-passenger-native</packagereq>
       <packagereq type="default">tfm-rubygem-passenger</packagereq>
+      <packagereq type="default">tfm-rubygem-passenger-native</packagereq>
+      <packagereq type="default">tfm-rubygem-passenger-native-libs</packagereq>
       <packagereq type="default">tfm-rubygem-patternfly-sass</packagereq>
       <packagereq type="default">tfm-rubygem-pg</packagereq>
       <packagereq type="default">tfm-rubygem-po_to_json</packagereq>
@@ -135,8 +127,8 @@
       <packagereq type="default">tfm-rubygem-roadie-rails</packagereq>
       <packagereq type="default">tfm-rubygem-ruby-libvirt</packagereq>
       <packagereq type="default">tfm-rubygem-ruby2ruby</packagereq>
-      <packagereq type="default">tfm-rubygem-rubyforge</packagereq>
       <packagereq type="default">tfm-rubygem-ruby_parser</packagereq>
+      <packagereq type="default">tfm-rubygem-rubyforge</packagereq>
       <packagereq type="default">tfm-rubygem-safemode</packagereq>
       <packagereq type="default">tfm-rubygem-scoped_search</packagereq>
       <packagereq type="default">tfm-rubygem-secure_headers</packagereq>
@@ -158,16 +150,16 @@
       <packagereq type="default">tfm-rubygem-will_paginate</packagereq>
       <packagereq type="default">tfm-rubygem-wirb</packagereq>
       <packagereq type="default">tfm-rubygem-x-editable-rails</packagereq>
-
+      <packagereq type="default">tfm-runtime</packagereq>
+      <packagereq type="default">tfm-runtime-assets</packagereq>
+      <packagereq type="default">tfm-scldevel</packagereq>
       <!--
         The following list is for foreman-*-nonscl-rhel7 tag. Please only put packages
         that should go to nonscl tag bellow. Do not delete the following line please:
 
         <packagereq type="default">foreman-*-nonscl-rhel7</packagereq>
       -->
-
       <packagereq type="default">foreman-installer</packagereq>
-
       <packagereq type="default">mod_passenger</packagereq>
       <packagereq type="default">nodejs-babel-core</packagereq>
       <packagereq type="default">nodejs-babel-loader</packagereq>
@@ -181,10 +173,10 @@
       <packagereq type="default">nodejs-extract-text-webpack-plugin</packagereq>
       <packagereq type="default">nodejs-file-loader</packagereq>
       <packagereq type="default">nodejs-ipaddr.js</packagereq>
+      <packagereq type="default">nodejs-jquery</packagereq>
       <packagereq type="default">nodejs-jquery-flot</packagereq>
       <packagereq type="default">nodejs-jquery-ujs</packagereq>
       <packagereq type="default">nodejs-jquery.cookie</packagereq>
-      <packagereq type="default">nodejs-jquery</packagereq>
       <packagereq type="default">nodejs-jstz</packagereq>
       <packagereq type="default">nodejs-lodash</packagereq>
       <packagereq type="default">nodejs-select2</packagereq>
@@ -207,9 +199,9 @@
       <packagereq type="default">rubygem-multi_json</packagereq>
       <packagereq type="default">rubygem-netrc</packagereq>
       <packagereq type="default">rubygem-oauth</packagereq>
-      <packagereq type="default">rubygem-passenger-native-libs</packagereq>
-      <packagereq type="default">rubygem-passenger-native</packagereq>
       <packagereq type="default">rubygem-passenger</packagereq>
+      <packagereq type="default">rubygem-passenger-native</packagereq>
+      <packagereq type="default">rubygem-passenger-native-libs</packagereq>
       <packagereq type="default">rubygem-powerbar</packagereq>
       <packagereq type="default">rubygem-rack-protection</packagereq>
       <packagereq type="default">rubygem-rb-inotify</packagereq>
@@ -217,7 +209,6 @@
       <packagereq type="default">rubygem-rubyipmi</packagereq>
       <packagereq type="default">rubygem-sinatra</packagereq>
       <packagereq type="default">rubygem-tilt</packagereq>
-
       <!--
         Do not edit this section manually and use ./comps_doc.sh script
       -->
@@ -370,7 +361,6 @@
       <packagereq type="default">tfm-rubygem-wirb-doc</packagereq>
       <packagereq type="default">tfm-rubygem-x-editable-rails-doc</packagereq>
       <!--RGD-END-->
-
     </packagelist>
   </group>
 </comps>


### PR DESCRIPTION
A convenience to run when creating npm packages. It does everything but
changing the comps (the current format makes it hard to add a new line
alphabetically).

I think that comps, a better spec template, and creating a proper cache for both el7/f24 through npm2rpm (not sure how to tackle that one yet...) is all that's left to make adding packages nearly a 1-step thing.