### PR TITLE
Add --clone to copy-tags script

### DIFF
--- a/koji/copy-tags-commands.sh
+++ b/koji/copy-tags-commands.sh
@@ -14,7 +14,7 @@ NONSCL_SYSTEMS=""
 SCL_SYSTEMS="rhel7"
 
 clone() {
-  echo kkoji clone-tag --config $PRODUCT-$OLD-$SYSTEM $PRODUCT-$VERSION-$SYSTEM
+  echo kkoji clone-tag --config $PRODUCT-$OLD-$SYSTEM $PRODUCT-$VERSION-$SYSTEM --all
 
   echo kkoji add-tag --parent=$PRODUCT-$VERSION-$SYSTEM $PRODUCT-$VERSION-$SYSTEM-override
   echo kkoji add-tag --parent=$PRODUCT-$VERSION-$SYSTEM-override $PRODUCT-$VERSION-$SYSTEM-build


### PR DESCRIPTION
Without this, on new Koji versions the builds will not be cloned, only the packages.