### PR TITLE
Fix repoclosure for 1.14

### DIFF
--- a/repoclosure/yum_el7.conf
+++ b/repoclosure/yum_el7.conf
@@ -55,10 +55,6 @@ baseurl=https://copr-be.cloud.fedoraproject.org/results/isimluk/OpenSCAP/epel-7-
 includepkgs=openscap
 
 # Used as lookaside repos for layered repos (plugins)
-[el7-foreman-nightly]
-name=Foreman nightly EL7
-baseurl=http://yum.theforeman.org/nightly/el7/$basearch
-
-[el7-foreman-1.6]
-name=Foreman 1.6 EL7
-baseurl=http://yum.theforeman.org/releases/1.6/el7/$basearch
+[el7-foreman-1.14]
+name=Foreman 1.14 EL7
+baseurl=http://yum.theforeman.org/releases/1.14/el7/$basearch

--- a/repoclosure/yum_f24.conf
+++ b/repoclosure/yum_f24.conf
@@ -21,3 +21,8 @@ failovermethod=priority
 name=updates
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f24&arch=x86_64
 failovermethod=priority
+
+# Used as lookaside repos for layered repos (plugins)
+[f24-foreman-1.14]
+name=Foreman 1.14 F24
+baseurl=http://yum.theforeman.org/releases/1.14/f24/$basearch


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.16
* [ ] 1.15
* [ ] 1.14

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
