### PR TITLE
Refs #19923 - force nokogiri lower version limit

### DIFF
--- a/debian/jessie/foreman/debian.rb
+++ b/debian/jessie/foreman/debian.rb
@@ -1,1 +1,2 @@
 gem 'concurrent-ruby', '= 1.0.3'
+gem 'nokogiri', '~> 1.7'

--- a/debian/stretch/foreman/debian.rb
+++ b/debian/stretch/foreman/debian.rb
@@ -1,1 +1,2 @@
 gem 'concurrent-ruby', '= 1.0.3'
+gem 'nokogiri', '~> 1.7'

--- a/debian/xenial/foreman/debian.rb
+++ b/debian/xenial/foreman/debian.rb
@@ -1,1 +1,2 @@
 gem 'concurrent-ruby', '= 1.0.3'
+gem 'nokogiri', '~> 1.7'


### PR DESCRIPTION
This should be built into:

* [x] Nightly
* [ ] 1.15
* [ ] 1.14
* [ ] 1.13

Because of whatever reason (bundler bug?) nokogiri 1.6.6.4 is chosen else.