### PR TITLE
use ruby2.0 for foreman-proxy on trusty

### DIFF
--- a/debian/trusty/foreman-proxy/control
+++ b/debian/trusty/foreman-proxy/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/theforeman/smart-proxy
 
 Package: foreman-proxy
 Architecture: all
-Depends: ruby | ruby-interpreter, rake, ruby-sinatra, ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext, ruby-concurrent (>= 1.0.0), ruby-concurrent (<< 2.0.0)
+Depends: ruby2.0, rake, ruby-sinatra, ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext, ruby-concurrent (>= 1.0.0), ruby-concurrent (<< 2.0.0)
 Recommends: sudo, wget, ping, ruby-gssapi, ruby-rubyipmi (>= 0.9.2), ruby-rkerberos (>= 0.1.1), ruby-libvirt (>= 0.6.0), ruby-rb-inotify, foreman-debug
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems

--- a/debian/trusty/foreman-proxy/postinst
+++ b/debian/trusty/foreman-proxy/postinst
@@ -42,7 +42,7 @@ case "$1" in
     trap "rm -rf $TEMP" EXIT
     (
       cd $TEMP
-      if ruby $FOREMAN_HOME/extra/migrate_settings.rb -t . > /var/log/foreman-proxy/migrate_settings.log 2>&1; then
+      if /usr/bin/ruby2.0 $FOREMAN_HOME/extra/migrate_settings.rb -t . > /var/log/foreman-proxy/migrate_settings.log 2>&1; then
         (
           cd result && for f in migration_state settings.yml settings.d/*.yml; do
             [ -e "$f" ] && cat $f > ${CONFIGDIR}/$f

--- a/debian/trusty/foreman-proxy/rules
+++ b/debian/trusty/foreman-proxy/rules
@@ -15,6 +15,7 @@ build:
 	touch foreman-proxy/migration_state
 	mv Gemfile Gemfile.in
 	rm -f bundler.d/development.rb bundler.d/test.rb bundler.d/windows.rb
+	sed -i -e 's~#!/usr/bin/env ruby~#!/usr/bin/ruby2.0~' bin/smart-proxy
 	dh $@
 
 %:

--- a/dependencies/trusty/bundler_ext/changelog
+++ b/dependencies/trusty/bundler_ext/changelog
@@ -1,3 +1,9 @@
+ruby-bundler-ext (0.4.1-2) stable; urgency=low
+
+  * depend on rebuilt bundler package for Ruby 2.0 integration
+
+ -- Michael Moll <mmoll@mmoll.at>  Thu, 20 Oct 2016 13:03:25 +0200
+
 ruby-bundler-ext (0.4.1-1) stable; urgency=low
 
   * 0.4.1 released

--- a/dependencies/trusty/bundler_ext/control
+++ b/dependencies/trusty/bundler_ext/control
@@ -10,6 +10,6 @@ XS-Ruby-Versions: all
 Package: ruby-bundler-ext
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, bundler (>= 0)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, bundler (>= 1.3.5-2ubuntu2)
 Description: Load system gems via Bundler DSL
  Simple library leveraging the Bundler Gemfile DSL to load gems already on the system and managed by the systems package manager (like yum/apt)


### PR DESCRIPTION
this should be built into:

* [x] Nightly

contrary to #1389, the ruby interpreter used is changed here. Depends on #1380 (already merged now), to really get bundler correctly for bundler_ext.

This is for future-proofing Ubuntu/trusty as platform, as foreman-proxy might (need to) drop support for Ruby 1.9.3 in the future. @iNecas is there anything to be aware of regarding the smart_proxy*-core proxy plugins on Debian?