### PR TITLE
pin concurrent-ruby to 1.0.3

### DIFF
--- a/debian/jessie/foreman/debian.rb
+++ b/debian/jessie/foreman/debian.rb
@@ -1,0 +1,1 @@
+gem 'concurrent-ruby', '= 1.0.3'

--- a/debian/jessie/foreman/foreman.install
+++ b/debian/jessie/foreman/foreman.install
@@ -22,6 +22,7 @@ vendor/cache                             usr/share/foreman/vendor
 extras/dbmigrate                         usr/share/foreman/extras
 extras/ignored_environments.yml.sample   usr/share/foreman/extras
 extras/noVNC                             usr/share/foreman/extras
+debian/debian.rb                         usr/share/foreman/bundler.d
 bundler.d/facter.rb                      usr/share/foreman/bundler.d
 bundler.d/jsonp.rb                       usr/share/foreman/bundler.d
 public                                   var/lib/foreman

--- a/debian/jessie/foreman/rules
+++ b/debian/jessie/foreman/rules
@@ -14,6 +14,7 @@ build:
 	/bin/rm -rf node_modules
 	/usr/bin/npm install npm
 	/usr/bin/nodejs node_modules/.bin/npm install --no-optional
+	/bin/cp debian/debian.rb bundler.d/
 	/usr/bin/bundle package
 	/usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production
 	/usr/bin/bundle exec rake webpack:compile

--- a/debian/trusty/foreman/debian.rb
+++ b/debian/trusty/foreman/debian.rb
@@ -1,0 +1,1 @@
+gem 'concurrent-ruby', '= 1.0.3'

--- a/debian/trusty/foreman/foreman.install
+++ b/debian/trusty/foreman/foreman.install
@@ -22,6 +22,7 @@ vendor/cache                             usr/share/foreman/vendor
 extras/dbmigrate                         usr/share/foreman/extras
 extras/ignored_environments.yml.sample   usr/share/foreman/extras
 extras/noVNC                             usr/share/foreman/extras
+debian/debian.rb                         usr/share/foreman/bundler.d
 bundler.d/facter.rb                      usr/share/foreman/bundler.d
 bundler.d/jsonp.rb                       usr/share/foreman/bundler.d
 public                                   var/lib/foreman

--- a/debian/trusty/foreman/rules
+++ b/debian/trusty/foreman/rules
@@ -14,6 +14,7 @@ build:
 	/bin/rm -rf node_modules
 	/usr/bin/npm install npm
 	/usr/bin/nodejs node_modules/.bin/npm install --no-optional
+	/bin/cp debian/debian.rb bundler.d/
 	/usr/bin/ruby2.0 /usr/bin/bundle pack --all
 	/usr/bin/ruby2.0 /usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production
 	/usr/bin/ruby2.0 /usr/bin/bundle exec rake webpack:compile

--- a/debian/xenial/foreman/debian.rb
+++ b/debian/xenial/foreman/debian.rb
@@ -1,0 +1,1 @@
+gem 'concurrent-ruby', '= 1.0.3'

--- a/debian/xenial/foreman/foreman.install
+++ b/debian/xenial/foreman/foreman.install
@@ -22,6 +22,7 @@ vendor/cache                             usr/share/foreman/vendor
 extras/dbmigrate                         usr/share/foreman/extras
 extras/ignored_environments.yml.sample   usr/share/foreman/extras
 extras/noVNC                             usr/share/foreman/extras
+debian/debian.rb                         usr/share/foreman/bundler.d
 bundler.d/facter.rb                      usr/share/foreman/bundler.d
 bundler.d/jsonp.rb                       usr/share/foreman/bundler.d
 public                                   var/lib/foreman

--- a/debian/xenial/foreman/rules
+++ b/debian/xenial/foreman/rules
@@ -13,6 +13,7 @@ build:
 	/bin/cp config/email.yaml.example config/email.yaml
 	/bin/rm -rf node_modules
 	/usr/bin/npm install --no-optional
+	/bin/cp debian/debian.rb bundler.d/
 	/usr/bin/bundle package
 	/usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production
 	/usr/bin/bundle exec rake webpack:compile


### PR DESCRIPTION
Dynflow commit 5fc0ba81 locked concurrent-ruby-edge to 0.2.3, which is
locked to concurrent-ruby 1.0.3. Foreman-tasks uses Dynflow and as other
gems pull in concurrent-ruby also in the Foreman core package, it needs to
get locked here also.

This should be built into:

* [x] Nightly