### PR TITLE
Update rubygem-hammer_cli_foreman_remote_execution to 0.0.6

### DIFF
--- a/dependencies/jessie/hammer_cli_foreman_remote_execution/changelog
+++ b/dependencies/jessie/hammer_cli_foreman_remote_execution/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-remote-execution (0.0.6-1) stable; urgency=low
+
+  * 0.0.6 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Wed, 16 Aug 2017 16:16:48 +0200
+
 ruby-hammer-cli-foreman-remote-execution (0.0.5-1) stable; urgency=low
 
   * 0.0.5 released

--- a/dependencies/stretch/hammer_cli_foreman_remote_execution/changelog
+++ b/dependencies/stretch/hammer_cli_foreman_remote_execution/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-remote-execution (0.0.6-1) stable; urgency=low
+
+  * 0.0.6 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Wed, 16 Aug 2017 16:16:48 +0200
+
 ruby-hammer-cli-foreman-remote-execution (0.0.5-1) stable; urgency=low
 
   * Initial release for Debian/stretch

--- a/dependencies/trusty/hammer_cli_foreman_remote_execution/changelog
+++ b/dependencies/trusty/hammer_cli_foreman_remote_execution/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-remote-execution (0.0.6-1) stable; urgency=low
+
+  * 0.0.6 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Wed, 16 Aug 2017 16:16:48 +0200
+
 ruby-hammer-cli-foreman-remote-execution (0.0.5-2) stable; urgency=low
 
   * Use Ruby 2.0 explicitly on Ubuntu/trusty

--- a/dependencies/xenial/hammer_cli_foreman_remote_execution/changelog
+++ b/dependencies/xenial/hammer_cli_foreman_remote_execution/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-remote-execution (0.0.6-1) stable; urgency=low
+
+  * 0.0.6 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Wed, 16 Aug 2017 16:16:48 +0200
+
 ruby-hammer-cli-foreman-remote-execution (0.0.5-1) stable; urgency=low
 
   * Initial release for Ubuntu/xenial


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.15
* [ ] 1.14
* [ ] 1.13

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
