### PR TITLE
installer: require Puppet 4.9 (DEB)

### DIFF
--- a/debian/jessie/foreman-installer/control
+++ b/debian/jessie/foreman-installer/control
@@ -14,7 +14,7 @@ Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-kafo (>= 1.0.5),
-         puppet-agent (>= 1.6.1) | puppet (>= 4.6.1),
+         puppet-agent (>= 1.9.0) | puppet (>= 4.9.0),
          curl,
          lsb-release
 Description: Automated puppet-based installer for The Foreman

--- a/debian/stretch/foreman-installer/control
+++ b/debian/stretch/foreman-installer/control
@@ -14,7 +14,7 @@ Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby,
          ruby-kafo (>= 1.0.5),
-         puppet-agent (>= 1.6.1) | puppet (>= 4.6.1),
+         puppet-agent (>= 1.9.0) | puppet (>= 4.9.0),
          curl,
          lsb-release
 Description: Automated puppet-based installer for The Foreman

--- a/debian/xenial/foreman-installer/control
+++ b/debian/xenial/foreman-installer/control
@@ -14,7 +14,7 @@ Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-kafo (>= 1.0.5),
-         puppet-agent (>= 1.6.1) | puppet (>= 4.6.1),
+         puppet-agent (>= 1.9.0) | puppet (>= 4.9.0),
          curl,
          lsb-release
 Description: Automated puppet-based installer for The Foreman


### PR DESCRIPTION
this should be built into:

* [x] Nightly

This is required since https://github.com/theforeman/puppet-tftp/commit/3a97422f61b37fd07e0583b9ad7eba2e4b66de0c and https://github.com/theforeman/puppet-git/commit/bb41057b854ca3338de276a3527d2b2c69c200e3