### PR TITLE
update foreman-tasks to 0.10.6 (DEB)

### DIFF
--- a/plugins/ruby-foreman-tasks/debian/changelog
+++ b/plugins/ruby-foreman-tasks/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-tasks (0.10.6-1) stable; urgency=low
+
+  * 0.10.6 released
+
+ -- Michael Moll <mmoll@mmoll.at>  Wed, 01 Nov 2017 18:33:21 +0100
+
 ruby-foreman-tasks (0.10.4-1) stable; urgency=low
 
   * 0.10.4 released

--- a/plugins/ruby-foreman-tasks/debian/gem.list
+++ b/plugins/ruby-foreman-tasks/debian/gem.list
@@ -1,6 +1,11 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman-tasks-0.10.4.gem"
+GEMS="https://rubygems.org/downloads/foreman-tasks-0.10.6.gem"
 GEMS="$GEMS https://rubygems.org/downloads/foreman-tasks-core-0.2.4.gem"
 GEMS="$GEMS https://rubygems.org/downloads/parse-cron-0.1.4.gem"
-GEMS="$GEMS https://rubygems.org/downloads/sinatra-1.4.6.gem"
-GEMS="$GEMS https://rubygems.org/downloads/rack-protection-1.4.0.gem"
+# use 2.x for deb/develop
+GEMS="$GEMS https://rubygems.org/downloads/sinatra-2.0.0.gem"
+GEMS="$GEMS https://rubygems.org/downloads/rack-protection-2.0.0.gem"
+GEMS="$GEMS https://rubygems.org/downloads/mustermann-1.0.1.gem"
+# use 1.4.x for deb/1.16
+#GEMS="$GEMS https://rubygems.org/downloads/sinatra-1.4.8.gem"
+#GEMS="$GEMS https://rubygems.org/downloads/rack-protection-1.4.0.gem"

--- a/plugins/ruby-foreman-tasks/foreman-tasks.rb
+++ b/plugins/ruby-foreman-tasks/foreman-tasks.rb
@@ -1,1 +1,1 @@
-gem 'foreman-tasks', '0.10.4'
+gem 'foreman-tasks', '0.10.6'


### PR DESCRIPTION
Also, now that DEB builds are using Rails 5, use Rails 5 compatible
dependencies: sinatra and rack-protection, rack itself comes with the
foreman package, as it's a dependency of Rails.
this should be built into:

* [x] Nightly
* [x] 1.16 - at least I guess it's still 1.16 compatible... @iNecas?
