### PR TITLE
Update foreman_remote_execution to 1.2.1 (DEB)

### DIFF
--- a/plugins/ruby-foreman-remote-execution/debian/changelog
+++ b/plugins/ruby-foreman-remote-execution/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution (1.2.1-1) stable; urgency=low
+
+  * 1.2.1 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Mon, 12 Sep 2016 21:15:28 +0200
+
 ruby-foreman-remote-execution (1.1.0-1) stable; urgency=low
 
   * 1.1.0 released

--- a/plugins/ruby-foreman-remote-execution/debian/control
+++ b/plugins/ruby-foreman-remote-execution/debian/control
@@ -2,12 +2,15 @@ Source: ruby-foreman-remote-execution
 Section: ruby
 Priority: extra
 Maintainer: Stephen Benjamin <stephen@redhat.com>
-Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.13.0~rc1), foreman (>= 1.13.0~rc1), foreman-sqlite3 (>= 1.13.0~rc1), ruby-foreman-tasks (>= 0.8.0), ruby-foreman-tasks (<< 0.9.0), ruby-foreman-deface
+Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.13.0~rc1), foreman (>= 1.13.0~rc1),
+  foreman-sqlite3 (>= 1.13.0~rc1), ruby-foreman-tasks (>= 0.8.2), ruby-foreman-tasks (<< 0.9.0),
+  ruby-foreman-deface
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_remote_execution
 
 Package: ruby-foreman-remote-execution
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.13.0~rc1), ruby-foreman-tasks (>= 0.8.0), ruby-foreman-tasks (<< 0.9.0), ruby-foreman-deface
+Depends: ${misc:Depends}, bundler, foreman (>= 1.13.0~rc1), ruby-foreman-tasks (>= 0.8.2),
+  ruby-foreman-tasks (<< 0.9.0), ruby-foreman-deface
 Description: Foreman Remote Execution Plugin
   A plugin bringing remote execution to the Foreman, completing the config management functionality with remote management functionality

--- a/plugins/ruby-foreman-remote-execution/debian/gem.list
+++ b/plugins/ruby-foreman-remote-execution/debian/gem.list
@@ -1,2 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.1.0.gem"
+GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.2.1.gem"
+GEMS="$GEMS https://rubygems.org/downloads/foreman_remote_execution_core-1.0.1.gem"

--- a/plugins/ruby-foreman-tasks/debian/changelog
+++ b/plugins/ruby-foreman-tasks/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-tasks (0.8.2-1) stable; urgency=low
+
+  * 0.8.2 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Mon, 12 Sep 2016 21:10:31 +0200
+
 ruby-foreman-tasks (0.8.0-1) stable; urgency=low
 
   * 0.8.0 released

--- a/plugins/ruby-foreman-tasks/debian/control
+++ b/plugins/ruby-foreman-tasks/debian/control
@@ -4,7 +4,7 @@ Priority: extra
 Maintainer: Michael Moll <mmoll@mmoll.at>
 Build-Depends: debhelper, foreman (>= 1.13.0~rc1), foreman-sqlite3 (>= 1.13.0~rc1), foreman-assets
 Standards-Version: 3.9.3
-Homepage: https://github.com/Dynflow/dynflow
+Homepage: https://github.com/theforeman/foreman-tasks
 
 Package: ruby-foreman-tasks
 Architecture: all

--- a/plugins/ruby-foreman-tasks/debian/gem.list
+++ b/plugins/ruby-foreman-tasks/debian/gem.list
@@ -1,5 +1,6 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman-tasks-0.8.0.gem"
+GEMS="https://rubygems.org/downloads/foreman-tasks-0.8.2.gem"
+GEMS="$GEMS https://rubygems.org/downloads/foreman-tasks-core-0.1.1.gem"
 GEMS="$GEMS https://rubygems.org/downloads/daemons-1.2.4.gem"
 GEMS="$GEMS https://rubygems.org/downloads/parse-cron-0.1.4.gem"
 GEMS="$GEMS https://rubygems.org/downloads/sequel-4.37.0.gem"

--- a/plugins/ruby-foreman-tasks/foreman-tasks.rb
+++ b/plugins/ruby-foreman-tasks/foreman-tasks.rb
@@ -1,1 +1,1 @@
-gem 'foreman-tasks', '0.8.0'
+gem 'foreman-tasks', '0.8.2'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.13
* [ ] 1.12
* [ ] 1.11

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

We moved the smart_proxy_remote_execution_ssh_core and part of foreman_remote_execution
to foreman_tasks_core and foreman_remote_execution_core to be able to use rex
without a proxy and reuse the code for foreman-ansible. No installer change
should be necessary.