### PR TITLE
Excluded directories in foreman-tail dir

### DIFF
--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -715,6 +715,7 @@ install -Dpm0644 %{SOURCE8} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-f
 cp -p Gemfile.in %{buildroot}%{_datadir}/%{name}/Gemfile.in
 cp -p -r app bin bundler.d config config.ru extras lib locale Rakefile script %{buildroot}%{_datadir}/%{name}
 rm -rf %{buildroot}%{_datadir}/%{name}/extras/{jumpstart,spec}
+find %{buildroot}%{_datadir}/%{name}/script/%{name}-tail.d/* -type d |xargs rm -rf
 
 # remove all test units from produciton release
 find %{buildroot}%{_datadir}/%{name} -type d -name "test" |xargs rm -rf


### PR DESCRIPTION
* [x] Nightly
* [ ] 1.11
* [ ] 1.10
* [ ] 1.9

Foreman tail prints three error lines on each execution which is caused by
directories that are not expected there.

```
[root@tyan-gt24-08 ~]# find /usr/share/foreman/script/foreman-tail.d
/usr/share/foreman/script/foreman-tail.d
/usr/share/foreman/script/foreman-tail.d/00-syslog
/usr/share/foreman/script/foreman-tail.d/05-foreman_cron
/usr/share/foreman/script/foreman-tail.d/10-foreman_seed
/usr/share/foreman/script/foreman-tail.d/30-named
/usr/share/foreman/script/foreman-tail.d/50-httpd
/usr/share/foreman/script/foreman-tail.d/60-puppetmaster
/usr/share/foreman/script/foreman-tail.d/80-proxy
/usr/share/foreman/script/foreman-tail.d/90-rails
/usr/share/foreman/script/foreman-tail.d/common
/usr/share/foreman/script/foreman-tail.d/common/05-foreman_cron
/usr/share/foreman/script/foreman-tail.d/common/10-foreman_seed
/usr/share/foreman/script/foreman-tail.d/common/60-puppetmaster
/usr/share/foreman/script/foreman-tail.d/common/80-proxy
/usr/share/foreman/script/foreman-tail.d/common/90-rails
/usr/share/foreman/script/foreman-tail.d/debian
/usr/share/foreman/script/foreman-tail.d/debian/00-syslog
/usr/share/foreman/script/foreman-tail.d/debian/50-httpd
/usr/share/foreman/script/foreman-tail.d/redhat
/usr/share/foreman/script/foreman-tail.d/redhat/00-syslog
/usr/share/foreman/script/foreman-tail.d/redhat/30-named
/usr/share/foreman/script/foreman-tail.d/redhat/50-httpd
[root@tyan-gt24-08 ~]# foreman-tail >/dev/null
cat: /usr/share/foreman/script/foreman-tail.d/common: Is a directory
cat: /usr/share/foreman/script/foreman-tail.d/debian: Is a directory
cat: /usr/share/foreman/script/foreman-tail.d/redhat: Is a directory
```