### PR TITLE
Update PULL_REQUEST_TEMPLATE for 1.15

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 For plugin updates, please indicate which repos this should be built into:
 
 * [x] Nightly
+* [ ] 1.15
 * [ ] 1.14
 * [ ] 1.13
-* [ ] 1.12
 
 See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
 


### PR DESCRIPTION
To be merged once 1.15 repos are out

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.14
* [ ] 1.13
* [ ] 1.12

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
