### PR TITLE
Update deface to 1.2.0 [deb]

### DIFF
--- a/plugins/ruby-foreman-deface/debian/changelog
+++ b/plugins/ruby-foreman-deface/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-deface (1.2.0-1) stable; urgency=low
+
+  * 1.2.0 released
+
+ -- Dominic Cleal <dominic@cleal.org>  Mon, 20 Mar 2017 11:56:09 +0000
+
 ruby-foreman-deface (1.0.2-2) stable; urgency=low
 
   * Add missing polyglot dependency on 1.11+

--- a/plugins/ruby-foreman-deface/debian/gem.list
+++ b/plugins/ruby-foreman-deface/debian/gem.list
@@ -1,4 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/deface-1.0.2.gem"
-GEMS="$GEMS https://rubygems.org/downloads/colorize-0.7.7.gem"
+GEMS="https://rubygems.org/downloads/deface-1.2.0.gem"
 GEMS="$GEMS https://rubygems.org/downloads/polyglot-0.3.5.gem"

--- a/plugins/ruby-foreman-deface/foreman_deface.rb
+++ b/plugins/ruby-foreman-deface/foreman_deface.rb
@@ -1,1 +1,1 @@
-gem 'deface', '1.0.2'
+gem 'deface', '1.2.0'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly

---

`colorize` was replaced by `rainbow`, which is already in the `foreman` bundle cache.