### PR TITLE
[DEB] Update smart_proxy_dynflow{,_core} to 0.1.6

### DIFF
--- a/plugins/smart_proxy_dynflow/changelog
+++ b/plugins/smart_proxy_dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-dynflow (0.1.6-1) stable; urgency=low
+
+  * 0.1.6 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Tue, 09 May 2017 13:41:42 +0200
+
 ruby-smart-proxy-dynflow (0.1.5-2) stable; urgency=low
 
   * Add dependency on ruby-smart-proxy-dynflow-core

--- a/plugins/smart_proxy_dynflow/dynflow.rb
+++ b/plugins/smart_proxy_dynflow/dynflow.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_dynflow', '0.1.5'
+gem 'smart_proxy_dynflow', '0.1.6'

--- a/plugins/smart_proxy_dynflow_core/changelog
+++ b/plugins/smart_proxy_dynflow_core/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-dynflow-core (0.1.6-1) stable; urgency=low
+
+  * 0.1.6 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Tue, 09 May 2017 13:44:05 +0200
+
 ruby-smart-proxy-dynflow-core (0.1.5-1) stable; urgency=low
 
   * 0.1.5 released

--- a/plugins/smart_proxy_dynflow_core/dynflow_core.rb
+++ b/plugins/smart_proxy_dynflow_core/dynflow_core.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_dynflow_core', '0.1.5'
+gem 'smart_proxy_dynflow_core', '0.1.6'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.15
* [ ] 1.14
* [ ] 1.13

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
