### PR TITLE
Add rubygem-smart_proxy_dhcp_infoblox package

### DIFF
--- a/comps/comps-foreman-plugins-fedora24.xml
+++ b/comps/comps-foreman-plugins-fedora24.xml
@@ -55,6 +55,7 @@
       <packagereq type="default">rubygem-puppetdb_foreman</packagereq>
       <packagereq type="default">rubygem-smart_proxy_abrt</packagereq>
       <packagereq type="default">rubygem-smart_proxy_chef</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_dhcp_infoblox</packagereq>
       <packagereq type="default">rubygem-smart_proxy_discovery</packagereq>
       <packagereq type="default">rubygem-smart_proxy_discovery_image</packagereq>
       <packagereq type="default">rubygem-smart_proxy_dns_infoblox</packagereq>
@@ -166,6 +167,7 @@
       <packagereq type="default">rubygem-satyr-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_abrt-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_chef-doc</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_dhcp_infoblox-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_discovery-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_discovery_image-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_dns_infoblox-doc</packagereq>

--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -61,6 +61,7 @@
       <packagereq type="default">rubygem-newt</packagereq>
       <packagereq type="default">rubygem-smart_proxy_abrt</packagereq>
       <packagereq type="default">rubygem-smart_proxy_chef</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_dhcp_infoblox</packagereq>
       <packagereq type="default">rubygem-smart_proxy_discovery</packagereq>
       <packagereq type="default">rubygem-smart_proxy_discovery_image</packagereq>
       <packagereq type="default">rubygem-smart_proxy_dns_infoblox</packagereq>
@@ -145,6 +146,7 @@
       <packagereq type="default">rubygem-sequel-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_abrt-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_chef-doc</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_dhcp_infoblox-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_discovery-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_discovery_image-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_dns_infoblox-doc</packagereq>

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -385,6 +385,7 @@ whitelist = rubygem-algebrick
   rubygem-sequel
   rubygem-smart_proxy_abrt
   rubygem-smart_proxy_chef
+  rubygem-smart_proxy_dhcp_infoblox
   rubygem-smart_proxy_discovery
   rubygem-smart_proxy_discovery_image
   rubygem-smart_proxy_dns_infoblox
@@ -468,6 +469,7 @@ whitelist = rubygem-algebrick
   rubygem-route53
   rubygem-satyr
   rubygem-smart_proxy_abrt
+  rubygem-smart_proxy_dhcp_infoblox
   rubygem-smart_proxy_discovery
   rubygem-smart_proxy_discovery_image
   rubygem-smart_proxy_dns_infoblox

--- a/rubygem-smart_proxy_dhcp_infoblox/rubygem-smart_proxy_dhcp_infoblox.spec
+++ b/rubygem-smart_proxy_dhcp_infoblox/rubygem-smart_proxy_dhcp_infoblox.spec
@@ -1,0 +1,96 @@
+# Generated from smart_proxy_dhcp_infoblox-0.0.3.gem by gem2rpm -*- rpm-spec -*-
+%global gem_name smart_proxy_dhcp_infoblox
+%global plugin_name dhcp_infoblox
+
+%global foreman_proxy_dir %{_datarootdir}/foreman-proxy
+%global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
+%global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
+
+Name: rubygem-%{gem_name}
+Version: 0.0.5
+Release: 1%{?foremandist}%{?dist}
+Summary: Infoblox DHCP provider plugin for Foreman's smart proxy
+Group: Applications/Internet
+License: GPLv3
+URL: https://github.com/theforeman/smart_proxy_dhcp_infoblox
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
+Requires: foreman-proxy >= 1.13.0
+%if 0%{?rhel} == 6
+Requires: ruby(abi)
+%else
+Requires: ruby(release)
+%endif
+Requires: ruby
+Requires: ruby(rubygems)
+Requires: rubygem(infoblox)
+%if 0%{?rhel} == 6
+BuildRequires: ruby(abi)
+%else
+BuildRequires: ruby(release)
+%endif
+BuildRequires: ruby
+BuildRequires: rubygems-devel
+BuildArch: noarch
+Provides: rubygem(%{gem_name}) = %{version}
+Provides: foreman-proxy-plugin-%{plugin_name}
+
+%description
+Infoblox DHCP provider plugin for Foreman's smart proxy.
+
+
+%package doc
+Summary: Documentation for %{name}
+Group: Documentation
+Requires: %{name} = %{version}-%{release}
+BuildArch: noarch
+
+%description doc
+Documentation for %{name}.
+
+%prep
+gem unpack %{SOURCE0}
+
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
+
+%build
+# Create the gem as gem install only works on a gem file
+gem build %{gem_name}.gemspec
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%gem_install
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -a .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+# bundler file
+mkdir -p %{buildroot}%{foreman_proxy_bundlerd_dir}
+mv %{buildroot}%{gem_instdir}/bundler.d/%{plugin_name}.rb \
+   %{buildroot}%{foreman_proxy_bundlerd_dir}
+
+# sample config
+mkdir -p %{buildroot}%{foreman_proxy_settingsd_dir}
+mv %{buildroot}%{gem_instdir}/config/dhcp_infoblox.yml.example \
+   %{buildroot}%{foreman_proxy_settingsd_dir}/dhcp_infoblox.yml
+
+%files
+%dir %{gem_instdir}
+%config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/dhcp_infoblox.yml
+%doc %{gem_instdir}/LICENSE
+%{gem_instdir}/bundler.d
+%{gem_instdir}/config
+%{gem_libdir}
+%{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
+%exclude %{gem_cache}
+%{gem_spec}
+
+%files doc
+%doc %{gem_docdir}
+%doc %{gem_instdir}/README.md
+%{gem_instdir}/test
+
+%changelog

--- a/rubygem-smart_proxy_dhcp_infoblox/smart_proxy_dhcp_infoblox-0.0.5.gem
+++ b/rubygem-smart_proxy_dhcp_infoblox/smart_proxy_dhcp_infoblox-0.0.5.gem
@@ -1,0 +1,1 @@
+../.git/annex/objects/xZ/WP/SHA256E-s25600--37feb242c704b9202843eec6a264ad76faf159e6de9c7b9b35aadfab68143a31.5.gem/SHA256E-s25600--37feb242c704b9202843eec6a264ad76faf159e6de9c7b9b35aadfab68143a31.5.gem


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.13
* [ ] 1.12
* [ ] 1.11

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
Scratch builds are:
EL7: https://koji.katello.org/koji/taskinfo?taskID=527742
F24: https://koji.katello.org/koji/taskinfo?taskID=527743

The RPM is installable on nightly.
