### PR TITLE
Remove python-urllib3 in favor of whats in base CentOS

### DIFF
--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -53,9 +53,6 @@
        <packagereq type="default">tfm-rubygem-qpid_messaging</packagereq>
        <packagereq type="default">tfm-rubygem-hammer_cli_csv</packagereq>
 
-       <!-- katello thirdparty non-rubygem packages -->
-       <packagereq type="default">python-urllib3</packagereq>
-
        <!-- temporary qpid packages -->
        <packagereq type="default">qpid-dispatch-router</packagereq>
        <packagereq type="default">qpid-dispatch-tools</packagereq>

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -357,7 +357,6 @@ scl = tfm
 blacklist = rubygem-jenkins_api_client
   rubygem-mixlib-shellout
   rubygem-terminal-table
-  python-urllib3
 
 [katello-thirdparty-rhel7]
 disttag = .el7
@@ -365,7 +364,6 @@ scl = tfm
 whitelist = rubygem-jenkins_api_client
   rubygem-mixlib-shellout
   rubygem-terminal-table
-  python-urllib3
 
 [katello-nightly-fedora26]
 disttag = .fc26


### PR DESCRIPTION
We carried a patched version of urllib3 for RHBZ#1329395.
This is fixed since python-urllib3-1.10.2-3.el7 which is in EL7.4+.

This is the foreman part of https://github.com/Katello/katello-packaging/pull/570.