### PR TITLE
Update kafo to 0.9.6 [deb]

### DIFF
--- a/dependencies/jessie/kafo/changelog
+++ b/dependencies/jessie/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (0.9.6-1) stable; urgency=low
+
+  * Update kafo to 0.9.6
+
+ -- Marek Hulan <mhulan@redhat.com>  Fri, 09 Sep 2016 16:50:34 +0200
+
 ruby-kafo (0.9.5-1) stable; urgency=low
 
   * Update kafo to 0.9.5

--- a/dependencies/trusty/kafo/changelog
+++ b/dependencies/trusty/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (0.9.6-1) stable; urgency=low
+
+  * Update kafo to 0.9.6
+
+ -- Marek Hulan <mhulan@redhat.com>  Fri, 09 Sep 2016 16:50:34 +0200
+
 ruby-kafo (0.9.5-1) stable; urgency=low
 
   * Update kafo to 0.9.5

--- a/dependencies/xenial/kafo/changelog
+++ b/dependencies/xenial/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (0.9.6-1) stable; urgency=low
+
+  * Update kafo to 0.9.6
+
+ -- Marek Hulan <mhulan@redhat.com>  Fri, 09 Sep 2016 16:50:34 +0200
+
 ruby-kafo (0.9.5-1) stable; urgency=low
 
   * Update kafo to 0.9.5


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.13
* [ ] 1.12
* [ ] 1.11

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

