### PR TITLE
Revert "fixes #18123 - change multipart-post dep to RPM name from virtual"

### DIFF
--- a/rubygem-faraday/rubygem-faraday.spec
+++ b/rubygem-faraday/rubygem-faraday.spec
@@ -15,8 +15,8 @@ Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
 Requires: %{?scl_prefix_ruby}ruby
-Requires: %{?scl_prefix}rubygem-multipart-post >= 1.2.0
-Requires: %{?scl_prefix}rubygem-multipart-post < 3
+Requires: %{?scl_prefix}rubygem(multipart-post) >= 1.2.0
+Requires: %{?scl_prefix}rubygem(multipart-post) < 3
 
 BuildRequires: %{?scl_prefix_ruby}ruby(release)
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel


### PR DESCRIPTION
This reverts commit 045a244ee91c61c2e60be9f645828a95b88f23b5.

rubygem-multipart-post-2.0.0-4.el7 in EPEL7 includes the proper provides which means this workaround is no longer needed.