### PR TITLE
Bump babel-core dependency in foreman.spec

### DIFF
--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -218,7 +218,7 @@ BuildRequires: http-parser
 # Temporary dep on libuv until https://bugs.centos.org/view.php?id=10606
 # is resolved
 BuildRequires: libuv
-BuildRequires: npm(babel-core) < 6.8.0
+BuildRequires: npm(babel-core) < 6.27.0
 BuildRequires: npm(babel-core) >= 6.7.2
 BuildRequires: npm(babel-loader) < 7.2.0
 BuildRequires: npm(babel-loader) >= 7.1.1


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.16
* [ ] 1.15
* [ ] 1.14

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

This should fix the repoclosure as we have babel-core 6.26 but try to install babel-core < 6.8
