### PR TITLE
Refs #20571 - use npm instead of yarn (DEB, 1.16)

### DIFF
--- a/debian/jessie/foreman/control
+++ b/debian/jessie/foreman/control
@@ -5,7 +5,7 @@ Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 7), cdbs, bundler (>= 1.3), ruby2.1-dev, git | git-core,
                zlib1g-dev, libmysqlclient-dev, libpq-dev, pkg-config, libvirt-dev,
-               libsqlite3-dev, build-essential, curl, nodejs (>= 6.10), yarn,
+               libsqlite3-dev, build-essential, curl, nodejs (>= 6.10),
                python
 Homepage: http://www.theforeman.org/
 

--- a/debian/jessie/foreman/rules
+++ b/debian/jessie/foreman/rules
@@ -11,9 +11,8 @@ build:
 	/bin/cp config/settings.yaml.example config/settings.yaml
 	/bin/cp config/database.yml.example config/database.yml
 	/bin/rm -rf node_modules
-	/bin/rm -f package-lock.json
-	/bin/rm -f yarn.lock
-	/usr/bin/yarn install --no-optional
+	/usr/bin/npm install npm@'<5.0.0'
+	/usr/bin/nodejs node_modules/.bin/npm install --no-optional
 	/bin/cp debian/debian.rb bundler.d/
 	/usr/bin/bundle package
 	/usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production

--- a/debian/stretch/foreman/control
+++ b/debian/stretch/foreman/control
@@ -5,7 +5,7 @@ Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 7), cdbs, bundler (>= 1.3), ruby2.3-dev, git | git-core,
                zlib1g-dev, default-libmysqlclient-dev, libpq-dev, pkg-config, libvirt-dev,
-               libsqlite3-dev, build-essential, curl, nodejs (>= 6.10), yarn,
+               libsqlite3-dev, build-essential, curl, nodejs (>= 6.10),
                python
 Homepage: http://www.theforeman.org/
 

--- a/debian/stretch/foreman/rules
+++ b/debian/stretch/foreman/rules
@@ -12,9 +12,8 @@ build:
 	/bin/sed -i -e 's~#:rails: 4.2~:rails: 4.2~' config/settings.yaml
 	/bin/cp config/database.yml.example config/database.yml
 	/bin/rm -rf node_modules
-	/bin/rm -f package-lock.json
-	/bin/rm -f yarn.lock
-	/usr/bin/yarn install --no-optional
+	/usr/bin/npm install npm@'<5.0.0'
+	/usr/bin/nodejs node_modules/.bin/npm install --no-optional
 	/bin/cp debian/debian.rb bundler.d/
 	/usr/bin/bundle package
 	/usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production

--- a/debian/xenial/foreman/control
+++ b/debian/xenial/foreman/control
@@ -5,7 +5,7 @@ Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 7), cdbs, bundler (>= 1.3), ruby2.3-dev, git | git-core,
                zlib1g-dev, libmysqlclient-dev, libpq-dev, pkg-config, libvirt-dev,
-               libsqlite3-dev, build-essential, curl, nodejs (>= 6.10), yarn,
+               libsqlite3-dev, build-essential, curl, nodejs (>= 6.10),
                python
 Homepage: http://www.theforeman.org/
 

--- a/debian/xenial/foreman/rules
+++ b/debian/xenial/foreman/rules
@@ -12,9 +12,8 @@ build:
 	/bin/sed -i -e 's~#:rails: 4.2~:rails: 4.2~' config/settings.yaml
 	/bin/cp config/database.yml.example config/database.yml
 	/bin/rm -rf node_modules
-	/bin/rm -f package-lock.json
-	/bin/rm -f yarn.lock
-	/usr/bin/yarn install --no-optional
+	/usr/bin/npm install npm@'<5.0.0'
+	/usr/bin/nodejs node_modules/.bin/npm install --no-optional
 	/bin/cp debian/debian.rb bundler.d/
 	/usr/bin/bundle package
 	/usr/bin/bundle exec rake locale:pack assets:precompile RAILS_ENV=production


### PR DESCRIPTION
this should be built into:

* [ ] Nightly
* [x] 1.16

If RC1 builds happen before the next datatables release (https://github.com/DataTables/Dist-DataTables-Bootstrap/pull/2#), this is needed.