### PR TITLE
Updated ruby-puppetdb-foreman to 3.0.1 [deb]

### DIFF
--- a/plugins/ruby-puppetdb-foreman/debian/changelog
+++ b/plugins/ruby-puppetdb-foreman/debian/changelog
@@ -1,3 +1,9 @@
+ruby-puppetdb-foreman (3.0.1-1) stable; urgency=low
+
+  * 3.0.1 released
+
+ -- Timo Goebel <mail@timogoebel.name>  Wed, 26 Apr 2017 10:57:40 +0200
+
 ruby-puppetdb-foreman (2.0.0-1) stable; urgency=low
 
   * 2.0.0 released

--- a/plugins/ruby-puppetdb-foreman/debian/control
+++ b/plugins/ruby-puppetdb-foreman/debian/control
@@ -2,7 +2,7 @@ Source: ruby-puppetdb-foreman
 Section: ruby
 Priority: extra
 Maintainer: Daniel Lobato <dlobatog@redhat.com>
-Build-Depends: debhelper (>= 8.0.0)
+Build-Depends: debhelper (>= 8.0.0), foreman-sqlite3 (>= 1.11.0~rc1)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/puppetdb_foreman
 

--- a/plugins/ruby-puppetdb-foreman/debian/gem.list
+++ b/plugins/ruby-puppetdb-foreman/debian/gem.list
@@ -1,2 +1,2 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/puppetdb_foreman-2.0.0.gem"
+GEMS="https://rubygems.org/downloads/puppetdb_foreman-3.0.1.gem"

--- a/plugins/ruby-puppetdb-foreman/debian/install
+++ b/plugins/ruby-puppetdb-foreman/debian/install
@@ -1,2 +1,3 @@
 puppetdb_foreman.rb usr/share/foreman/bundler.d
 cache               usr/share/foreman/vendor
+apipie-cache/puppetdb_foreman    var/lib/foreman/public/apipie-cache/plugin

--- a/plugins/ruby-puppetdb-foreman/debian/postinst
+++ b/plugins/ruby-puppetdb-foreman/debian/postinst
@@ -38,6 +38,15 @@ else
   fi
 fi
 
+# DB migrate/seed after install
+if [ -f /usr/share/foreman/config/database.yml ]; then
+  if [ ! -z "${DEBUG}" ]; then
+    /usr/sbin/foreman-rake apipie:cache:index || true
+  else
+    /usr/sbin/foreman-rake apipie:cache:index >> $LOGFILE 2>&1 || true
+  fi
+fi
+
 # Own all the core files
 chown -Rf foreman:foreman '/usr/share/foreman'
 

--- a/plugins/ruby-puppetdb-foreman/debian/rules
+++ b/plugins/ruby-puppetdb-foreman/debian/rules
@@ -9,5 +9,19 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+PLUGIN = puppetdb_foreman
+
+build:
+	cp cache/* /usr/share/foreman/vendor/cache/
+	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
+	cd /usr/share/foreman && ( \
+		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake db:migrate RAILS_ENV=development && \
+		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:apipie:cache[$(PLUGIN)] cache_part=resources \
+		OUT=/var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) RAILS_ENV=development \
+		)
+	[ -e apipie-cache ] || mkdir apipie-cache/
+	cp -rp /var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) ./apipie-cache/
+
 %:
 	dh $@

--- a/plugins/ruby-puppetdb-foreman/puppetdb_foreman.rb
+++ b/plugins/ruby-puppetdb-foreman/puppetdb_foreman.rb
@@ -1,1 +1,1 @@
-gem 'puppetdb_foreman', '2.0.0'
+gem 'puppetdb_foreman', '3.0.1'


### PR DESCRIPTION
Please build for:

* [x] Nightly
* [x] 1.15
* [x] 1.14
* [x] 1.13

⚠️ Fair warning: I have no clue about debian packaging. The changes for apipie cache are just copy-pasted.