### PR TITLE
Update rubygem-safemod to 1.2.5

### DIFF
--- a/rubygem-safemode/rubygem-safemode.spec
+++ b/rubygem-safemode/rubygem-safemode.spec
@@ -6,8 +6,8 @@
 Summary: A library for safe evaluation of Ruby code
 Name: %{?scl_prefix}rubygem-%{gem_name}
 
-Version: 1.2.4
-Release: 2%{?dist}
+Version: 1.2.5
+Release: 1%{?dist}
 Group: Development/Ruby
 License: MIT
 URL: http://github.com/svenfuchs/safemode

--- a/rubygem-safemode/safemode-1.2.4.gem
+++ b/rubygem-safemode/safemode-1.2.4.gem
@@ -1,1 +1,0 @@
-../.git/annex/objects/xP/2j/SHA256E-s20992--b9520fe8ad5b5098acbaa1f84bf877a940bdbeedc7e2c7bd45d74791f63755ae.4.gem/SHA256E-s20992--b9520fe8ad5b5098acbaa1f84bf877a940bdbeedc7e2c7bd45d74791f63755ae.4.gem

--- a/rubygem-safemode/safemode-1.2.5.gem
+++ b/rubygem-safemode/safemode-1.2.5.gem
@@ -1,0 +1,1 @@
+../.git/annex/objects/vv/3Q/SHA256E-s20992--5212ae579472d3de6662eaa6104b42aa5addbc8bb597733510fdce566b49a9bf.5.gem/SHA256E-s20992--5212ae579472d3de6662eaa6104b42aa5addbc8bb597733510fdce566b49a9bf.5.gem


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.14
* [ ] 1.13
* [ ] 1.12

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
