### PR TITLE
Correct release for 1.16 RC2

### DIFF
--- a/foreman-installer/foreman-installer.spec
+++ b/foreman-installer/foreman-installer.spec
@@ -6,7 +6,7 @@
 Name:       foreman-installer
 Epoch:      1
 Version:    1.16.0
-Release: 0.1%{?dotalphatag}%{?dist}
+Release: 0.2%{?dotalphatag}%{?dist}
 Summary:    Puppet-based installer for The Foreman
 Group:      Applications/System
 License:    GPLv3+ and ASL 2.0

--- a/foreman-proxy/foreman-proxy.spec
+++ b/foreman-proxy/foreman-proxy.spec
@@ -11,7 +11,7 @@
 
 Name:           foreman-proxy
 Version:        1.16.0
-Release: 0.1%{?dotalphatag}%{?dist}
+Release: 0.2%{?dotalphatag}%{?dist}
 Summary:        Restful Proxy for DNS, DHCP, TFTP, PuppetCA and Puppet
 
 Group:          Applications/System

--- a/foreman-selinux/foreman-selinux.spec
+++ b/foreman-selinux/foreman-selinux.spec
@@ -37,7 +37,7 @@
 
 Name:           foreman-selinux
 Version:        1.16.0
-Release:        0.1%{?dotalphatag}%{?dist}
+Release:        0.2%{?dotalphatag}%{?dist}
 Summary:        SELinux policy module for Foreman
 
 Group:          System Environment/Base

--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -14,7 +14,7 @@
 
 Name:   foreman
 Version: 1.16.0
-Release: 0.1%{?dotalphatag}%{?dist}
+Release: 0.2%{?dotalphatag}%{?dist}
 Summary:Systems Management web application
 
 Group:  Applications/System


### PR DESCRIPTION
In 411d6349b8e49d784d9fcd42fc7c29e3344390e0 I lowered the release where I shouldn't have since this means the 0.1 RC2 version is considered older than the 0.2 RC1.