### PR TITLE
Update smart_proxy_monitoring to 0.1.1 [deb]

### DIFF
--- a/plugins/smart_proxy_monitoring/changelog
+++ b/plugins/smart_proxy_monitoring/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-monitoring (0.1.1-1) stable; urgency=low
+
+  * 0.1.1 released
+
+ -- Timo Goebel <mail@timogoebel.name>  Tue, 17 Oct 2017 10:24:36 +0200
+
 ruby-smart-proxy-monitoring (0.1.0-1) stable; urgency=low
 
   * Initial Debian package


### PR DESCRIPTION
Please build for:

* [x] Nightly
* [x] 1.16
* [x] 1.15
* [x] 1.14
