### PR TITLE
Removed old tito.props entries

### DIFF
--- a/rel-eng/compare-with-tags.rb
+++ b/rel-eng/compare-with-tags.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+#
+# Compares tito.props with koji and prints out differences in Github markup for
+# review and cleanup.
+#
+
+require 'configparser'
+
+cfg = ConfigParser.new('tito.props')
+cfg.each do |entry|
+  tag = entry.first
+  scl = entry.last['scl']
+  next unless tag =~ /^foreman/
+  comp_pkgs = entry.last['whitelist'].split
+  comp_pkgs.map!{ |x| (scl && x =~ /^rubygem-/) ? "#{scl}-#{x}" : x }
+  koji_pkgs = []
+  `koji list-pkgs --tag=#{tag} --quiet`.each_line do |line|
+    koji_pkgs << line.split.first
+  end
+  missing_pkgs = comp_pkgs - koji_pkgs
+  extra_pkgs = koji_pkgs - comp_pkgs
+  puts "\n# Packages missing in tag #{tag}"
+  missing_pkgs.sort.each { |x| puts " * [x] #{x}" }
+  puts "```shell"
+  missing_pkgs.sort.each { |x| puts "koji add-pkg --owner=kojiadm #{tag} #{x}" }
+  puts "```"
+  puts "\n# Packages not expected in #{tag}"
+  extra_pkgs.sort.each { |x| puts " * [x] #{x}" }
+  puts "```shell"
+  extra_pkgs.sort.each { |x| puts "koji remove-pkg #{tag} #{x}" }
+  puts "```"
+end

--- a/rel-eng/packages/rubygem-foreman_openstack_cluster
+++ b/rel-eng/packages/rubygem-foreman_openstack_cluster
@@ -1,1 +1,0 @@
-0.0.1-1 rubygem-foreman_openstack_cluster/

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -301,7 +301,6 @@ whitelist = foreman
   rubygem-kafo_parsers
   rubygem-kafo_wizards
   rubygem-launchy
-  rubygem-librarian-puppet
   rubygem-patternfly-sass
   rubygem-po_to_json
   rubygem-powerbar
@@ -324,8 +323,6 @@ whitelist = foreman
   rubygem-spice-html5-rails
   rubygem-sprockets-rails
   rubygem-sshkey
-  rubygem-strong_parameters
-  rubygem-therubyracer
   rubygem-trollop
   rubygem-useragent
   rubygem-validates_lengths_from_database
@@ -364,7 +361,6 @@ whitelist = rubygem-algebrick
   rubygem-foreman_chef
   rubygem-foreman_cockpit
   rubygem-foreman_column_view
-  rubygem-foreman_content
   rubygem-foreman_custom_parameters
   rubygem-foreman_default_hostgroup
   rubygem-foreman_dhcp_browser
@@ -382,7 +378,6 @@ whitelist = rubygem-algebrick
   rubygem-foreman_omaha
   rubygem-foreman_one
   rubygem-foreman_openscap
-  rubygem-foreman_openstack_cluster
   rubygem-foreman_param_lookup
   rubygem-foreman_remote_execution
   rubygem-foreman_remote_execution_core
@@ -484,7 +479,6 @@ whitelist = puppet-foreman_scap_client
   rubygem-foreman_chef
   rubygem-foreman_cockpit
   rubygem-foreman_column_view
-  rubygem-foreman_content
   rubygem-foreman_custom_parameters
   rubygem-foreman_default_hostgroup
   rubygem-foreman_dhcp_browser
@@ -502,7 +496,6 @@ whitelist = puppet-foreman_scap_client
   rubygem-foreman_omaha
   rubygem-foreman_one
   rubygem-foreman_openscap
-  rubygem-foreman_openstack_cluster
   rubygem-foreman_param_lookup
   rubygem-foreman_remote_execution
   rubygem-foreman_remote_execution_core

--- a/tfm/scl_prefix_update.conf
+++ b/tfm/scl_prefix_update.conf
@@ -84,7 +84,6 @@ sass-rails=scl_prefix_ror
 sprockets=scl_prefix_ror
 sqlite3=scl_prefix_ror
 test_declarative=scl_prefix_ror
-therubyracer=scl_prefix_ror
 thor=scl_prefix_ruby
 treetop=scl_prefix_ror
 tzinfo=scl_prefix_ror


### PR DESCRIPTION
These items were removed from the repo and we forgot to remove them from
`tito.props`.

* rubygem-librarian-puppet
* rubygem-strong_parameters
* rubygem-therubyracer
* rubygem-foreman_content
* rubygem-foreman_openstack_cluster

Also includes a script which compares `tito.props` against koji and
prints out a review Markdown formatted text.

---