### PR TITLE
Fix ExclusiveArch for nodejs packages on EL6

### DIFF
--- a/nodejs-babel-core/nodejs-babel-core.spec
+++ b/nodejs-babel-core/nodejs-babel-core.spec
@@ -74,7 +74,11 @@ BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
 BuildRequires: npm
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 Provides: bundled-npm(babel-core) = 6.7.7
 Provides: bundled-npm(babel-messages) = 6.8.0

--- a/nodejs-babel-loader/nodejs-babel-loader.spec
+++ b/nodejs-babel-loader/nodejs-babel-loader.spec
@@ -25,7 +25,11 @@ BuildRequires: npm
 BuildRequires: npm(webpack)
 BuildRequires: npm(babel-core)
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 Provides: bundled-npm(babel-loader) = 6.2.4
 Provides: bundled-npm(mkdirp) = 0.5.1

--- a/nodejs-babel-preset-es2015/nodejs-babel-preset-es2015.spec
+++ b/nodejs-babel-preset-es2015/nodejs-babel-preset-es2015.spec
@@ -106,7 +106,11 @@ BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
 BuildRequires: npm
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 Provides: bundled-npm(babel-preset-es2015) = 6.6.0
 Provides: bundled-npm(babel-plugin-transform-es2015-object-super) = 6.8.0

--- a/nodejs-es6-promise/nodejs-es6-promise.spec
+++ b/nodejs-es6-promise/nodejs-es6-promise.spec
@@ -13,7 +13,11 @@ BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
 BuildRequires: npm
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 %{?nodejs_find_provides_and_requires}
 

--- a/nodejs-expose-loader/nodejs-expose-loader.spec
+++ b/nodejs-expose-loader/nodejs-expose-loader.spec
@@ -13,7 +13,11 @@ BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
 BuildRequires: npm
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 %{?nodejs_find_provides_and_requires}
 

--- a/nodejs-extract-text-webpack-plugin/nodejs-extract-text-webpack-plugin.spec
+++ b/nodejs-extract-text-webpack-plugin/nodejs-extract-text-webpack-plugin.spec
@@ -25,7 +25,11 @@ BuildRequires: nodejs-packaging
 BuildRequires: npm
 BuildRequires: npm(webpack)
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 Provides: bundled-npm(extract-text-webpack-plugin) = 1.0.1
 Provides: bundled-npm(loader-utils) = 0.2.15

--- a/nodejs-file-loader/nodejs-file-loader.spec
+++ b/nodejs-file-loader/nodejs-file-loader.spec
@@ -19,7 +19,11 @@ BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
 BuildRequires: npm
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 Provides: bundled-npm(file-loader) = 0.9.0
 Provides: bundled-npm(loader-utils) = 0.2.15

--- a/nodejs-jquery-flot/nodejs-jquery-flot.spec
+++ b/nodejs-jquery-flot/nodejs-jquery-flot.spec
@@ -13,7 +13,11 @@ BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
 BuildRequires: npm
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 %{?nodejs_find_provides_and_requires}
 

--- a/nodejs-jquery-ujs/nodejs-jquery-ujs.spec
+++ b/nodejs-jquery-ujs/nodejs-jquery-ujs.spec
@@ -13,7 +13,11 @@ BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
 Requires: npm(jquery) >= 1.8.0
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 
 %description

--- a/nodejs-jquery.cookie/nodejs-jquery.cookie.spec
+++ b/nodejs-jquery.cookie/nodejs-jquery.cookie.spec
@@ -13,7 +13,11 @@ BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
 Requires: npm(jquery) >= 1.2.0
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 
 %description

--- a/nodejs-jquery/nodejs-jquery.spec
+++ b/nodejs-jquery/nodejs-jquery.spec
@@ -12,7 +12,11 @@ Requires: nodejs(engine)
 BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 
 %description

--- a/nodejs-jstz/nodejs-jstz.spec
+++ b/nodejs-jstz/nodejs-jstz.spec
@@ -12,7 +12,11 @@ Source0: http://registry.npmjs.org/jstz/-/jstz-1.0.7.tgz
 BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 
 %description

--- a/nodejs-lodash/nodejs-lodash.spec
+++ b/nodejs-lodash/nodejs-lodash.spec
@@ -11,7 +11,11 @@ Source0: http://registry.npmjs.org/%{npm_name}/-/%{npm_name}-%{version}.tgz
 BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 
 %description

--- a/nodejs-select2/nodejs-select2.spec
+++ b/nodejs-select2/nodejs-select2.spec
@@ -12,7 +12,11 @@ Source0: http://registry.npmjs.org/select2/-/select2-3.5.2-browserify.tgz
 BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 
 %description

--- a/nodejs-stats-webpack-plugin/nodejs-stats-webpack-plugin.spec
+++ b/nodejs-stats-webpack-plugin/nodejs-stats-webpack-plugin.spec
@@ -13,7 +13,11 @@ BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
 BuildRequires: npm
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 %{?nodejs_find_provides_and_requires}
 

--- a/nodejs-url-loader/nodejs-url-loader.spec
+++ b/nodejs-url-loader/nodejs-url-loader.spec
@@ -21,7 +21,11 @@ BuildRequires: nodejs-packaging
 BuildRequires: npm
 BuildRequires: npm(file-loader)
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 Provides: bundled-npm(url-loader) = 0.5.7
 Provides: bundled-npm(mime) = 1.2.11

--- a/nodejs-webpack/nodejs-webpack.spec
+++ b/nodejs-webpack/nodejs-webpack.spec
@@ -247,7 +247,11 @@ BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
 BuildRequires: npm
 BuildArch: noarch
+%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
+%else
+ExclusiveArch: %{ix86} x86_64 %{arm} noarch
+%endif
 Provides: npm(%{npm_name}) = %{version}
 Provides: bundled-npm(webpack) = 1.13.1
 Provides: bundled-npm(mkdirp) = 0.5.1

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -22,18 +22,26 @@ whitelist = foreman-installer
   nodejs-babel-core
   nodejs-babel-loader
   nodejs-babel-preset-es2015
+  nodejs-css-loader
+  nodejs-datatables.net
+  nodejs-datatables.net-bs
   nodejs-diff
+  nodejs-es6-promise
   nodejs-expose-loader
+  nodejs-extract-text-webpack-plugin
+  nodejs-file-loader
   nodejs-ipaddr.js
   nodejs-jquery
+  nodejs-jquery.cookie
   nodejs-jquery-flot
   nodejs-jquery-ujs
-  nodejs-jquery.cookie
   nodejs-jstz
   nodejs-lodash
   nodejs-multiselect
   nodejs-select2
   nodejs-stats-webpack-plugin
+  nodejs-style-loader
+  nodejs-url-loader
   nodejs-webpack
   puppet-agent-oauth
   rubygem-apipie-bindings


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.13
* [ ] 1.12
* [ ] 1.11

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

