### PR TITLE
Fix cannot stat 'node_modules' for el7

### DIFF
--- a/nodejs-babel-core/nodejs-babel-core.spec
+++ b/nodejs-babel-core/nodejs-babel-core.spec
@@ -166,7 +166,7 @@ done
 %setup -T -q -a 61 -D -n npm_cache
 
 %build
-npm install %{npm_name}@%{version} --cache-min Infinity --cache .
+npm install --cache-min Infinity --cache . --global-style true %{npm_name}@%{version}
 
 %install
 mkdir -p %{buildroot}%{nodejs_sitelib}/%{npm_name}

--- a/nodejs-babel-core/nodejs-babel-core.spec
+++ b/nodejs-babel-core/nodejs-babel-core.spec
@@ -2,7 +2,7 @@
 
 Name: nodejs-%{npm_name}
 Version: 6.7.7
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: Babel compiler core
 License: MIT
 Group: Development/Libraries

--- a/nodejs-babel-loader/nodejs-babel-loader.spec
+++ b/nodejs-babel-loader/nodejs-babel-loader.spec
@@ -30,6 +30,7 @@ Source14: http://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz
 Source15: http://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz
 Source16: http://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz
 Source17: babel-loader-7.1.1-registry.npmjs.org.tgz
+BuildRequires: npm
 BuildRequires: nodejs-packaging
 BuildArch:  noarch
 ExclusiveArch: %{nodejs_arches} noarch

--- a/nodejs-babel-loader/nodejs-babel-loader.spec
+++ b/nodejs-babel-loader/nodejs-babel-loader.spec
@@ -68,7 +68,7 @@ done
 %setup -T -q -a 17 -D -n npm_cache
 
 %build
-npm install --cache-min Infinity --cache . --no-optional --global-style true %{npm_name}@%{version}
+npm install --cache-min Infinity --cache . --global-style true %{npm_name}@%{version}
 
 %install
 mkdir -p %{buildroot}%{nodejs_sitelib}/%{npm_name}

--- a/nodejs-babel-loader/nodejs-babel-loader.spec
+++ b/nodejs-babel-loader/nodejs-babel-loader.spec
@@ -8,7 +8,7 @@
 
 Name: nodejs-%{npm_name}
 Version: 7.1.1
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: babel module loader for webpack
 License: MIT
 URL: https://github.com/babel/babel-loader

--- a/nodejs-babel-preset-es2015/nodejs-babel-preset-es2015.spec
+++ b/nodejs-babel-preset-es2015/nodejs-babel-preset-es2015.spec
@@ -2,7 +2,7 @@
 
 Name: nodejs-%{npm_name}
 Version: 6.6.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Babel preset for all es2015 plugins
 License: MIT
 Group: Development/Libraries

--- a/nodejs-babel-preset-es2015/nodejs-babel-preset-es2015.spec
+++ b/nodejs-babel-preset-es2015/nodejs-babel-preset-es2015.spec
@@ -230,7 +230,7 @@ done
 %setup -T -q -a 93 -D -n npm_cache
 
 %build
-npm install %{npm_name}@%{version} --cache-min Infinity --cache . --verbose
+npm install --cache-min Infinity --cache . --global-style true %{npm_name}@%{version}
 
 %install
 mkdir -p %{buildroot}%{nodejs_sitelib}/%{npm_name}

--- a/nodejs-css-loader/nodejs-css-loader.spec
+++ b/nodejs-css-loader/nodejs-css-loader.spec
@@ -276,7 +276,7 @@ done
 %setup -T -q -a 120 -D -n npm_cache
 
 %build
-npm install --cache-min Infinity --cache . %{npm_name}@%{version}
+npm install --cache-min Infinity --cache . --global-style true %{npm_name}@%{version}
 
 %install
 mkdir -p %{buildroot}%{nodejs_sitelib}/%{npm_name}

--- a/nodejs-css-loader/nodejs-css-loader.spec
+++ b/nodejs-css-loader/nodejs-css-loader.spec
@@ -4,7 +4,7 @@
 
 Name: nodejs-%{npm_name}
 Version: 0.23.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: css loader module for webpack
 License: MIT
 URL: https://www.npmjs.com/package/css-loader

--- a/nodejs-file-loader/nodejs-file-loader.spec
+++ b/nodejs-file-loader/nodejs-file-loader.spec
@@ -2,7 +2,7 @@
 
 Name: nodejs-%{npm_name}
 Version: 0.9.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: file loader module for webpack
 License: MIT
 Group: Development/Libraries

--- a/nodejs-file-loader/nodejs-file-loader.spec
+++ b/nodejs-file-loader/nodejs-file-loader.spec
@@ -56,7 +56,7 @@ done
 %setup -T -q -a 6 -D -n npm_cache
 
 %build
-npm install --cache-min Infinity --cache . file-loader@0.9.0
+npm install --cache-min Infinity --cache . --global-style true %{npm_name}@%{version}
 
 %install
 mkdir -p %{buildroot}%{nodejs_sitelib}/%{npm_name}

--- a/nodejs-style-loader/nodejs-style-loader.spec
+++ b/nodejs-style-loader/nodejs-style-loader.spec
@@ -4,7 +4,7 @@
 
 Name: nodejs-%{npm_name}
 Version: 0.13.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: style loader module for webpack
 License: MIT
 URL: https://www.npmjs.com/package/style-loader

--- a/nodejs-style-loader/nodejs-style-loader.spec
+++ b/nodejs-style-loader/nodejs-style-loader.spec
@@ -49,7 +49,7 @@ done
 %setup -T -q -a 6 -D -n npm_cache
 
 %build
-npm install --cache-min Infinity --cache . %{npm_name}@%{version}
+npm install --cache-min Infinity --cache . --global-style true %{npm_name}@%{version}
 
 %install
 mkdir -p %{buildroot}%{nodejs_sitelib}/%{npm_name}

--- a/nodejs-url-loader/nodejs-url-loader.spec
+++ b/nodejs-url-loader/nodejs-url-loader.spec
@@ -61,7 +61,7 @@ done
 %build
 mkdir node_modules
 ln -s %{nodejs_sitelib}/file-loader node_modules/
-npm install --cache-min Infinity --cache . url-loader@0.5.7
+npm install --cache-min Infinity --cache . --global-style true %{npm_name}@%{version}
 
 %install
 mkdir -p %{buildroot}%{nodejs_sitelib}/%{npm_name}

--- a/nodejs-url-loader/nodejs-url-loader.spec
+++ b/nodejs-url-loader/nodejs-url-loader.spec
@@ -2,7 +2,7 @@
 
 Name: nodejs-%{npm_name}
 Version: 0.5.7
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: url loader module for webpack
 License: MIT
 Group: Development/Libraries


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.15
* [ ] 1.14
* [ ] 1.13

---

For following packages

    nodejs-babel-core
    nodejs-babel-loader
    nodejs-babel-preset-es2015
    nodejs-css-loader
    nodejs-extract-text-webpack-plugin
    nodejs-file-loader
    nodejs-style-loader
    nodejs-url-loader
    nodejs-webpack

I get an error

    + cp -pfr .editorconfig .eslintrc .npmignore .travis.yml ExtractedModule.js OrderUndefinedError.js index.js loader.js package.json node_modules /builddir/build/BUILDROOT/nodejs-extract-text-webpack-plugin-1.0.1-2.el7.centos.x86_64/usr/lib/node_modules/extract-text-webpack-plugin
    cp: cannot stat 'node_modules': No such file or directory
    error: Bad exit status from /var/tmp/rpm-tmp.Rpkyrq (%install)
        Bad exit status from /var/tmp/rpm-tmp.Rpkyrq (%install)

while trying to build them in Copr for EL7. This PR fixes it.