### PR TITLE
Add missing deface dependency to ruby-foreman-memcache [deb]

### DIFF
--- a/plugins/ruby-foreman-memcache/debian/changelog
+++ b/plugins/ruby-foreman-memcache/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-memcache (0.0.5-2) stable; urgency=low
+
+  * Add missing deface dependency
+
+ -- Dominic Cleal <dominic@cleal.org>  Fri, 27 Jan 2017 14:46:43 +0000
+
 ruby-foreman-memcache (0.0.5-1) stable; urgency=low
 
   * 0.0.5 released

--- a/plugins/ruby-foreman-memcache/debian/control
+++ b/plugins/ruby-foreman-memcache/debian/control
@@ -8,6 +8,6 @@ Homepage: https://github.com/theforeman/foreman-memcache
 
 Package: ruby-foreman-memcache
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.5.0~rc1)
+Depends: ${misc:Depends}, bundler, foreman (>= 1.5.0~rc1), ruby-foreman-deface
 Description: Foreman Memcache Plugin
  Memcache plugin for Foreman


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x]  1.14
* [x] 1.13
* [ ] 1.12

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

Unless a new release is made sooner, with https://github.com/theforeman/foreman_memcache/pull/10.