### PR TITLE
Fixes #16981 - require ruby version 2.3.1 for xenial.

### DIFF
--- a/debian/xenial/foreman-proxy/control
+++ b/debian/xenial/foreman-proxy/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/theforeman/smart-proxy
 
 Package: foreman-proxy
 Architecture: all
-Depends: ruby | ruby-interpreter, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext, ruby-concurrent (>= 1.0.0), ruby-concurrent (<< 2.0.0)
+Depends: ruby | ruby-interpreter, ruby2.3 (>= 2.3.1), rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext, ruby-concurrent (>= 1.0.0), ruby-concurrent (<< 2.0.0)
 Recommends: sudo, wget, ping, ruby-gssapi, ruby-rubyipmi (>= 0.9.2), ruby-rkerberos (>= 0.1.1), ruby-libvirt (>= 0.6.0), ruby-rb-inotify, foreman-debug
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.13
* [ ] 1.12
* [ ] 1.11

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

