### PR TITLE
set NODE_ENV=production for npm install (DEB)

### DIFF
--- a/debian/jessie/foreman/rules
+++ b/debian/jessie/foreman/rules
@@ -17,8 +17,8 @@ build/foreman::
 	/bin/cp config/database.yml.example config/database.yml
 	/bin/cp config/email.yaml.example config/email.yaml
 	/usr/bin/gem install -f thor -v '0.19.1'
-	/usr/bin/npm install npm
-	/usr/bin/nodejs node_modules/.bin/npm install --no-optional
+	NODE_ENV=production /usr/bin/npm install npm --no-optional
+	NODE_ENV=production /usr/bin/nodejs node_modules/.bin/npm install --no-optional
 	/usr/bin/bundle package
 	/usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production
 	/usr/bin/bundle exec rake webpack:compile

--- a/debian/trusty/foreman/rules
+++ b/debian/trusty/foreman/rules
@@ -16,8 +16,8 @@ build/foreman::
 	/bin/cp config/settings.yaml.example config/settings.yaml
 	/bin/cp config/database.yml.example config/database.yml
 	/bin/cp config/email.yaml.example config/email.yaml
-	/usr/bin/npm install npm
-	/usr/bin/nodejs node_modules/.bin/npm install --no-optional
+	NODE_ENV=production /usr/bin/npm install npm --no-optional
+	NODE_ENV=production /usr/bin/nodejs node_modules/.bin/npm install --no-optional
 	/usr/bin/ruby2.0 /usr/bin/bundle pack --all
 	/usr/bin/ruby2.0 /usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production
 	/usr/bin/ruby2.0 /usr/bin/bundle exec rake webpack:compile

--- a/debian/xenial/foreman/rules
+++ b/debian/xenial/foreman/rules
@@ -19,7 +19,7 @@ build/foreman::
 	/usr/bin/gem install -f thor -v '0.19.1'
 	/usr/bin/gem install -f rake -v '10.5.0'
 	/usr/bin/gem install -f power_assert -v '0.2.7'
-	/usr/bin/npm install --no-optional
+	NODE_ENV=production /usr/bin/npm install --no-optional
 	/usr/bin/bundle package
 	/usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production
 	/usr/bin/bundle exec rake webpack:compile


### PR DESCRIPTION
I'm unsure about the consequences in the application itself (@dLobatog? @tbrisker?), but this seems to lead to a significant speedup when building the package.