### PR TITLE
Bump ruby-smart-proxy-dns-powerdns to 0.3.0

### DIFF
--- a/plugins/smart_proxy_dns_powerdns/control
+++ b/plugins/smart_proxy_dns_powerdns/control
@@ -12,7 +12,7 @@ XS-Ruby-Versions: all
 Package: ruby-smart-proxy-dns-powerdns
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.11.0~rc1), ruby-mysql2, ruby-pg
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.13.0~rc1), ruby-mysql2, ruby-pg
 Recommends: pdns-server
 Description: PowerDNS DNS provider plugin for Foreman's smart proxy
  PowerDNS DNS provider plugin for Foreman's smart proxy

--- a/plugins/smart_proxy_dns_powerdns/dns_powerdns.rb
+++ b/plugins/smart_proxy_dns_powerdns/dns_powerdns.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_dns_powerdns', '0.2.1'
+gem 'smart_proxy_dns_powerdns', '0.3.0'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.14
* [x] 1.13
* [ ] 1.12