### PR TITLE
Update ldap_fluff to 0.4.5

### DIFF
--- a/rubygem-ldap_fluff/ldap_fluff-0.4.4.gem
+++ b/rubygem-ldap_fluff/ldap_fluff-0.4.4.gem
@@ -1,1 +1,0 @@
-../.git/annex/objects/QG/V5/SHA256E-s15360--cbfdb5a4b7699ac7f63c2eacb92f8452ddcc53e6a59bad4d68da211f880eeb25.4.gem/SHA256E-s15360--cbfdb5a4b7699ac7f63c2eacb92f8452ddcc53e6a59bad4d68da211f880eeb25.4.gem

--- a/rubygem-ldap_fluff/ldap_fluff-0.4.5.gem
+++ b/rubygem-ldap_fluff/ldap_fluff-0.4.5.gem
@@ -1,0 +1,1 @@
+../.git/annex/objects/X0/G7/SHA256E-s15360--d851ddf9b742aeccdaff32805a7acc47d203505af74722e223c359b96c0ced0c.5.gem/SHA256E-s15360--d851ddf9b742aeccdaff32805a7acc47d203505af74722e223c359b96c0ced0c.5.gem

--- a/rubygem-ldap_fluff/rubygem-ldap_fluff.spec
+++ b/rubygem-ldap_fluff/rubygem-ldap_fluff.spec
@@ -5,7 +5,7 @@
 
 Summary: LDAP integration for Active Directory, FreeIPA and POSIX
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 0.4.4
+Version: 0.4.5
 Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv2+ or Ruby


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.14
* [x] 1.13
* [ ] 1.12

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

This will NOT build because I thought I had access to push to rubygems but apparently I don't. @ares or @domcleal mind to push it and retrigger tests?

