### PR TITLE
Only use Puppet 3.x to build foreman-installer [deb/1.14]

### DIFF
--- a/debian/jessie/foreman-installer/control
+++ b/debian/jessie/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet-agent | puppet (>= 3.6.0), ruby-kafo (>= 1.0.5)
+               puppet (>= 3.6.0), ruby-kafo (>= 1.0.5)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all

--- a/debian/trusty/foreman-installer/control
+++ b/debian/trusty/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet-agent | puppet (>= 3.6.0), ruby-kafo (>= 1.0.5)
+               puppet (>= 3.6.0), ruby-kafo (>= 1.0.5)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all

--- a/debian/xenial/foreman-installer/control
+++ b/debian/xenial/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet-agent | puppet (>= 3.6.0), ruby-kafo (>= 1.0.5)
+               puppet (>= 3.6.0), ruby-kafo (>= 1.0.5)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all


### PR DESCRIPTION
Depending on puppet-agent is insufficient as it also needs
puppet-strings to build, so prefer Puppet 3.x, so builds will fail when
puppet-agent becomes available in our pbuilder configuration.

(applicable to deb/1.14, deb/1.13, should be merged before https://github.com/theforeman/foreman-infra/pull/270)