### PR TITLE
Add http-parser to extras

### DIFF
--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -9,6 +9,8 @@
     <packagelist>
       <packagereq type="default">centos-release-scl</packagereq>
       <packagereq type="default">centos-release-scl-rh</packagereq>
+      <packagereq type="default">http-parser</packagereq>
+      <packagereq type="default">http-parser-devel</packagereq>
       <packagereq type="default">foreman</packagereq>
       <packagereq type="default">foreman-assets</packagereq>
       <packagereq type="default">foreman-bootloaders-redhat</packagereq>

--- a/extras/extras-foreman-rhel6-x86_64
+++ b/extras/extras-foreman-rhel6-x86_64
@@ -1,2 +1,0 @@
-http://mirror.centos.org/centos/6/extras/x86_64/Packages/centos-release-scl-7-3.el6.centos.noarch.rpm
-http://mirror.centos.org/centos/6/extras/x86_64/Packages/centos-release-scl-rh-2-2.el6.centos.noarch.rpm

--- a/extras/extras-foreman-rhel7-x86_64
+++ b/extras/extras-foreman-rhel7-x86_64
@@ -1,2 +1,4 @@
 http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-2-2.el7.centos.noarch.rpm
 http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-rh-2-2.el7.centos.noarch.rpm
+https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
+https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-devel-2.7.1-3.el7.x86_64.rpm


### PR DESCRIPTION
* [x] Nightly
* [x] 1.15
* [x] 1.14

The extras/ directory files contains links to rpms that the mash script in Koji downloads and puts in our repos.

As explained in https://github.com/theforeman/foreman-packaging/pull/1772, we have to carry http-parser and http-parser-devel until EL 7.4 is out. A possible solution to do so is to just download the RPM and sign it instead of also building it ourselves.

At the moment nightlies are not passing tests consistently as they cannot be built when the http-parser-devel is not found on Koji (apparently some Koji caches still return it), this ought to fix that problem. See [packaging_repoclosure](http://ci.theforeman.org/job/packaging_repoclosure/) logs of recent failures for an example of that.

No need for signing as (http://projects.theforeman.org/projects/foreman/wiki/RPM_Packaging#Signing-extra-centos-release-scl--RPMs) says, if this doesn't get to a final release.