### PR TITLE
Update foreman_ansible to 1.3.0 [deb]

### DIFF
--- a/plugins/ruby-foreman-ansible/debian/changelog
+++ b/plugins/ruby-foreman-ansible/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-ansible (1.3.0-1) stable; urgency=low
+
+  * 1.3.0 released
+
+ -- Daniel Lobato Garcia <me@daniellobato.me>  Fri, 02 Dec 2016 18:31:24 +0100
+
 ruby-foreman-ansible (1.2.1-1) stable; urgency=low
 
   * 1.2.1 released

--- a/plugins/ruby-foreman-ansible/debian/gem.list
+++ b/plugins/ruby-foreman-ansible/debian/gem.list
@@ -1,3 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_ansible-1.2.1.gem"
+GEMS="https://rubygems.org/downloads/foreman_ansible-1.3.0.gem"
 GEMS="$GEMS https://rubygems.org/downloads/foreman_ansible_core-0.0.1.gem"

--- a/plugins/ruby-foreman-ansible/foreman_ansible.rb
+++ b/plugins/ruby-foreman-ansible/foreman_ansible.rb
@@ -1,1 +1,1 @@
-gem 'foreman_ansible', '1.2.1'
+gem 'foreman_ansible', '1.3.0'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.13
* [x] 1.12
* [ ] 1.11

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

As in https://github.com/theforeman/foreman-packaging/pull/1440 - I'm not sure if the dep chain for 1.12 will work, if not, don't worry.