### PR TITLE
Revert "Add Ansible dependency for Ansible proxy plugin"

### DIFF
--- a/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
+++ b/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
@@ -24,8 +24,6 @@ Requires: rubygem(smart_proxy_dynflow) < 1.0
 Requires: ruby
 Requires: ruby(rubygems)
 
-Requires: ansible >= 2.2
-
 %if 0%{?rhel} == 6
 Requires: ruby(abi)
 BuildRequires: ruby(abi)


### PR DESCRIPTION
This reverts commit a1171d31a145b5b6bc6c3e9232302b44aadb7705.

this should be built into:

* [x] Nightly
* [x] 1.16
* [x] 1.15

This breaks repoclosure, see i.e. http://ci.theforeman.org/job/packaging_repoclosure/36940/console

AFAICT, the rpm coming with EL7 doesn't support something like "Recommends:" or "Suggests:", yet. And it seems the ansible package isn't part of EPEL right now.