### PR TITLE
Refs #13455 - Require genisoimage for -libvirt (RPM)

### DIFF
--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -346,6 +346,7 @@ Requires: %{?scl_prefix}rubygem(fog-libvirt) < 1.0
 Requires: %{?scl_prefix}rubygem(ruby-libvirt) >= 0.4
 Requires: %{?scl_prefix}rubygem(ruby-libvirt) < 1.0
 Requires: %{name} = %{version}-%{release}
+Requires: genisoimage
 Obsoletes: foreman-virt < 1.0.0
 Provides: foreman-virt = 1.0.0
 


### PR DESCRIPTION
this should be built into:

* [x] Nightly
* [x] 1.14
* [x] 1.13 (if there will be a 1.13.4 release)