### PR TITLE
Update fast_gettext requirement for Foreman

### DIFF
--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -84,8 +84,8 @@ Requires: %{?scl_prefix}rubygem(secure_headers) >= 3.4
 Requires: %{?scl_prefix}rubygem(secure_headers) < 4.0
 Requires: %{?scl_prefix}rubygem(safemode) >= 1.2.4
 Requires: %{?scl_prefix}rubygem(safemode) < 2.0
-Requires: %{?scl_prefix}rubygem(fast_gettext) >= 0.8
-Requires: %{?scl_prefix}rubygem(fast_gettext) < 1.2.0
+Requires: %{?scl_prefix}rubygem(fast_gettext) >= 1.4.0
+Requires: %{?scl_prefix}rubygem(fast_gettext) < 2.0.0
 Requires: %{?scl_prefix}rubygem(gettext_i18n_rails) >= 1.0
 Requires: %{?scl_prefix}rubygem(gettext_i18n_rails) < 2.0
 Requires: %{?scl_prefix}rubygem(rails-i18n) >= 4.0.0
@@ -164,8 +164,8 @@ BuildRequires: %{?scl_prefix}rubygem(secure_headers) >= 3.4
 BuildRequires: %{?scl_prefix}rubygem(secure_headers) < 4.0
 BuildRequires: %{?scl_prefix}rubygem(safemode) >= 1.2.4
 BuildRequires: %{?scl_prefix}rubygem(safemode) < 2.0
-BuildRequires: %{?scl_prefix}rubygem(fast_gettext) >= 0.8
-BuildRequires: %{?scl_prefix}rubygem(fast_gettext) < 1.2.0
+BuildRequires: %{?scl_prefix}rubygem(fast_gettext) >= 1.4.0
+BuildRequires: %{?scl_prefix}rubygem(fast_gettext) < 2.0.0
 BuildRequires: %{?scl_prefix}rubygem(gettext_i18n_rails) >= 1.0
 BuildRequires: %{?scl_prefix}rubygem(gettext_i18n_rails) < 2.0
 BuildRequires: %{?scl_prefix}rubygem(rails-i18n) >= 4.0.0


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.15
* [ ] 1.14
* [ ] 1.13

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
