### PR TITLE
[DEB] Update foreman_remote_execution to 1.3.0 and foreman_remote_execution_core to 1.0.3

### DIFF
--- a/dependencies/jessie/foreman_remote_execution_core/changelog
+++ b/dependencies/jessie/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.0.3-1) stable; urgency=low
+
+  * 1.0.3 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Wed, 29 Mar 2017 10:40:33 +0200
+
 ruby-foreman-remote-execution-core (1.0.2-1) stable; urgency=low
 
   * 1.0.2 released

--- a/dependencies/trusty/foreman_remote_execution_core/changelog
+++ b/dependencies/trusty/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.0.3-1) stable; urgency=low
+
+  * 1.0.3 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Wed, 29 Mar 2017 10:40:33 +0200
+
 ruby-foreman-remote-execution-core (1.0.2-1) stable; urgency=low
 
   * 1.0.2 released

--- a/dependencies/xenial/foreman_remote_execution_core/changelog
+++ b/dependencies/xenial/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.0.3-1) stable; urgency=low
+
+  * 1.0.3 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Wed, 29 Mar 2017 10:40:33 +0200
+
 ruby-foreman-remote-execution-core (1.0.2-1) stable; urgency=low
 
   * 1.0.2 released

--- a/plugins/ruby-foreman-remote-execution/debian/changelog
+++ b/plugins/ruby-foreman-remote-execution/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution (1.3.0-1) stable; urgency=low
+
+  * 1.3.0 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Wed, 29 Mar 2017 10:32:26 +0200
+
 ruby-foreman-remote-execution (1.2.2-1) stable; urgency=low
 
   * 1.2.2 released

--- a/plugins/ruby-foreman-remote-execution/debian/control
+++ b/plugins/ruby-foreman-remote-execution/debian/control
@@ -2,15 +2,15 @@ Source: ruby-foreman-remote-execution
 Section: ruby
 Priority: extra
 Maintainer: Stephen Benjamin <stephen@redhat.com>
-Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.13.0~rc1), foreman (>= 1.13.0~rc1),
-  foreman-sqlite3 (>= 1.13.0~rc1), ruby-foreman-tasks (>= 0.8.2), ruby-foreman-tasks (<< 0.9.0),
+Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.15.0~rc1), foreman (>= 1.15.0~rc1),
+  foreman-sqlite3 (>= 1.15.0~rc1), ruby-foreman-tasks (>= 0.9.0), ruby-foreman-tasks (<< 0.10.0),
   ruby-foreman-deface
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_remote_execution
 
 Package: ruby-foreman-remote-execution
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.13.0~rc1), ruby-foreman-tasks (>= 0.8.2),
-  ruby-foreman-tasks (<< 0.9.0), ruby-foreman-deface
+Depends: ${misc:Depends}, bundler, foreman (>= 1.15.0~rc1), ruby-foreman-tasks (>= 0.9.0),
+  ruby-foreman-tasks (<< 0.10.0), ruby-foreman-deface
 Description: Foreman Remote Execution Plugin
   A plugin bringing remote execution to the Foreman, completing the config management functionality with remote management functionality

--- a/plugins/ruby-foreman-remote-execution/debian/gem.list
+++ b/plugins/ruby-foreman-remote-execution/debian/gem.list
@@ -1,3 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.2.2.gem"
-GEMS="$GEMS https://rubygems.org/downloads/foreman_remote_execution_core-1.0.2.gem"
+GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.3.0.gem"
+GEMS="$GEMS https://rubygems.org/downloads/foreman_remote_execution_core-1.0.3.gem"

--- a/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
+++ b/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
@@ -1,1 +1,1 @@
-gem 'foreman_remote_execution', '1.2.2'
+gem 'foreman_remote_execution', '1.3.0'


### PR DESCRIPTION
Requires https://github.com/theforeman/foreman-packaging/pull/1581

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.14
* [ ] 1.13
* [ ] 1.12

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
