### PR TITLE
Update foreman-tasks use of foreman_precompile_plugin macro

### DIFF
--- a/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
+++ b/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
@@ -18,7 +18,7 @@
 Summary: Tasks support for Foreman with Dynflow integration
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.10.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Group: Development/Libraries
 License: GPLv3
 URL: https://github.com/theforeman/foreman-tasks
@@ -92,7 +92,7 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s -r plugin:assets:precompile[foreman_tasks]
+%foreman_precompile_plugin -a -s
 
 mkdir -p %{buildroot}%{foreman_pluginconf_dir}
 mv %{buildroot}/%{gem_instdir}/config/%{gem_name}.yaml.example \


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.15
* [ ] 1.14
* [ ] 1.13

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
