### PR TITLE
 foreman_remote_execution 1.3.4 - proxy part [deb/1.15]

### DIFF
--- a/dependencies/jessie/dynflow/changelog
+++ b/dependencies/jessie/dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-dynflow (0.8.30-1) stable; urgency=low
+
+  * 0.8.30 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Fri, 06 Oct 2017 17:16:37 +0200
+
 ruby-dynflow (0.8.24-1) stable; urgency=low
 
   * 0.8.24 released

--- a/dependencies/trusty/dynflow/changelog
+++ b/dependencies/trusty/dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-dynflow (0.8.30-1) stable; urgency=low
+
+  * 0.8.30 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Fri, 06 Oct 2017 17:16:37 +0200
+
 ruby-dynflow (0.8.24-1) stable; urgency=low
 
   * 0.8.24 released

--- a/dependencies/xenial/dynflow/changelog
+++ b/dependencies/xenial/dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-dynflow (0.8.30-1) stable; urgency=low
+
+  * 0.8.30 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Fri, 06 Oct 2017 17:16:37 +0200
+
 ruby-dynflow (0.8.24-1) stable; urgency=low
 
   * 0.8.24 released

--- a/plugins/smart_proxy_dynflow/changelog
+++ b/plugins/smart_proxy_dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-dynflow (0.1.8-1) stable; urgency=low
+
+  * 0.1.8 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Fri, 06 Oct 2017 17:12:07 +0200
+
 ruby-smart-proxy-dynflow (0.1.6-1) stable; urgency=low
 
   * 0.1.6 released

--- a/plugins/smart_proxy_dynflow/dynflow.rb
+++ b/plugins/smart_proxy_dynflow/dynflow.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_dynflow', '0.1.6'
+gem 'smart_proxy_dynflow', '0.1.8'

--- a/plugins/smart_proxy_dynflow_core/changelog
+++ b/plugins/smart_proxy_dynflow_core/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-dynflow-core (0.1.8-1) stable; urgency=low
+
+  * 0.1.8 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Fri, 06 Oct 2017 17:13:31 +0200
+
 ruby-smart-proxy-dynflow-core (0.1.6-1) stable; urgency=low
 
   * 0.1.6 released

--- a/plugins/smart_proxy_dynflow_core/control
+++ b/plugins/smart_proxy_dynflow_core/control
@@ -10,7 +10,7 @@ XS-Ruby-Versions: all
 Package: ruby-smart-proxy-dynflow-core
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, ruby-dynflow (>= 0.8.6),
-  ruby-dynflow (<< 0.9.0), ruby-foreman-tasks-core (>= 0.1.0), ruby-foreman-tasks-core (<< 0.2.0),
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, ruby-dynflow (>= 0.8.29),
+  ruby-dynflow (<< 0.9.0), ruby-foreman-tasks-core (>= 0.1.7), ruby-foreman-tasks-core (<< 0.2.0),
   ruby-sequel, ruby-sqlite3
 Description: Dynflow runtime for Foreman smart proxy

--- a/plugins/smart_proxy_dynflow_core/dynflow_core.rb
+++ b/plugins/smart_proxy_dynflow_core/dynflow_core.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_dynflow_core', '0.1.6'
+gem 'smart_proxy_dynflow_core', '0.1.8'

--- a/plugins/smart_proxy_remote_execution_ssh/changelog
+++ b/plugins/smart_proxy_remote_execution_ssh/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-remote-execution-ssh (0.1.6-1) stable; urgency=low
+
+  * 0.1.6 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Fri, 06 Oct 2017 17:21:39 +0200
+
 ruby-smart-proxy-remote-execution-ssh (0.1.5-1) stable; urgency=low
 
   * 0.1.5 released

--- a/plugins/smart_proxy_remote_execution_ssh/control
+++ b/plugins/smart_proxy_remote_execution_ssh/control
@@ -11,7 +11,7 @@ Package: ruby-smart-proxy-remote-execution-ssh
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.11.0~rc3),
-  ruby-foreman-remote-execution-core (>= 1.0.0),
+  ruby-foreman-remote-execution-core (>= 1.0.6),
   ruby-foreman-remote-execution-core (<< 1.1.0),
   ruby-smart-proxy-dynflow (>= 0.1.0), ruby-smart-proxy-dynflow (<< 0.2.0)
 Description: SSH remote execution provider for Foreman smart proxy

--- a/plugins/smart_proxy_remote_execution_ssh/remote_execution_ssh.rb
+++ b/plugins/smart_proxy_remote_execution_ssh/remote_execution_ssh.rb
@@ -1,2 +1,2 @@
-gem 'smart_proxy_remote_execution_ssh', '0.1.5'
+gem 'smart_proxy_remote_execution_ssh', '0.1.6'
 gem 'foreman_remote_execution_core'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [ ] 1.16
* [x] 1.15
* [ ] 1.14

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

The smart-proxy part for the remote execution dependencies for 1.3.4 against Foreman 1.15