### PR TITLE
Updated ruby-foreman-memcache to 0.0.5 (DEB)

### DIFF
--- a/plugins/ruby-foreman-memcache/debian/changelog
+++ b/plugins/ruby-foreman-memcache/debian/changelog
@@ -1,7 +1,6 @@
 ruby-foreman-memcache (0.0.5-1) stable; urgency=low
 
   * 0.0.5 released
-  * Set HOME to ~foreman as rb-readline requires it
 
  -- Bram Vogelaar <bram@attachmentgenie.com>  Wed, 25 Jan 2017 11:29:00 +0000
 

--- a/plugins/ruby-foreman-memcache/debian/changelog
+++ b/plugins/ruby-foreman-memcache/debian/changelog
@@ -1,11 +1,6 @@
 ruby-foreman-memcache (0.0.5-1) stable; urgency=low
 
   * 0.0.5 released
-
- -- Bram Vogelaar <bram@inuits.eu>  Wed, 25 Jan 2017 11:30:45 +0100
-
-ruby-foreman-memcache (0.0.5) stable; urgency=low
-
   * Set HOME to ~foreman as rb-readline requires it
 
  -- Bram Vogelaar <bram@attachmentgenie.com>  Wed, 25 Jan 2017 11:29:00 +0000

--- a/plugins/ruby-foreman-memcache/debian/changelog
+++ b/plugins/ruby-foreman-memcache/debian/changelog
@@ -1,3 +1,15 @@
+ruby-foreman-memcache (0.0.5-1) stable; urgency=low
+
+  * 0.0.5 released
+
+ -- Bram Vogelaar <bram@inuits.eu>  Wed, 25 Jan 2017 11:30:45 +0100
+
+ruby-foreman-memcache (0.0.5) stable; urgency=low
+
+  * Set HOME to ~foreman as rb-readline requires it
+
+ -- Bram Vogelaar <bram@attachmentgenie.com>  Wed, 25 Jan 2017 11:29:00 +0000
+
 ruby-foreman-memcache (0.0.3-2) stable; urgency=low
 
   * Set HOME to ~foreman as rb-readline requires it

--- a/plugins/ruby-foreman-memcache/debian/gem.list
+++ b/plugins/ruby-foreman-memcache/debian/gem.list
@@ -1,3 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_memcache-0.0.3.gem"
+GEMS="https://rubygems.org/downloads/foreman_memcache-0.0.5.gem"
 GEMS="$GEMS https://rubygems.org/downloads/dalli-2.7.2.gem"

--- a/plugins/ruby-foreman-memcache/foreman_memcache.rb
+++ b/plugins/ruby-foreman-memcache/foreman_memcache.rb
@@ -1,1 +1,1 @@
-gem 'foreman_memcache', '0.0.3'
+gem 'foreman_memcache', '0.0.5'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.14
* [ ] 1.13
* [ ] 1.12

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
