### PR TITLE
Update foreman_remote_execution_core to 1.0.4 (DEB, proxy)

### DIFF
--- a/dependencies/jessie/foreman_remote_execution_core/changelog
+++ b/dependencies/jessie/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.0.4-1) stable; urgency=low
+
+  * 1.0.4 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Fri, 02 Jun 2017 14:36:14 +0200
+
 ruby-foreman-remote-execution-core (1.0.3-1) stable; urgency=low
 
   * 1.0.3 released

--- a/dependencies/stretch/foreman_remote_execution_core/changelog
+++ b/dependencies/stretch/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.0.4-1) stable; urgency=low
+
+  * 1.0.4 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Fri, 02 Jun 2017 14:36:14 +0200
+
 ruby-foreman-remote-execution-core (1.0.3-1) stable; urgency=low
 
   * Initial release for Debian/stretch

--- a/dependencies/trusty/foreman_remote_execution_core/changelog
+++ b/dependencies/trusty/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.0.4-1) stable; urgency=low
+
+  * 1.0.4 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Fri, 02 Jun 2017 14:36:14 +0200
+
 ruby-foreman-remote-execution-core (1.0.3-1) stable; urgency=low
 
   * 1.0.3 released

--- a/dependencies/xenial/foreman_remote_execution_core/changelog
+++ b/dependencies/xenial/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.0.4-1) stable; urgency=low
+
+  * 1.0.4 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Fri, 02 Jun 2017 14:36:14 +0200
+
 ruby-foreman-remote-execution-core (1.0.3-1) stable; urgency=low
 
   * 1.0.3 released


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.15
* [ ] 1.14
* [ ] 1.13

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
