### PR TITLE
update foreman_xen to 0.5.1 (DEB)

### DIFF
--- a/plugins/ruby-foreman-xen/debian/changelog
+++ b/plugins/ruby-foreman-xen/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-xen (0.5.1-1) stable; urgency=low
+
+  * 0.5.1 released
+
+ -- Michael Moll <mmoll@mmoll.at>  Thu, 22 Mar 2017 02:52:45 +0100
+
 ruby-foreman-xen (0.4.1-1) stable; urgency=low
 
   * 0.4.1 released

--- a/plugins/ruby-foreman-xen/debian/control
+++ b/plugins/ruby-foreman-xen/debian/control
@@ -2,7 +2,7 @@ Source: ruby-foreman-xen
 Section: ruby
 Priority: extra
 Maintainer: Michael Moll <mmoll@mmoll.at>
-Build-Depends: debhelper
+Build-Depends: debhelper, foreman-assets(>= 1.13.0~rc1), foreman-sqlite3(>= 1.13.0~rc1)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-xen
 

--- a/plugins/ruby-foreman-xen/debian/gem.list
+++ b/plugins/ruby-foreman-xen/debian/gem.list
@@ -1,2 +1,2 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_xen-0.4.1.gem"
+GEMS="https://rubygems.org/downloads/foreman_xen-0.5.1.gem"

--- a/plugins/ruby-foreman-xen/debian/install
+++ b/plugins/ruby-foreman-xen/debian/install
@@ -1,2 +1,3 @@
 foreman_xen.rb      usr/share/foreman/bundler.d
 cache               usr/share/foreman/vendor
+foreman_xen         var/lib/foreman/public/assets

--- a/plugins/ruby-foreman-xen/debian/rules
+++ b/plugins/ruby-foreman-xen/debian/rules
@@ -9,5 +9,18 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+PLUGIN = foreman_xen
+
+build:
+	cp cache/* /usr/share/foreman/vendor/cache/
+	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
+	cd /usr/share/foreman && ( \
+		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake db:migrate RAILS_ENV=development && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production \
+		)
+	GEM_PATH=$$(cd /usr/share/foreman && /usr/bin/foreman-ruby /usr/bin/bundle show $(PLUGIN)) && \
+    cp -rp $${GEM_PATH}/public/assets/$(PLUGIN) ./
+
 %:
-	dh $@ 
+	dh $@

--- a/plugins/ruby-foreman-xen/foreman_xen.rb
+++ b/plugins/ruby-foreman-xen/foreman_xen.rb
@@ -1,1 +1,1 @@
-gem 'foreman_xen', '0.4.1'
+gem 'foreman_xen', '0.5.1'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.14

While I think the plugin is still compatible with 1.13, it's better to only cherry-pick it into 1.14 support-wise.