### PR TITLE
[DEB] Update foreman_templates to 5.0.0

### DIFF
--- a/plugins/ruby-foreman-templates/debian/changelog
+++ b/plugins/ruby-foreman-templates/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-templates (5.0.0-1) stable; urgency=low
+
+  * Update foreman_templates to 5.0.0
+
+ -- Marek Hulan <mhulan@redhat.com>  Tue, 25 Apr 2017 13:39:15 +0200
+
 ruby-foreman-templates (4.0.2-1) stable; urgency=low
 
   * Update foreman_templates to 4.0.2

--- a/plugins/ruby-foreman-templates/debian/control
+++ b/plugins/ruby-foreman-templates/debian/control
@@ -2,13 +2,13 @@ Source: ruby-foreman-templates
 Section: ruby
 Priority: extra
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
-Build-Depends: debhelper (>= 8.0.0)
+Build-Depends: debhelper (>= 8.0.0), foreman (>= 1.15.0~rc1), foreman-sqlite3 (>= 1.15.0~rc1), git
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_templates
 
 Package: ruby-foreman-templates
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.14.1), git
+Depends: ${misc:Depends}, bundler, foreman (>= 1.15.0~rc1), git
 Description: Foreman Templates Plugin
  This plugin will sync the contents of the Foreman Community Templates
  repository (or a git repo of your choice) to your local Foreman instance.

--- a/plugins/ruby-foreman-templates/debian/gem.list
+++ b/plugins/ruby-foreman-templates/debian/gem.list
@@ -1,4 +1,4 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_templates-4.0.2.gem"
+GEMS="https://rubygems.org/downloads/foreman_templates-5.0.0.gem"
 GEMS="$GEMS https://rubygems.org/downloads/diffy-3.0.7.gem"
 GEMS="$GEMS https://rubygems.org/downloads/git-1.2.9.1.gem"

--- a/plugins/ruby-foreman-templates/debian/install
+++ b/plugins/ruby-foreman-templates/debian/install
@@ -1,2 +1,3 @@
-foreman_templates.rb usr/share/foreman/bundler.d
-cache                usr/share/foreman/vendor
+foreman_templates.rb              usr/share/foreman/bundler.d
+cache                             usr/share/foreman/vendor
+apipie-cache/foreman_templates    var/lib/foreman/public/apipie-cache/plugin

--- a/plugins/ruby-foreman-templates/debian/postinst
+++ b/plugins/ruby-foreman-templates/debian/postinst
@@ -38,6 +38,19 @@ else
   fi
 fi
 
+# Generate apipie cache
+if [ -f /usr/share/foreman/config/database.yml ]; then
+  if [ ! -z "${DEBUG}" ]; then
+    # plugin does not have migration
+    # /usr/sbin/foreman-rake db:migrate || true
+    /usr/sbin/foreman-rake apipie:cache:index || true
+  else
+    # plugin does not have migration
+    # /usr/sbin/foreman-rake db:migrate >> $LOGFILE 2>&1 || true
+    /usr/sbin/foreman-rake apipie:cache:index >> $LOGFILE 2>&1 || true
+  fi
+fi
+
 # Own all the core files
 chown -Rf foreman:foreman '/usr/share/foreman'
 

--- a/plugins/ruby-foreman-templates/debian/rules
+++ b/plugins/ruby-foreman-templates/debian/rules
@@ -9,5 +9,18 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+PLUGIN=foreman_templates
+
+build:
+	cp cache/* /usr/share/foreman/vendor/cache/
+	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
+	cd /usr/share/foreman && ( \
+		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
+		OUT=/var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) RAILS_ENV=development \
+	)
+	[ -e apipie-cache ] || mkdir apipie-cache/
+	cp -rp /var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) ./apipie-cache/
+
 %:
 	dh $@ 

--- a/plugins/ruby-foreman-templates/foreman_templates.rb
+++ b/plugins/ruby-foreman-templates/foreman_templates.rb
@@ -1,1 +1,1 @@
-gem 'foreman_templates', '4.0.2'
+gem 'foreman_templates', '5.0.0'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.15
* [ ] 1.14
* [ ] 1.13

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

The 5.x restores the compatibility with Foreman 1.15