### PR TITLE
execute build tasks only once

### DIFF
--- a/debian/jessie/foreman/rules
+++ b/debian/jessie/foreman/rules
@@ -7,7 +7,7 @@ include /usr/share/cdbs/1/rules/debhelper.mk
 # DEB_VERBOSE_ALL=1
 # DH_VERBOSE=1
 
-build/foreman::
+build:
 	#
 	# Build the gem cache
 	#

--- a/debian/trusty/foreman/rules
+++ b/debian/trusty/foreman/rules
@@ -7,7 +7,7 @@ include /usr/share/cdbs/1/rules/debhelper.mk
 # DEB_VERBOSE_ALL=1
 # DH_VERBOSE=1
 
-build/foreman::
+build:
 	#
 	# Build the gem cache
 	#

--- a/debian/xenial/foreman/rules
+++ b/debian/xenial/foreman/rules
@@ -7,7 +7,7 @@ include /usr/share/cdbs/1/rules/debhelper.mk
 # DEB_VERBOSE_ALL=1
 # DH_VERBOSE=1
 
-build/foreman::
+build:
 	#
 	# Build the gem cache
 	#


### PR DESCRIPTION
this should be built into:

* [x] Nightly

It seems that the build tasks when building all the packages are executed at least twice and this change fixes this. I tested the resulting Ubuntu/xenial packages and a quick all-in-one-install seemed to work well.

@GregSutcliffe do you remember any background on that?