### PR TITLE
Update kafo_parsers to 0.1.6

### DIFF
--- a/dependencies/jessie/kafo_parsers/changelog
+++ b/dependencies/jessie/kafo_parsers/changelog
@@ -1,3 +1,9 @@
+ruby-kafo-parsers (0.1.6-1) stable; urgency=low
+
+  * Update kafo_parsers to 0.1.6
+
+ -- Marek Hulan <mhulan@redhat.com>  Thu, 05 Jan 2017 14:43:54 +0100
+
 ruby-kafo-parsers (0.1.5-1) stable; urgency=low
 
   * Update kafo_parsers to 0.1.5

--- a/dependencies/trusty/kafo_parsers/changelog
+++ b/dependencies/trusty/kafo_parsers/changelog
@@ -1,3 +1,9 @@
+ruby-kafo-parsers (0.1.6-1) stable; urgency=low
+
+  * Update kafo_parsers to 0.1.6
+
+ -- Marek Hulan <mhulan@redhat.com>  Thu, 05 Jan 2017 14:43:54 +0100
+
 ruby-kafo-parsers (0.1.5-1) stable; urgency=low
 
   * Update kafo_parsers to 0.1.5

--- a/dependencies/xenial/kafo_parsers/changelog
+++ b/dependencies/xenial/kafo_parsers/changelog
@@ -1,3 +1,9 @@
+ruby-kafo-parsers (0.1.6-1) stable; urgency=low
+
+  * Update kafo_parsers to 0.1.6
+
+ -- Marek Hulan <mhulan@redhat.com>  Thu, 05 Jan 2017 14:43:54 +0100
+
 ruby-kafo-parsers (0.1.5-1) stable; urgency=low
 
   * Update kafo_parsers to 0.1.5


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.14
* [ ] 1.13
* [ ] 1.12

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
