### PR TITLE
Release smart_proxy_ansible 1.0.1 [deb]

### DIFF
--- a/plugins/smart_proxy_ansible/ansible.rb
+++ b/plugins/smart_proxy_ansible/ansible.rb
@@ -1,2 +1,2 @@
-gem 'smart_proxy_ansible', '0.0.1'
-gem 'foreman_ansible_core'
+gem 'smart_proxy_ansible', '1.0.1'
+gem 'foreman_ansible_core', '~> 1.0.0'

--- a/plugins/smart_proxy_ansible/changelog
+++ b/plugins/smart_proxy_ansible/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-ansible (1.0.1-1) stable; urgency=low
+
+  * 1.0.1 released
+
+ -- Daniel Lobato Garcia <me@daniellobato.me>  Thu, 19 Jan 2017 21:04:02 +0100
+
 ruby-smart-proxy-ansible (1.0.0-2) unstable; urgency=low
 
   * Add dependency on ansible

--- a/plugins/smart_proxy_ansible/control
+++ b/plugins/smart_proxy_ansible/control
@@ -11,6 +11,7 @@ Package: ruby-smart-proxy-ansible
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.11.0~rc3),
-  ruby-foreman-ansible-core, ruby-smart-proxy-dynflow (>= 0.1.0), ruby-smart-proxy-dynflow (<< 0.2.0),
+  ruby-foreman-ansible-core (>= 1.0.0), ruby-foreman-ansible-core (<< 1.1.0),
+  ruby-smart-proxy-dynflow (>= 0.1.0), ruby-smart-proxy-dynflow (<< 0.2.0),
   ansible (>= 2.2.0)
 Description: Ansible support for Foreman smart proxy


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.14
* [x] 1.13
* [x] 1.12

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

Relies on https://github.com/theforeman/foreman-packaging/pull/1497  to work - thanks! Please merge for all possible versions