### PR TITLE
Update node-gyp requirements

### DIFF
--- a/nodejs-node-gyp/nodejs-node-gyp.spec
+++ b/nodejs-node-gyp/nodejs-node-gyp.spec
@@ -132,10 +132,14 @@ Source118: addon-rpm.gypi
 Patch1: node-gyp-addon-gypi.patch
 Requires: nodejs(engine)
 # this is the standard set of headers expected to build any node native module
-Requires: nodejs-devel libuv-devel http-parser-devel
+Requires: nodejs-devel
+Requires: libuv-devel
+Requires: http-parser-devel
 # we also need a C++ compiler to actually build stuff ;-)
 Requires: gcc-c++
 BuildRequires: nodejs-devel
+BuildRequires: libuv-devel
+BuildRequires: http-parser-devel
 BuildRequires: nodejs-packaging
 BuildRequires: npm
 BuildArch: noarch


### PR DESCRIPTION
* [x] Nightly
* [ ] 1.15
* [ ] 1.14
* [ ] 1.13

Meant to fix the errors seen in nightly http://ci.theforeman.org/job/packaging_repoclosure/36504/console

```
07:29:08 Num Packages in Repos: 30464
07:29:08 package: nodejs-node-gyp-3.3.1-1.el7.noarch from undertest-yum_el7-4203183943-68
07:29:08   unresolved deps: 
07:29:08      http-parser-devel
```