### PR TITLE
remove test and dev gems for building (DEB)

### DIFF
--- a/debian/jessie/foreman/rules
+++ b/debian/jessie/foreman/rules
@@ -12,7 +12,8 @@ build/foreman::
 	# Build the gem cache
 	#
 	/bin/cp debian/debian.rb bundler.d/
-	/bin/rm -f bundler.d/therubyracer.rb
+	/bin/rm -f bundler.d/development.rb
+	/bin/rm -f bundler.d/test.rb
 	/bin/cp config/settings.yaml.example config/settings.yaml
 	/bin/cp config/database.yml.example config/database.yml
 	/bin/cp config/email.yaml.example config/email.yaml

--- a/debian/trusty/foreman/rules
+++ b/debian/trusty/foreman/rules
@@ -12,7 +12,8 @@ build/foreman::
 	# Build the gem cache
 	#
 	/bin/cp debian/debian.rb bundler.d/
-	/bin/rm -f bundler.d/therubyracer.rb
+	/bin/rm -f bundler.d/development.rb
+	/bin/rm -f bundler.d/test.rb
 	/bin/cp config/settings.yaml.example config/settings.yaml
 	/bin/cp config/database.yml.example config/database.yml
 	/bin/cp config/email.yaml.example config/email.yaml

--- a/debian/xenial/foreman/rules
+++ b/debian/xenial/foreman/rules
@@ -12,7 +12,8 @@ build/foreman::
 	# Build the gem cache
 	#
 	/bin/cp debian/debian.rb bundler.d/
-	/bin/rm -f bundler.d/therubyracer.rb
+	/bin/rm -f bundler.d/development.rb
+	/bin/rm -f bundler.d/test.rb
 	/bin/cp config/settings.yaml.example config/settings.yaml
 	/bin/cp config/database.yml.example config/database.yml
 	/bin/cp config/email.yaml.example config/email.yaml


### PR DESCRIPTION
These should not be needed for production build packages. therubyracer got removed in the meanwhile...

This PR is for now mainly to see, where the builds are going, maybe there are hidden prod or build dependencies.