### PR TITLE
Provide Copr releaser and fix building of nodejs-brace 

### DIFF
--- a/foreman-installer/README
+++ b/foreman-installer/README
@@ -1,0 +1,2 @@
+how to build this package:
+tito release copr-nightly --arg jenkins_job=packaging_trigger_installer_develop

--- a/foreman-selinux/README
+++ b/foreman-selinux/README
@@ -1,0 +1,2 @@
+how to build this package:
+tito release copr-nightly --arg jenkins_job=packaging_trigger_selinux_develop

--- a/foreman/README
+++ b/foreman/README
@@ -1,0 +1,2 @@
+this package can be built using:
+tito release copr-nightly --arg jenkins_job=test_develop

--- a/nodejs-brace/nodejs-brace.spec
+++ b/nodejs-brace/nodejs-brace.spec
@@ -22,8 +22,8 @@ ExclusiveArch: %{nodejs_arches} noarch
 ExclusiveArch: %{ix86} x86_64 %{arm} noarch
 %endif
 Provides: npm(%{npm_name}) = %{version}
-Provides: bundled-npm(brace) = 0.10.0
-Provides: bundled-npm(w3c-blob) = 0.0.1
+Provides: bundled(npm(brace)) = 0.10.0
+Provides: bundled(npm(w3c-blob)) = 0.0.1
 AutoReq: no
 AutoProv: no
 
@@ -55,4 +55,3 @@ cp -pf LICENSE README.md ../../
 %changelog
 * Fri Mar 24 2017 Dominic Cleal <dominic@cleal.org> 0.10.0-1
 - new package built with tito
-

--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -18,3 +18,9 @@ releaser = tito.release.KojiReleaser
 autobuild_tags = foreman-plugins-nightly-nonscl-rhel7 foreman-plugins-nightly-rhel7
 builder = tito.builder.FetchBuilder
 builder.rpmbuild_options = --define "foremandist .fm1_17"
+
+[copr-nightly]
+releaser = tito.release.CoprReleaser
+project_name = @theforeman/foreman-nightly
+builder.jenkins_url = http://ci.theforeman.org
+builder = tito.builder.FetchBuilder


### PR DESCRIPTION
This replaces https://github.com/theforeman/foreman-packaging/pull/1709
Regarding the README. This information is already in the main README.  But it is hidden in a bunch of general comments. It really does not hurt to repeat it. As it is really non-standard way how to build a package.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.16
* [ ] 1.15
* [ ] 1.14

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---


