### PR TITLE
Update foreman_remote_execution to 1.3.6 [deb/1.15]

### DIFF
--- a/plugins/ruby-foreman-remote-execution/debian/changelog
+++ b/plugins/ruby-foreman-remote-execution/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution (1.3.6-1) stable; urgency=low
+
+  * 1.3.6 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Fri, 13 Oct 2017 14:30:54 +0200
+
 ruby-foreman-remote-execution (1.3.5-1) stable; urgency=low
 
   * 1.3.5 released

--- a/plugins/ruby-foreman-remote-execution/debian/gem.list
+++ b/plugins/ruby-foreman-remote-execution/debian/gem.list
@@ -1,3 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.3.5.gem"
+GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.3.6.gem"
 GEMS="$GEMS https://rubygems.org/downloads/foreman_remote_execution_core-1.0.6.gem"

--- a/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
+++ b/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
@@ -1,1 +1,1 @@
-gem 'foreman_remote_execution', '1.3.5'
+gem 'foreman_remote_execution', '1.3.6'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [ ] 1.16
* [x] 1.15
* [ ] 1.14

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

Fix for projects.theforeman.org/issues/21168/, otherwise, creation of taxonomies is broken