### PR TITLE
Fixes #20550 - support for remote DB in backup and restore

### DIFF
--- a/katello/katello/db_config.rb
+++ b/katello/katello/db_config.rb
@@ -1,0 +1,66 @@
+require 'yaml'
+
+module KatelloUtilities
+  class DBConfig
+    attr_reader :foreman, :candlepin
+    INSTALLER_CONFIG = '/etc/foreman-installer/scenarios.d/last_scenario.yaml'
+
+    def initialize(scenario = INSTALLER_CONFIG)
+      config = YAML.load(File.read(scenario))
+      answers = YAML.load(File.read(config[:answer_file]))
+      @foreman = {
+          :username => answers['foreman']['db_username'],
+          :password => answers['foreman']['db_password'],
+          :database => answers['foreman']['db_database'] || 'foreman',
+          :host => answers['foreman']['db_host'] || 'localhost',
+          :port => answers['foreman']['db_port'] || '5432'
+      }
+      @candlepin = {
+          :username => answers['katello']['candlepin_db_user'],
+          :password => answers['katello']['candlepin_db_password'],
+          :database => answers['katello']['candlepin_db_name'] || 'candlepin',
+          :host => answers['katello']['candlepin_db_host'] || 'localhost',
+          :port => answers['katello']['candlepin_db_port'] || '5432',
+      }
+    end
+
+    def remote_db?(config)
+      !['localhost', '127.0.0.1', `hostname`.strip].include? config[:host]
+    end
+
+    def any_local_db?
+      !remote_db?(foreman) || !remote_db?(candlepin)
+    end
+
+    def any_remote_db?
+      remote_db?(foreman) || remote_db?(candlepin)
+    end
+
+    def pg_command_base(config, command, args)
+      "PGPASSWORD='#{config[:password]}' #{command} -U #{config[:username]} -h #{config[:host]} -p #{config[:port]} #{args}"
+    end
+
+    def pg_command(config, command, args)
+      pg_command_base(config, command, "-d #{config[:database]} #{args}")
+    end
+
+    def pg_dump_command(config, dump_file)
+      pg_command_base(config, 'pg_dump', "-Fc #{config[:database]} > #{dump_file}")
+    end
+
+    def pg_sql_statement(config, statement)
+      pg_command(config, 'psql', '-t -c "' + statement + '"')
+    end
+
+    # WARNING: deletes all the data from a dabase. No warnings. No confirmations.
+    def empty_database!(config)
+      generate_delete_statements = pg_sql_statement(config, %q(
+        select string_agg('drop table if exists \"' || tablename || '\" cascade;', '')
+        from pg_tables
+        where schemaname = 'public';
+      ))
+      delete_statements = `#{generate_delete_statements}`
+      system(pg_sql_statement(config, delete_statements)) if delete_statements
+    end
+  end
+end

--- a/katello/katello/helper.rb
+++ b/katello/katello/helper.rb
@@ -1,7 +1,14 @@
+require 'pathname'
+require_relative 'db_config'
+
 module KatelloUtilities
   module Helper
+    def last_scenario_config
+      Pathname.new("/etc/foreman-installer/scenarios.d/last_scenario.yaml").realpath.to_s
+    end
+
     def last_scenario
-      File.basename(File.readlink("/etc/foreman-installer/scenarios.d/last_scenario.yaml")).split(".")[0]
+      File.basename(last_scenario_config).split(".")[0]
     end
 
     def accepted_scenarios
@@ -48,6 +55,10 @@ module KatelloUtilities
 
     def timestamp
       DateTime.now.strftime('%Y%m%d%H%M%S')
+    end
+
+    def db_config
+      @katello_db_config ||= KatelloUtilities::DBConfig.new(last_scenario_config)
     end
   end
 end

--- a/katello/katello/katello-service
+++ b/katello/katello/katello-service
@@ -2,6 +2,14 @@
 
 require 'optparse'
 
+# check if production install
+if __FILE__.start_with?('/sbin/')
+  UTILS_PATH='/usr/share/katello'
+else
+  UTILS_PATH=File.expand_path('..', __FILE__)
+end
+require File.join(UTILS_PATH, 'db_config.rb')
+
 ACTIONS = ['restart', 'stop', 'start', 'status', 'list', 'enable', 'disable']
 COMMAND = '/usr/sbin/service-wait'
 SERVICES = {
@@ -25,6 +33,7 @@ SERVICES = {
 }
 
 @options = {:excluded => []}
+@db_config = KatelloUtilities::DBConfig.new
 
 OptionParser.new do |opts|
   opts.banner = "Usage: katello-service [options] [#{ACTIONS.join('|')}]"
@@ -50,6 +59,7 @@ OptionParser.new do |opts|
 end
 
 def service_exists?(service)
+  return false if !@db_config.any_local_db? and service == 'postgresql'
   systemd = `systemctl is-enabled #{service} 2>&1`.strip
   systemd == 'enabled' || systemd == 'disabled'
 end

--- a/katello/katello/katello.spec
+++ b/katello/katello/katello.spec
@@ -31,6 +31,7 @@ Source14:   restore.rb
 Source15:   backup.rb
 Source16:   hostname-change.rb
 Source17:   helper.rb
+Source18:   db_config.rb
 
 BuildRequires: asciidoc
 BuildRequires: util-linux
@@ -98,6 +99,7 @@ install -m 644 %{SOURCE14} %{buildroot}%{_datarootdir}/katello/restore.rb
 install -m 644 %{SOURCE15} %{buildroot}%{_datarootdir}/katello/backup.rb
 install -m 644 %{SOURCE16} %{buildroot}%{_datarootdir}/katello/hostname-change.rb
 install -m 644 %{SOURCE17} %{buildroot}%{_datarootdir}/katello/helper.rb
+install -m 644 %{SOURCE18} %{buildroot}%{_datarootdir}/katello/db_config.rb
 
 # install important scripts
 mkdir -p %{buildroot}%{_bindir}
@@ -151,6 +153,7 @@ Common runtime components of %{name}
 %{_datarootdir}/katello/backup.rb
 %{_datarootdir}/katello/hostname-change.rb
 %{_datarootdir}/katello/helper.rb
+%{_datarootdir}/katello/db_config.rb
 %config(missingok) %{_sysconfdir}/cron.weekly/katello-clean-empty-puppet-environments
 %config(missingok) %{_sysconfdir}/cron.weekly/katello-remove-orphans
 %config(missingok) %{_sysconfdir}/cron.daily/katello-repository-publish-check


### PR DESCRIPTION
Backup and restore scripts were changed to access postgress DB
using the configuration from Foreman and Candlepin and not directly
as DB superuser.

In online backup we skip dump of global objects as usually there are no
privileges to restore them on the remote DB.

In offline backup we do ofline backup as before only the remote DBs
are backed up using pg_dump as in online backup because we do not have
direct access to /var/lib/pgsql/data. We assume the remote DB is always
up.

The restore was updated accordingly and can restore offline backup
including dumps of the remote dbs.

katello-service was fixed to not touch postgresql service when the DB is
remote.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.16
* [ ] 1.15
* [ ] 1.14

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
