### PR TITLE
Update foreman-docker to 3.1.0 [deb]

### DIFF
--- a/plugins/ruby-foreman-docker/debian/changelog
+++ b/plugins/ruby-foreman-docker/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-docker (3.1.0-1) stable; urgency=low
+
+  * 3.1.0 released
+
+ -- Daniel Lobato Garcia <me@daniellobato.me>  Wed, 07 Jun 2017 19:23:50 +0200
+
 ruby-foreman-docker (3.0.0-1) stable; urgency=low
 
   * 3.0.0 released

--- a/plugins/ruby-foreman-docker/debian/control
+++ b/plugins/ruby-foreman-docker/debian/control
@@ -2,12 +2,12 @@ Source: ruby-foreman-docker
 Section: ruby
 Priority: extra
 Maintainer: Pujan Shah <pujan14@gmail.com>
-Build-Depends: debhelper, foreman-compute (>= 1.13.0~rc1), foreman-assets (>= 1.13.0~rc1), foreman-sqlite3 (>= 1.13.0~rc1), ruby-foreman-deface (<<2.0.0)
+Build-Depends: debhelper, foreman-compute (>= 1.15.0~rc1), foreman-assets (>= 1.15.0~rc1), foreman-sqlite3 (>= 1.15.0~rc1), ruby-foreman-deface (<<2.0.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-docker
 
 Package: ruby-foreman-docker
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman-compute (>= 1.13.0~rc1), ruby-foreman-deface (<<2.0.0)
+Depends: ${misc:Depends}, bundler, foreman-compute (>= 1.15.0~rc1), ruby-foreman-deface (<<2.0.0)
 Description: Foreman Docker compute resource
  Docker compute resource plugin for Foreman

--- a/plugins/ruby-foreman-docker/debian/gem.list
+++ b/plugins/ruby-foreman-docker/debian/gem.list
@@ -1,4 +1,4 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_docker-3.0.0.gem"
-GEMS="$GEMS https://rubygems.org/downloads/docker-api-1.31.0.gem"
-GEMS="$GEMS https://rubygems.org/downloads/wicked-1.3.0.gem"
+GEMS="https://rubygems.org/downloads/foreman_docker-3.1.0.gem"
+GEMS="$GEMS https://rubygems.org/downloads/docker-api-1.33.4.gem"
+GEMS="$GEMS https://rubygems.org/downloads/wicked-1.3.1.gem"

--- a/plugins/ruby-foreman-docker/foreman_docker.rb
+++ b/plugins/ruby-foreman-docker/foreman_docker.rb
@@ -1,1 +1,1 @@
-gem 'foreman_docker', '3.0.0'
+gem 'foreman_docker', '3.1.0'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.15
* [ ] 1.14
* [ ] 1.13

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

I was not sure where to include the new excon dependency, what's the criteria to know whether it should be on gem.list, on the control file, or on both?