### PR TITLE
Release foreman_ansible 1.4.1 [deb]

### DIFF
--- a/plugins/ruby-foreman-ansible/debian/changelog
+++ b/plugins/ruby-foreman-ansible/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-ansible (1.4.1-1) stable; urgency=low
+
+  * 1.4.1 released
+
+ -- Daniel Lobato Garcia <me@daniellobato.me>  Thu, 19 Jan 2017 20:50:43 +0100
+
 ruby-foreman-ansible (1.3.0-1) stable; urgency=low
 
   * 1.3.0 released

--- a/plugins/ruby-foreman-ansible/debian/control
+++ b/plugins/ruby-foreman-ansible/debian/control
@@ -11,6 +11,7 @@ Homepage: https://github.com/theforeman/foreman_ansible
 Package: ruby-foreman-ansible
 Architecture: all
 Depends: ${misc:Depends}, bundler, foreman (>= 1.12.0~rc1),
+  foreman-assets(>= 1.12.0~rc1),
   ruby-foreman-deface (<<2.0.0), ruby-foreman-tasks (>= 0.8.2-2),
   ruby-foreman-tasks (<<0.9.0)
 Description: Foreman Ansible plugin

--- a/plugins/ruby-foreman-ansible/debian/gem.list
+++ b/plugins/ruby-foreman-ansible/debian/gem.list
@@ -1,3 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_ansible-1.3.0.gem"
-GEMS="$GEMS https://rubygems.org/downloads/foreman_ansible_core-0.0.1.gem"
+GEMS="https://rubygems.org/downloads/foreman_ansible-1.4.1.gem"
+GEMS="$GEMS https://rubygems.org/downloads/foreman_ansible_core-1.0.0.gem"

--- a/plugins/ruby-foreman-ansible/debian/install
+++ b/plugins/ruby-foreman-ansible/debian/install
@@ -1,3 +1,4 @@
 foreman_ansible.rb  usr/share/foreman/bundler.d
-cache                usr/share/foreman/vendor
+cache               usr/share/foreman/vendor
+assets              var/lib/foreman/public
 apipie-cache/foreman_ansible var/lib/foreman/public/apipie-cache/plugin

--- a/plugins/ruby-foreman-ansible/debian/rules
+++ b/plugins/ruby-foreman-ansible/debian/rules
@@ -17,6 +17,7 @@ build:
 	cd /usr/share/foreman && ( \
 		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
 		/usr/bin/foreman-ruby /usr/bin/bundle exec rake db:migrate RAILS_ENV=development && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production && \
 		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
 		OUT=/var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) RAILS_ENV=development \
 		)

--- a/plugins/ruby-foreman-ansible/foreman_ansible.rb
+++ b/plugins/ruby-foreman-ansible/foreman_ansible.rb
@@ -1,1 +1,1 @@
-gem 'foreman_ansible', '1.3.0'
+gem 'foreman_ansible', '1.4.1'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.14
* [x] 1.13
* [x] 1.12

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

Relies on https://github.com/theforeman/foreman-packaging/pull/1497 to work - please merge for all applicable versions. 1.4.0 I had to skip because the dependency with foreman_ansible_core was too open