### PR TITLE
Remove extras/rdoc from foreman [deb]

### DIFF
--- a/debian/jessie/foreman/foreman.install
+++ b/debian/jessie/foreman/foreman.install
@@ -22,7 +22,6 @@ vendor/cache                             usr/share/foreman/vendor
 extras/dbmigrate                         usr/share/foreman/extras
 extras/ignored_environments.yml.sample   usr/share/foreman/extras
 extras/noVNC                             usr/share/foreman/extras
-extras/rdoc                              usr/share/foreman/extras
 bundler.d/facter.rb                      usr/share/foreman/bundler.d
 bundler.d/jsonp.rb                       usr/share/foreman/bundler.d
 debian/debian.rb                         usr/share/foreman/bundler.d

--- a/debian/trusty/foreman/foreman.install
+++ b/debian/trusty/foreman/foreman.install
@@ -22,7 +22,6 @@ vendor/cache                             usr/share/foreman/vendor
 extras/dbmigrate                         usr/share/foreman/extras
 extras/ignored_environments.yml.sample   usr/share/foreman/extras
 extras/noVNC                             usr/share/foreman/extras
-extras/rdoc                              usr/share/foreman/extras
 bundler.d/facter.rb                      usr/share/foreman/bundler.d
 bundler.d/jsonp.rb                       usr/share/foreman/bundler.d
 debian/debian.rb                         usr/share/foreman/bundler.d

--- a/debian/xenial/foreman/foreman.install
+++ b/debian/xenial/foreman/foreman.install
@@ -22,7 +22,6 @@ vendor/cache                             usr/share/foreman/vendor
 extras/dbmigrate                         usr/share/foreman/extras
 extras/ignored_environments.yml.sample   usr/share/foreman/extras
 extras/noVNC                             usr/share/foreman/extras
-extras/rdoc                              usr/share/foreman/extras
 bundler.d/facter.rb                      usr/share/foreman/bundler.d
 bundler.d/jsonp.rb                       usr/share/foreman/bundler.d
 debian/debian.rb                         usr/share/foreman/bundler.d


### PR DESCRIPTION
Originally removed in https://github.com/theforeman/foreman/commit/b1dad4cd18dfc69faa8f1509b0b5b9a361976d59.