### PR TITLE
Update add_npm_package

### DIFF
--- a/check_npm_version.sh
+++ b/check_npm_version.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+NPM_PACKAGE_NAME=$1
+
+if [[ -z $NPM_PACKAGE_NAME ]] ; then
+	echo "Usage: $0 PACKAGE"
+	exit 1
+fi
+
+if [[ -d nodejs-$NPM_PACKAGE_NAME ]] ; then
+	grep Version nodejs-$NPM_PACKAGE_NAME/*.spec
+else
+	./add_npm_package.sh $NPM_PACKAGE_NAME
+fi


### PR DESCRIPTION
It now defaults to single builds of the latest version if no arguments
are given. We also use named variables rather than $1 $2 $3. By using
bash -e we should error out when something fails rather than continuing.