### PR TITLE
Update clamp to 1.1.2

### DIFF
--- a/dependencies/jessie/clamp/changelog
+++ b/dependencies/jessie/clamp/changelog
@@ -1,3 +1,9 @@
+ruby-clamp (1.1.2-1) stable; urgency=low
+
+  * 1.1.2 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Thu, 19 Oct 2017 23:44:40 +0200
+
 ruby-clamp (1.0.0-1) stable; urgency=low
 
   * update to 1.0.0, which merged i18n patch

--- a/dependencies/trusty/clamp/changelog
+++ b/dependencies/trusty/clamp/changelog
@@ -1,3 +1,9 @@
+ruby-clamp (1.1.2-1) stable; urgency=low
+
+  * 1.1.2 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Thu, 19 Oct 2017 23:44:40 +0200
+
 ruby-clamp (1.0.0-1) stable; urgency=low
 
   * update to 1.0.0, which merged i18n patch


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.16
* [ ] 1.15
* [ ] 1.14

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
