### PR TITLE
Removed f24 from copy-tags-command script

### DIFF
--- a/koji/copy-tags-commands.sh
+++ b/koji/copy-tags-commands.sh
@@ -10,11 +10,11 @@ fi
 OLD=$1
 VERSION=$2
 
-NONSCL_SYSTEMS="fedora24"
+NONSCL_SYSTEMS=""
 SCL_SYSTEMS="rhel7"
 
 clone() {
-  echo kkoji clone-tag $PRODUCT-$OLD-$SYSTEM $PRODUCT-$VERSION-$SYSTEM
+  echo kkoji clone-tag --config $PRODUCT-$OLD-$SYSTEM $PRODUCT-$VERSION-$SYSTEM
 
   echo kkoji add-tag --parent=$PRODUCT-$VERSION-$SYSTEM $PRODUCT-$VERSION-$SYSTEM-override
   echo kkoji add-tag --parent=$PRODUCT-$VERSION-$SYSTEM-override $PRODUCT-$VERSION-$SYSTEM-build


### PR DESCRIPTION
Seems useless to have this script handle this, keeping the NONSCL variable though in case we decide to later on add any nonscl distribution.