### PR TITLE
Refs #15779 - handle foreman-tasks in core (DEB)

### DIFF
--- a/debian/jessie/foreman/control
+++ b/debian/jessie/foreman/control
@@ -14,9 +14,10 @@ Section: web
 Priority: extra
 Depends: ruby2.1, bundler (>= 1.3), zlib1g-dev,
          ruby2.1-dev, build-essential,
-         rake (>=0.8.4), ${misc:Depends}
+         rake (>=0.8.4), bash, ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug, python-minimal
-Conflicts: ruby-activerecord-deprecated-finders
+Conflicts: ruby-activerecord-deprecated-finders, ruby-foreman-tasks
+Replaces: ruby-foreman-tasks
 Description: Systems management web interface
  Foreman is aimed to be a single address for all machines life cycle management.
  .

--- a/debian/jessie/foreman/foreman.foreman-tasks.init
+++ b/debian/jessie/foreman/foreman.foreman-tasks.init
@@ -1,0 +1,266 @@
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides:          foreman-tasks
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Init script for foreman-tasks
+# Description:       Init script for foreman-tasks service used by foreman-tasks foreman plugin
+### END INIT INFO
+
+# Author: Marek Hulan <mhulan@redhat.com>
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="Foreman-tasks start dynflow executor"
+NAME=foreman-tasks
+DAEMON=/usr/sbin/$NAME
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.2-14) to ensure that this file is present
+# and status_of_proc is working.
+. /lib/lsb/init-functions
+
+RETVAL=0
+FOREMAN_USER=${FOREMAN_USER:-foreman}
+FOREMAN_HOME=${FOREMAN_HOME:-/usr/share/foreman}
+FOREMAN_DATA_DIR=${FOREMAN_DATA_DIR:-/var/lib/foreman}
+FOREMAN_ENV=${FOREMAN_ENV:-production}
+FOREMAN_TASK_PARAMS=${FOREMAN_TASK_PARAMS:--p foreman}
+FOREMAN_PID_DIR=$FOREMAN_HOME/tmp/pids
+FOREMAN_LOG_DIR=${FOREMAN_LOG_DIR:-/var/log/foreman}
+DAEMON="/usr/sbin/foreman-tasks"
+PID_FILE=$FOREMAN_PID_DIR/dynflow_executor_monitor.pid
+export RAILS_ENV=$FOREMAN_ENV
+export FOREMAN_LOGGING=${FOREMAN_LOGGING:-warn}
+export FOREMAN_LOGGING_SQL=${FOREMAN_LOGGING_SQL:-warn}
+export RAILS_RELATIVE_URL_ROOT=$FOREMAN_PREFIX
+
+print_higher() {
+    if [ 0$1 -gt 0$2 ]; then
+        echo $1
+    else
+        echo $2
+    fi
+}
+
+print_lower() {
+    if [ 0$1 -gt 0$2 ]; then
+        echo $2
+    else
+        echo $1
+    fi
+}
+
+__pids_var_run() {
+        local base=${1##*/}
+        local pid_file=${2:-/var/run/$base.pid}
+
+        pid=
+        if [ -f "$pid_file" ] ; then
+                local line p
+                read line < "$pid_file"
+                for p in $line ; do
+                        [ -z "${p//[0-9]/}" -a -d "/proc/$p" ] && pid="$pid $p"
+                done
+                if [ -n "$pid" ]; then
+                        return 0
+                fi
+                return 1 # "Program is dead and /var/run pid file exists"
+        fi
+        return 3 # "Program is not running"
+}
+
+# Output PIDs of matching processes, found using pidof
+__pids_pidof() {
+        pidof -c -o $$ -o $PPID -o %PPID -x "$1" || \
+                pidof -c -o $$ -o $PPID -o %PPID -x "${1##*/}"
+}
+
+status_of_one() {
+    PID_FILE="$1"
+    local RC
+    local RETVAL
+    if [ -f "$PID_FILE" ]; then
+        # set $pid
+        __pids_var_run NOT_USED $PID_FILE
+        RC=$?
+        if [ -n "$pid" -o 0$RC -gt 0 ]; then
+            RETVAL=2 # Program is dead and pid file exists
+        fi
+        #check if proces with pid from the file is running
+        if status_of_proc -p $PID_FILE /usr/sbin/$NAME $NAME; then
+            echo "running."
+            RETVAL=0
+        else
+            echo "not running."
+            RETVAL=1
+        fi
+    else
+        echo "not running."
+        RETVAL=3
+    fi
+    return $RETVAL
+}
+
+kstatus() {
+    RETVAL=0
+    SECONDVAL=256
+    echo -n "dynflow_executor is "
+    status_of_one $FOREMAN_PID_DIR/dynflow_executor.pid
+    RC=$?
+    RETVAL=$( print_higher $RC $RETVAL )
+    SECONDVAL=$( print_lower $RC $SECONDVAL )
+    echo -n "dynflow_executor_monitor is "
+    status_of_one $FOREMAN_PID_DIR/dynflow_executor_monitor.pid
+    RC=$?
+    RETVAL=$( print_higher $RC $RETVAL )
+    SECONDVAL=$( print_lower $RC $SECONDVAL )
+    if [  0$SECONDVAL -eq 0  -a  0$RETVAL -gt 0 ]; then
+       # some is running, some not
+       return 10
+    else
+       return $RETVAL
+    fi
+}
+
+status_q() {
+    kstatus &> /dev/null
+    return $?
+}
+
+start() {
+
+    echo -n $"Starting $NAME: "
+    status_q
+    STATUS=$?
+    if [ 0$STATUS -eq 0 ]; then
+        echo -n $"$NAME is already running. "
+        RETVAL=0
+        echo_success
+    elif [ 0$STATUS -eq 10 ]; then
+        echo -n $"Some processes of $NAME is already running. Some not. Please stop $NAME first."
+        RETVAL=10
+        log_end_msg 1
+    else
+        # rails expects you to run from the root of the app
+        pushd ${FOREMAN_HOME} >/dev/null
+        # start jobs
+        su -s /bin/bash - ${FOREMAN_USER} -c "\
+            RAILS_RELATIVE_URL_ROOT='$RAILS_RELATIVE_URL_ROOT' \
+            RAILS_ENV='$RAILS_ENV' \
+            FOREMAN_LOGGING='$FOREMAN_LOGGING' \
+            FOREMAN_LOGGING_SQL='$FOREMAN_LOGGING_SQL' \
+            $DAEMON $FOREMAN_TASK_PARAMS -m -n $FOREMAN_TASK_WORKERS start &>>${FOREMAN_LOG_DIR}/jobs-startup.log"
+        RETVAL=$?
+        if [ $RETVAL = 0 ]; then
+            log_success_msg $NAME start
+        else
+            log_failure_msg $NAME start
+        fi
+        popd >/dev/null
+    fi
+
+    echo
+    return $RETVAL
+}
+
+stop() {
+
+    status_q
+    STATUS=$?
+    if [ 0$STATUS -eq 0 -o 0$STATUS -eq 10 ]; then
+        # rails expects you to run from the root of the app
+        pushd ${FOREMAN_HOME} >/dev/null
+        su -s /bin/bash - ${FOREMAN_USER} -c "\
+            RAILS_RELATIVE_URL_ROOT='$RAILS_RELATIVE_URL_ROOT' \
+            RAILS_ENV='$RAILS_ENV' \
+            FOREMAN_LOGGING='$FOREMAN_LOGGING' \
+            FOREMAN_LOGGING_SQL='$FOREMAN_LOGGING_SQL' \
+            $DAEMON $FOREMAN_TASK_PARAMS -m -n $FOREMAN_TASK_WORKERS stop &>>${FOREMAN_LOG_DIR}/jobs-startup.log"
+        if [ -f $FOREMAN_PID_DIR/dynflow_executor_monitor.pid ]; then
+            echo -n $"Stopping dynflow_executor_monitor: "
+            killproc -p $FOREMAN_PID_DIR/dynflow_executor_monitor.pid
+            echo
+        fi
+        if [ -f $FOREMAN_PID_DIR/dynflow_executor.pid ]; then
+            echo -n $"Stopping dynflow_executor: "
+            killproc -p $FOREMAN_PID_DIR/dynflow_executor.pid
+            echo
+        fi
+       popd >/dev/null
+        RETVAL=0
+    else
+        RETVAL=0
+        echo -n "Stopping $NAME: "
+        echo_failure
+        echo
+    fi
+
+    return $RETVAL
+}
+
+restart() {
+    stop
+    start
+}
+
+condstop() {
+    status_q
+    STATUS=$?
+    if [ 0$STATUS -eq 0 -o 0$STATUS -eq 10 ]; then
+        stop
+    else
+        RETVAL=0
+    fi
+}
+
+condrestart() {
+    status_q
+    STATUS=$?
+    if [ 0$STATUS -eq 0 -o 0$STATUS -eq 10 ]; then
+        restart
+    else
+        RETVAL=0
+    fi
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart)
+        restart
+        ;;
+    condrestart|try-restart)
+        condrestart
+        ;;
+    condstop)
+        condstop
+        ;;
+    status)
+        kstatus
+        RETVAL=$?
+        ;;
+    *)
+        echo "Usage: {start|stop|restart|condrestart|condstop|status}"
+        exit 1
+        ;;
+esac
+
+exit $RETVAL
+
+# vim:set sw=4 ts=4 et:

--- a/debian/jessie/foreman/foreman.install
+++ b/debian/jessie/foreman/foreman.install
@@ -6,6 +6,7 @@ config/settings.yaml                     etc/foreman
 config/database.yml                      etc/foreman
 script/foreman-rake                      usr/sbin
 script/foreman-tail                      usr/sbin
+debian/sbin/foreman-tasks                usr/sbin
 app                                      usr/share/foreman
 bin                                      usr/share/foreman
 config                                   usr/share/foreman
@@ -23,6 +24,7 @@ extras/dbmigrate                         usr/share/foreman/extras
 extras/ignored_environments.yml.sample   usr/share/foreman/extras
 extras/noVNC                             usr/share/foreman/extras
 bundler.d/facter.rb                      usr/share/foreman/bundler.d
+bundler.d/foreman_tasks.rb               usr/share/foreman/bundler.d
 bundler.d/jsonp.rb                       usr/share/foreman/bundler.d
 public                                   var/lib/foreman
 db                                       var/lib/foreman

--- a/debian/jessie/foreman/rules
+++ b/debian/jessie/foreman/rules
@@ -19,13 +19,19 @@ build:
 	/usr/bin/nodejs node_modules/.bin/npm install --no-optional
 	/usr/bin/bundle package
 	/usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production
+	/usr/bin/bundle exec rake assets:precompile[foreman_tasks] RAILS_ENV=production
 	/usr/bin/bundle exec rake webpack:compile
 	/usr/bin/bundle exec rake db:migrate --trace RAILS_ENV=production
 	# we need to allow taxonomies so apipie cache renders documentation with them
 	/bin/sed -i 's/:locations_enabled: false/:locations_enabled: true/' config/settings.yaml
 	/bin/sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' config/settings.yaml
 	/usr/bin/bundle exec rake apipie:cache cache_part=resources --trace RAILS_ENV=production
+	/usr/bin/bundle exec rake plugin:apipie:cache[foreman-tasks] cache_part=resources RAILS_ENV=production
 	/bin/rm db/production.sqlite3
 	/bin/sed -ri '1sXenv rubyXenv foreman-rubyX' bin/*
 	/bin/sed -ri 's~^BUNDLER_CMD=""~BUNDLER_CMD="/usr/bin/foreman-ruby /usr/bin/bundle exec"~' script/foreman-rake
 	/bin/mkdir -p .ssh
+
+install/foreman::
+	dh_installinit
+	dh_installinit --name=foreman-tasks

--- a/debian/jessie/foreman/sbin/foreman-tasks
+++ b/debian/jessie/foreman/sbin/foreman-tasks
@@ -1,0 +1,5 @@
+#!/usr/bin/foreman-ruby
+
+foreman_root = "/usr/share/foreman"
+require File.expand_path('./config/application', foreman_root)
+ForemanTasks::Dynflow::Daemon.new.run_background(ARGV.last, :foreman_root => foreman_root)

--- a/debian/trusty/foreman/control
+++ b/debian/trusty/foreman/control
@@ -14,8 +14,10 @@ Section: web
 Priority: extra
 Depends: ruby2.0, bundler (>= 1.3.5-2ubuntu2), ruby2.0-dev,
          zlib1g-dev, build-essential,
-         rake (>=0.8.4), ${misc:Depends}
+         rake (>=0.8.4), bash, ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug, python-minimal
+Conflicts: ruby-foreman-tasks
+Replaces: ruby-foreman-tasks
 Description: Systems management web interface
  Foreman is aimed to be a single address for all machines life cycle management.
  .

--- a/debian/trusty/foreman/foreman.foreman-tasks.init
+++ b/debian/trusty/foreman/foreman.foreman-tasks.init
@@ -1,0 +1,266 @@
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides:          foreman-tasks
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Init script for foreman-tasks
+# Description:       Init script for foreman-tasks service used by foreman-tasks foreman plugin
+### END INIT INFO
+
+# Author: Marek Hulan <mhulan@redhat.com>
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="Foreman-tasks start dynflow executor"
+NAME=foreman-tasks
+DAEMON=/usr/sbin/$NAME
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.2-14) to ensure that this file is present
+# and status_of_proc is working.
+. /lib/lsb/init-functions
+
+RETVAL=0
+FOREMAN_USER=${FOREMAN_USER:-foreman}
+FOREMAN_HOME=${FOREMAN_HOME:-/usr/share/foreman}
+FOREMAN_DATA_DIR=${FOREMAN_DATA_DIR:-/var/lib/foreman}
+FOREMAN_ENV=${FOREMAN_ENV:-production}
+FOREMAN_TASK_PARAMS=${FOREMAN_TASK_PARAMS:--p foreman}
+FOREMAN_PID_DIR=$FOREMAN_HOME/tmp/pids
+FOREMAN_LOG_DIR=${FOREMAN_LOG_DIR:-/var/log/foreman}
+DAEMON="/usr/sbin/foreman-tasks"
+PID_FILE=$FOREMAN_PID_DIR/dynflow_executor_monitor.pid
+export RAILS_ENV=$FOREMAN_ENV
+export FOREMAN_LOGGING=${FOREMAN_LOGGING:-warn}
+export FOREMAN_LOGGING_SQL=${FOREMAN_LOGGING_SQL:-warn}
+export RAILS_RELATIVE_URL_ROOT=$FOREMAN_PREFIX
+
+print_higher() {
+    if [ 0$1 -gt 0$2 ]; then
+        echo $1
+    else
+        echo $2
+    fi
+}
+
+print_lower() {
+    if [ 0$1 -gt 0$2 ]; then
+        echo $2
+    else
+        echo $1
+    fi
+}
+
+__pids_var_run() {
+        local base=${1##*/}
+        local pid_file=${2:-/var/run/$base.pid}
+
+        pid=
+        if [ -f "$pid_file" ] ; then
+                local line p
+                read line < "$pid_file"
+                for p in $line ; do
+                        [ -z "${p//[0-9]/}" -a -d "/proc/$p" ] && pid="$pid $p"
+                done
+                if [ -n "$pid" ]; then
+                        return 0
+                fi
+                return 1 # "Program is dead and /var/run pid file exists"
+        fi
+        return 3 # "Program is not running"
+}
+
+# Output PIDs of matching processes, found using pidof
+__pids_pidof() {
+        pidof -c -o $$ -o $PPID -o %PPID -x "$1" || \
+                pidof -c -o $$ -o $PPID -o %PPID -x "${1##*/}"
+}
+
+status_of_one() {
+    PID_FILE="$1"
+    local RC
+    local RETVAL
+    if [ -f "$PID_FILE" ]; then
+        # set $pid
+        __pids_var_run NOT_USED $PID_FILE
+        RC=$?
+        if [ -n "$pid" -o 0$RC -gt 0 ]; then
+            RETVAL=2 # Program is dead and pid file exists
+        fi
+        #check if proces with pid from the file is running
+        if status_of_proc -p $PID_FILE /usr/sbin/$NAME $NAME; then
+            echo "running."
+            RETVAL=0
+        else
+            echo "not running."
+            RETVAL=1
+        fi
+    else
+        echo "not running."
+        RETVAL=3
+    fi
+    return $RETVAL
+}
+
+kstatus() {
+    RETVAL=0
+    SECONDVAL=256
+    echo -n "dynflow_executor is "
+    status_of_one $FOREMAN_PID_DIR/dynflow_executor.pid
+    RC=$?
+    RETVAL=$( print_higher $RC $RETVAL )
+    SECONDVAL=$( print_lower $RC $SECONDVAL )
+    echo -n "dynflow_executor_monitor is "
+    status_of_one $FOREMAN_PID_DIR/dynflow_executor_monitor.pid
+    RC=$?
+    RETVAL=$( print_higher $RC $RETVAL )
+    SECONDVAL=$( print_lower $RC $SECONDVAL )
+    if [  0$SECONDVAL -eq 0  -a  0$RETVAL -gt 0 ]; then
+       # some is running, some not
+       return 10
+    else
+       return $RETVAL
+    fi
+}
+
+status_q() {
+    kstatus &> /dev/null
+    return $?
+}
+
+start() {
+
+    echo -n $"Starting $NAME: "
+    status_q
+    STATUS=$?
+    if [ 0$STATUS -eq 0 ]; then
+        echo -n $"$NAME is already running. "
+        RETVAL=0
+        echo_success
+    elif [ 0$STATUS -eq 10 ]; then
+        echo -n $"Some processes of $NAME is already running. Some not. Please stop $NAME first."
+        RETVAL=10
+        log_end_msg 1
+    else
+        # rails expects you to run from the root of the app
+        pushd ${FOREMAN_HOME} >/dev/null
+        # start jobs
+        su -s /bin/bash - ${FOREMAN_USER} -c "\
+            RAILS_RELATIVE_URL_ROOT='$RAILS_RELATIVE_URL_ROOT' \
+            RAILS_ENV='$RAILS_ENV' \
+            FOREMAN_LOGGING='$FOREMAN_LOGGING' \
+            FOREMAN_LOGGING_SQL='$FOREMAN_LOGGING_SQL' \
+            $DAEMON $FOREMAN_TASK_PARAMS -m -n $FOREMAN_TASK_WORKERS start &>>${FOREMAN_LOG_DIR}/jobs-startup.log"
+        RETVAL=$?
+        if [ $RETVAL = 0 ]; then
+            log_success_msg $NAME start
+        else
+            log_failure_msg $NAME start
+        fi
+        popd >/dev/null
+    fi
+
+    echo
+    return $RETVAL
+}
+
+stop() {
+
+    status_q
+    STATUS=$?
+    if [ 0$STATUS -eq 0 -o 0$STATUS -eq 10 ]; then
+        # rails expects you to run from the root of the app
+        pushd ${FOREMAN_HOME} >/dev/null
+        su -s /bin/bash - ${FOREMAN_USER} -c "\
+            RAILS_RELATIVE_URL_ROOT='$RAILS_RELATIVE_URL_ROOT' \
+            RAILS_ENV='$RAILS_ENV' \
+            FOREMAN_LOGGING='$FOREMAN_LOGGING' \
+            FOREMAN_LOGGING_SQL='$FOREMAN_LOGGING_SQL' \
+            $DAEMON $FOREMAN_TASK_PARAMS -m -n $FOREMAN_TASK_WORKERS stop &>>${FOREMAN_LOG_DIR}/jobs-startup.log"
+        if [ -f $FOREMAN_PID_DIR/dynflow_executor_monitor.pid ]; then
+            echo -n $"Stopping dynflow_executor_monitor: "
+            killproc -p $FOREMAN_PID_DIR/dynflow_executor_monitor.pid
+            echo
+        fi
+        if [ -f $FOREMAN_PID_DIR/dynflow_executor.pid ]; then
+            echo -n $"Stopping dynflow_executor: "
+            killproc -p $FOREMAN_PID_DIR/dynflow_executor.pid
+            echo
+        fi
+       popd >/dev/null
+        RETVAL=0
+    else
+        RETVAL=0
+        echo -n "Stopping $NAME: "
+        echo_failure
+        echo
+    fi
+
+    return $RETVAL
+}
+
+restart() {
+    stop
+    start
+}
+
+condstop() {
+    status_q
+    STATUS=$?
+    if [ 0$STATUS -eq 0 -o 0$STATUS -eq 10 ]; then
+        stop
+    else
+        RETVAL=0
+    fi
+}
+
+condrestart() {
+    status_q
+    STATUS=$?
+    if [ 0$STATUS -eq 0 -o 0$STATUS -eq 10 ]; then
+        restart
+    else
+        RETVAL=0
+    fi
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart)
+        restart
+        ;;
+    condrestart|try-restart)
+        condrestart
+        ;;
+    condstop)
+        condstop
+        ;;
+    status)
+        kstatus
+        RETVAL=$?
+        ;;
+    *)
+        echo "Usage: {start|stop|restart|condrestart|condstop|status}"
+        exit 1
+        ;;
+esac
+
+exit $RETVAL
+
+# vim:set sw=4 ts=4 et:

--- a/debian/trusty/foreman/foreman.install
+++ b/debian/trusty/foreman/foreman.install
@@ -6,6 +6,7 @@ config/settings.yaml                     etc/foreman
 config/database.yml                      etc/foreman
 script/foreman-rake                      usr/sbin
 script/foreman-tail                      usr/sbin
+debian/sbin/foreman-tasks                usr/sbin
 app                                      usr/share/foreman
 bin                                      usr/share/foreman
 config                                   usr/share/foreman
@@ -23,6 +24,7 @@ extras/dbmigrate                         usr/share/foreman/extras
 extras/ignored_environments.yml.sample   usr/share/foreman/extras
 extras/noVNC                             usr/share/foreman/extras
 bundler.d/facter.rb                      usr/share/foreman/bundler.d
+bundler.d/foreman_tasks.rb               usr/share/foreman/bundler.d
 bundler.d/jsonp.rb                       usr/share/foreman/bundler.d
 public                                   var/lib/foreman
 db                                       var/lib/foreman

--- a/debian/trusty/foreman/rules
+++ b/debian/trusty/foreman/rules
@@ -19,15 +19,21 @@ build:
 	/usr/bin/nodejs node_modules/.bin/npm install --no-optional
 	/usr/bin/ruby2.0 /usr/bin/bundle pack --all
 	/usr/bin/ruby2.0 /usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production
+	/usr/bin/ruby2.0 /usr/bin/bundle exec rake assets:precompile[foreman_tasks] RAILS_ENV=production
 	/usr/bin/ruby2.0 /usr/bin/bundle exec rake webpack:compile
 	/usr/bin/ruby2.0 /usr/bin/bundle exec rake db:migrate --trace RAILS_ENV=production
 	# we need to allow taxonomies so apipie cache renders documentation with them
 	/bin/sed -i 's/:locations_enabled: false/:locations_enabled: true/' config/settings.yaml
 	/bin/sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' config/settings.yaml
 	/usr/bin/ruby2.0 /usr/bin/bundle exec rake apipie:cache cache_part=resources --trace RAILS_ENV=production
+	/usr/bin/ruby2.0 /usr/bin/bundle exec rake plugin:apipie:cache[foreman-tasks] cache_part=resources --trace RAILS_ENV=production
 	/bin/rm db/production.sqlite3
 	# Use rake2.0 explicitly
 	/bin/sed -ri 'sX/usr/bin/rake$$X/usr/bin/rake2.0X' extras/dbmigrate script/foreman-rake
 	/bin/sed -ri '1sXenv rubyXenv foreman-rubyX' bin/*
 	/bin/sed -ri 's~^BUNDLER_CMD=""~BUNDLER_CMD="/usr/bin/foreman-ruby /usr/bin/bundle exec"~' script/foreman-rake
 	/bin/mkdir -p .ssh
+
+install/foreman::
+	dh_installinit
+	dh_installinit --name=foreman-tasks

--- a/debian/trusty/foreman/sbin/foreman-tasks
+++ b/debian/trusty/foreman/sbin/foreman-tasks
@@ -1,0 +1,5 @@
+#!/usr/bin/foreman-ruby
+
+foreman_root = "/usr/share/foreman"
+require File.expand_path('./config/application', foreman_root)
+ForemanTasks::Dynflow::Daemon.new.run_background(ARGV.last, :foreman_root => foreman_root)

--- a/debian/xenial/foreman/control
+++ b/debian/xenial/foreman/control
@@ -15,9 +15,10 @@ Section: web
 Priority: extra
 Depends: ruby2.3, bundler (>= 1.3), zlib1g-dev,
          ruby2.3-dev, build-essential,
-         rake (>=0.8.4), ${misc:Depends}
+         rake (>=0.8.4), bash, ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug, python-minimal
-Conflicts: ruby-activerecord-deprecated-finders
+Conflicts: ruby-activerecord-deprecated-finders, ruby-foreman-tasks
+Replaces: ruby-foreman-tasks
 Description: Systems management web interface
  Foreman is aimed to be a single address for all machines life cycle management.
  .

--- a/debian/xenial/foreman/foreman.foreman-tasks.init
+++ b/debian/xenial/foreman/foreman.foreman-tasks.init
@@ -1,0 +1,266 @@
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides:          foreman-tasks
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Init script for foreman-tasks
+# Description:       Init script for foreman-tasks service used by foreman-tasks foreman plugin
+### END INIT INFO
+
+# Author: Marek Hulan <mhulan@redhat.com>
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="Foreman-tasks start dynflow executor"
+NAME=foreman-tasks
+DAEMON=/usr/sbin/$NAME
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.2-14) to ensure that this file is present
+# and status_of_proc is working.
+. /lib/lsb/init-functions
+
+RETVAL=0
+FOREMAN_USER=${FOREMAN_USER:-foreman}
+FOREMAN_HOME=${FOREMAN_HOME:-/usr/share/foreman}
+FOREMAN_DATA_DIR=${FOREMAN_DATA_DIR:-/var/lib/foreman}
+FOREMAN_ENV=${FOREMAN_ENV:-production}
+FOREMAN_TASK_PARAMS=${FOREMAN_TASK_PARAMS:--p foreman}
+FOREMAN_PID_DIR=$FOREMAN_HOME/tmp/pids
+FOREMAN_LOG_DIR=${FOREMAN_LOG_DIR:-/var/log/foreman}
+DAEMON="/usr/sbin/foreman-tasks"
+PID_FILE=$FOREMAN_PID_DIR/dynflow_executor_monitor.pid
+export RAILS_ENV=$FOREMAN_ENV
+export FOREMAN_LOGGING=${FOREMAN_LOGGING:-warn}
+export FOREMAN_LOGGING_SQL=${FOREMAN_LOGGING_SQL:-warn}
+export RAILS_RELATIVE_URL_ROOT=$FOREMAN_PREFIX
+
+print_higher() {
+    if [ 0$1 -gt 0$2 ]; then
+        echo $1
+    else
+        echo $2
+    fi
+}
+
+print_lower() {
+    if [ 0$1 -gt 0$2 ]; then
+        echo $2
+    else
+        echo $1
+    fi
+}
+
+__pids_var_run() {
+        local base=${1##*/}
+        local pid_file=${2:-/var/run/$base.pid}
+
+        pid=
+        if [ -f "$pid_file" ] ; then
+                local line p
+                read line < "$pid_file"
+                for p in $line ; do
+                        [ -z "${p//[0-9]/}" -a -d "/proc/$p" ] && pid="$pid $p"
+                done
+                if [ -n "$pid" ]; then
+                        return 0
+                fi
+                return 1 # "Program is dead and /var/run pid file exists"
+        fi
+        return 3 # "Program is not running"
+}
+
+# Output PIDs of matching processes, found using pidof
+__pids_pidof() {
+        pidof -c -o $$ -o $PPID -o %PPID -x "$1" || \
+                pidof -c -o $$ -o $PPID -o %PPID -x "${1##*/}"
+}
+
+status_of_one() {
+    PID_FILE="$1"
+    local RC
+    local RETVAL
+    if [ -f "$PID_FILE" ]; then
+        # set $pid
+        __pids_var_run NOT_USED $PID_FILE
+        RC=$?
+        if [ -n "$pid" -o 0$RC -gt 0 ]; then
+            RETVAL=2 # Program is dead and pid file exists
+        fi
+        #check if proces with pid from the file is running
+        if status_of_proc -p $PID_FILE /usr/sbin/$NAME $NAME; then
+            echo "running."
+            RETVAL=0
+        else
+            echo "not running."
+            RETVAL=1
+        fi
+    else
+        echo "not running."
+        RETVAL=3
+    fi
+    return $RETVAL
+}
+
+kstatus() {
+    RETVAL=0
+    SECONDVAL=256
+    echo -n "dynflow_executor is "
+    status_of_one $FOREMAN_PID_DIR/dynflow_executor.pid
+    RC=$?
+    RETVAL=$( print_higher $RC $RETVAL )
+    SECONDVAL=$( print_lower $RC $SECONDVAL )
+    echo -n "dynflow_executor_monitor is "
+    status_of_one $FOREMAN_PID_DIR/dynflow_executor_monitor.pid
+    RC=$?
+    RETVAL=$( print_higher $RC $RETVAL )
+    SECONDVAL=$( print_lower $RC $SECONDVAL )
+    if [  0$SECONDVAL -eq 0  -a  0$RETVAL -gt 0 ]; then
+       # some is running, some not
+       return 10
+    else
+       return $RETVAL
+    fi
+}
+
+status_q() {
+    kstatus &> /dev/null
+    return $?
+}
+
+start() {
+
+    echo -n $"Starting $NAME: "
+    status_q
+    STATUS=$?
+    if [ 0$STATUS -eq 0 ]; then
+        echo -n $"$NAME is already running. "
+        RETVAL=0
+        echo_success
+    elif [ 0$STATUS -eq 10 ]; then
+        echo -n $"Some processes of $NAME is already running. Some not. Please stop $NAME first."
+        RETVAL=10
+        log_end_msg 1
+    else
+        # rails expects you to run from the root of the app
+        pushd ${FOREMAN_HOME} >/dev/null
+        # start jobs
+        su -s /bin/bash - ${FOREMAN_USER} -c "\
+            RAILS_RELATIVE_URL_ROOT='$RAILS_RELATIVE_URL_ROOT' \
+            RAILS_ENV='$RAILS_ENV' \
+            FOREMAN_LOGGING='$FOREMAN_LOGGING' \
+            FOREMAN_LOGGING_SQL='$FOREMAN_LOGGING_SQL' \
+            $DAEMON $FOREMAN_TASK_PARAMS -m -n $FOREMAN_TASK_WORKERS start &>>${FOREMAN_LOG_DIR}/jobs-startup.log"
+        RETVAL=$?
+        if [ $RETVAL = 0 ]; then
+            log_success_msg $NAME start
+        else
+            log_failure_msg $NAME start
+        fi
+        popd >/dev/null
+    fi
+
+    echo
+    return $RETVAL
+}
+
+stop() {
+
+    status_q
+    STATUS=$?
+    if [ 0$STATUS -eq 0 -o 0$STATUS -eq 10 ]; then
+        # rails expects you to run from the root of the app
+        pushd ${FOREMAN_HOME} >/dev/null
+        su -s /bin/bash - ${FOREMAN_USER} -c "\
+            RAILS_RELATIVE_URL_ROOT='$RAILS_RELATIVE_URL_ROOT' \
+            RAILS_ENV='$RAILS_ENV' \
+            FOREMAN_LOGGING='$FOREMAN_LOGGING' \
+            FOREMAN_LOGGING_SQL='$FOREMAN_LOGGING_SQL' \
+            $DAEMON $FOREMAN_TASK_PARAMS -m -n $FOREMAN_TASK_WORKERS stop &>>${FOREMAN_LOG_DIR}/jobs-startup.log"
+        if [ -f $FOREMAN_PID_DIR/dynflow_executor_monitor.pid ]; then
+            echo -n $"Stopping dynflow_executor_monitor: "
+            killproc -p $FOREMAN_PID_DIR/dynflow_executor_monitor.pid
+            echo
+        fi
+        if [ -f $FOREMAN_PID_DIR/dynflow_executor.pid ]; then
+            echo -n $"Stopping dynflow_executor: "
+            killproc -p $FOREMAN_PID_DIR/dynflow_executor.pid
+            echo
+        fi
+       popd >/dev/null
+        RETVAL=0
+    else
+        RETVAL=0
+        echo -n "Stopping $NAME: "
+        echo_failure
+        echo
+    fi
+
+    return $RETVAL
+}
+
+restart() {
+    stop
+    start
+}
+
+condstop() {
+    status_q
+    STATUS=$?
+    if [ 0$STATUS -eq 0 -o 0$STATUS -eq 10 ]; then
+        stop
+    else
+        RETVAL=0
+    fi
+}
+
+condrestart() {
+    status_q
+    STATUS=$?
+    if [ 0$STATUS -eq 0 -o 0$STATUS -eq 10 ]; then
+        restart
+    else
+        RETVAL=0
+    fi
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart)
+        restart
+        ;;
+    condrestart|try-restart)
+        condrestart
+        ;;
+    condstop)
+        condstop
+        ;;
+    status)
+        kstatus
+        RETVAL=$?
+        ;;
+    *)
+        echo "Usage: {start|stop|restart|condrestart|condstop|status}"
+        exit 1
+        ;;
+esac
+
+exit $RETVAL
+
+# vim:set sw=4 ts=4 et:

--- a/debian/xenial/foreman/foreman.install
+++ b/debian/xenial/foreman/foreman.install
@@ -6,6 +6,7 @@ config/settings.yaml                     etc/foreman
 config/database.yml                      etc/foreman
 script/foreman-rake                      usr/sbin
 script/foreman-tail                      usr/sbin
+debian/sbin/foreman-tasks                usr/sbin
 app                                      usr/share/foreman
 bin                                      usr/share/foreman
 config                                   usr/share/foreman
@@ -23,6 +24,7 @@ extras/dbmigrate                         usr/share/foreman/extras
 extras/ignored_environments.yml.sample   usr/share/foreman/extras
 extras/noVNC                             usr/share/foreman/extras
 bundler.d/facter.rb                      usr/share/foreman/bundler.d
+bundler.d/foreman_tasks.rb               usr/share/foreman/bundler.d
 bundler.d/jsonp.rb                       usr/share/foreman/bundler.d
 public                                   var/lib/foreman
 db                                       var/lib/foreman

--- a/debian/xenial/foreman/rules
+++ b/debian/xenial/foreman/rules
@@ -18,13 +18,19 @@ build:
 	/usr/bin/npm install --no-optional
 	/usr/bin/bundle package
 	/usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production
+	/usr/bin/bundle exec rake assets:precompile[foreman_tasks] RAILS_ENV=production
 	/usr/bin/bundle exec rake webpack:compile
 	/usr/bin/bundle exec rake db:migrate --trace RAILS_ENV=production
 	# we need to allow taxonomies so apipie cache renders documentation with them
 	/bin/sed -i 's/:locations_enabled: false/:locations_enabled: true/' config/settings.yaml
 	/bin/sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' config/settings.yaml
 	/usr/bin/bundle exec rake apipie:cache cache_part=resources --trace RAILS_ENV=production
+	/usr/bin/bundle exec rake plugin:apipie:cache[foreman-tasks] cache_part=resources RAILS_ENV=production
 	/bin/rm db/production.sqlite3
 	/bin/sed -ri '1sXenv rubyXenv foreman-rubyX' bin/*
 	/bin/sed -ri 's~^BUNDLER_CMD=""~BUNDLER_CMD="/usr/bin/foreman-ruby /usr/bin/bundle exec"~' script/foreman-rake
 	/bin/mkdir -p .ssh
+
+install/foreman::
+	dh_installinit
+	dh_installinit --name=foreman-tasks

--- a/debian/xenial/foreman/sbin/foreman-tasks
+++ b/debian/xenial/foreman/sbin/foreman-tasks
@@ -1,0 +1,5 @@
+#!/usr/bin/foreman-ruby
+
+foreman_root = "/usr/share/foreman"
+require File.expand_path('./config/application', foreman_root)
+ForemanTasks::Dynflow::Daemon.new.run_background(ARGV.last, :foreman_root => foreman_root)


### PR DESCRIPTION
This should be built into:

* [x] Nightly

This obsoletes the ruby-foreman-tasks plugin DEB package, which will need to get removed after this (and plugins will need their dependencies updated).

This PR should resolve the bootstrapping problem of the plugin approach.