### PR TITLE
Make foreman-selinux depend on container-selinux

### DIFF
--- a/foreman-selinux/foreman-selinux.spec
+++ b/foreman-selinux/foreman-selinux.spec
@@ -51,6 +51,7 @@ BuildRequires:  /usr/bin/pod2man
 BuildArch:      noarch
 
 Requires:           selinux-policy >= %{selinux_policy_ver}
+Requires:           container-selinux >= 2.0
 Requires(post):     /usr/sbin/semodule, /sbin/restorecon, /usr/sbin/setsebool, /usr/sbin/selinuxenabled, /usr/sbin/semanage
 Requires(post):     policycoreutils-python
 Requires(post):     selinux-policy-targeted
@@ -130,6 +131,7 @@ Summary: SELinux policy module for Foreman Proxy
 Group:   System Environment/Base
 
 Requires:           selinux-policy >= %{selinux_policy_ver}
+Requires:           container-selinux >= 2.0
 Requires(post):     /usr/sbin/semodule, /sbin/restorecon, /usr/sbin/setsebool, /usr/sbin/selinuxenabled, /usr/sbin/semanage
 Requires(post):     policycoreutils-python
 Requires(post):     selinux-policy-targeted


### PR DESCRIPTION
foreman-selinux used to define a type docker_port_t because there was no
official policy that defined this type.

container-selinux has this type too, and both policies cannot be
installed together. Since container-selinux is the default policy on EL
systems for container stuff, foreman-selinux shouldn't stop it from
being installed, and depend on it instead for the types it needs.

https://github.com/projectatomic/container-selinux/blob/master/container.te#L77 is where it's being defined. I see that at least version 2.0 is needed to get it, and I can't find RPMs earlier than that. 

https://github.com/theforeman/foreman-selinux/pull/66 removes the policy on foreman-selinux so it depends on it.

@rhatdan are we OK making the dependency on 2.0 here or there's 1.0 RPMs with this type too?

-----------------------------------------------

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.14
* [x] 1.13
* [x] 1.12

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

