### PR TITLE
Use puppet-agent-puppet-strings package to build installer [deb]

### DIFF
--- a/debian/jessie/foreman-installer/control
+++ b/debian/jessie/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet-agent | puppet (>= 3.6.0), ruby-kafo (>= 1.0.5)
+               puppet-agent-puppet-strings, ruby-kafo (>= 1.0.5)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all

--- a/debian/trusty/foreman-installer/control
+++ b/debian/trusty/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet-agent | puppet (>= 3.6.0), ruby-kafo (>= 1.0.5)
+               puppet-agent-puppet-strings, ruby-kafo (>= 1.0.5)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all

--- a/debian/xenial/foreman-installer/control
+++ b/debian/xenial/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet-agent | puppet (>= 3.6.0), ruby-kafo (>= 1.0.5)
+               puppet-agent-puppet-strings, ruby-kafo (>= 1.0.5)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all


### PR DESCRIPTION
Switches to Puppet 4 (puppet-agent) for building, which supports
YARD-based documentation but drops parsing of validation functions
from manifests.

Depends on https://github.com/theforeman/foreman-infra/pull/270.