### PR TITLE
Release 1.15.0-0.2.RC1 

### DIFF
--- a/foreman-installer/foreman-installer.spec
+++ b/foreman-installer/foreman-installer.spec
@@ -6,7 +6,7 @@
 Name:       foreman-installer
 Epoch:      1
 Version:    1.15.0
-Release:    0.1%{?dotalphatag}%{?dist}
+Release:    0.2%{?dotalphatag}%{?dist}
 Summary:    Puppet-based installer for The Foreman
 Group:      Applications/System
 License:    GPLv3+ and ASL 2.0

--- a/foreman-proxy/foreman-proxy.spec
+++ b/foreman-proxy/foreman-proxy.spec
@@ -11,7 +11,7 @@
 
 Name:           foreman-proxy
 Version:        1.15.0
-Release:        0.1%{?dotalphatag}%{?dist}
+Release:        0.2%{?dotalphatag}%{?dist}
 Summary:        Restful Proxy for DNS, DHCP, TFTP, PuppetCA and Puppet
 
 Group:          Applications/System

--- a/foreman-selinux/foreman-selinux.spec
+++ b/foreman-selinux/foreman-selinux.spec
@@ -37,7 +37,7 @@
 
 Name:           foreman-selinux
 Version:        1.15.0
-Release:        0.1%{?dotalphatag}%{?dist}
+Release:        0.2%{?dotalphatag}%{?dist}
 Summary:        SELinux policy module for Foreman
 
 Group:          System Environment/Base

--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -14,7 +14,7 @@
 
 Name:   foreman
 Version: 1.15.0
-Release: 0.1%{?dotalphatag}%{?dist}
+Release: 0.2%{?dotalphatag}%{?dist}
 Summary:Systems Management web application
 
 Group:  Applications/System


### PR DESCRIPTION
Since removing the old builds was not possible & [release_packages](http://ci.theforeman.org/view/Release%20pipeline/) is not green to allow release_mash to proceed. 

To continue the pipeline release_packages needs to be green - which it will not be as the builds exist in Koji already and the job stops. debs are built just fine too https://github.com/theforeman/foreman-packaging/pull/1605#issuecomment-292201828 