### PR TITLE
Install webpack binary without the .js extension

### DIFF
--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -846,7 +846,7 @@ export BUNDLER_EXT_GROUPS="default assets"
 ln -s %{nodejs_sitelib} node_modules
 export NODE_ENV=production
 %{?scl:scl enable %{scl} "}
-webpack.js --bail --config config/webpack.config.js
+webpack --bail --config config/webpack.config.js
 %{?scl:"}
 %{scl_rake} assets:precompile RAILS_ENV=production --trace
 %{scl_rake} db:migrate db:schema:dump RAILS_ENV=production --trace

--- a/nodejs-webpack/nodejs-webpack.spec
+++ b/nodejs-webpack/nodejs-webpack.spec
@@ -4,7 +4,7 @@
 
 Name: nodejs-%{npm_name}
 Version: 3.4.1
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Packs CommonJs/AMD modules for the browser
 License: MIT
 URL: https://github.com/webpack/webpack
@@ -365,16 +365,15 @@ mkdir -p %{buildroot}%{nodejs_sitelib}/%{npm_name}
 cd node_modules/webpack
 cp -pfr LICENSE README.md bin buildin hot lib package.json schemas web_modules node_modules %{buildroot}%{nodejs_sitelib}/%{npm_name}
 cp -pf README.md LICENSE ../../
-# If any binaries are included, symlink them to bindir here
-mkdir -p %{buildroot}%{nodejs_sitelib}/${npm_name}/bin
+mkdir -p %{buildroot}%{nodejs_sitelib}/%{npm_name}/bin
 mkdir -p %{buildroot}%{_bindir}/
-install -p -D -m0755 bin/webpack.js %{buildroot}%{nodejs_sitelib}/%{npm_name}/bin/webpack.js
-ln -sf %{nodejs_sitelib}/%{npm_name}/bin/webpack.js %{buildroot}%{_bindir}/webpack.js
+install -p -D -m0755 bin/webpack.js %{buildroot}%{nodejs_sitelib}/%{npm_name}/bin/webpack
+ln -sf %{nodejs_sitelib}/%{npm_name}/bin/webpack %{buildroot}%{_bindir}/webpack
 
 %files
 %{nodejs_sitelib}/%{npm_name}
-%{_bindir}/webpack.js
-%doc LICENSE
+%{_bindir}/webpack
+%license LICENSE
 %doc README.md
 
 %changelog


### PR DESCRIPTION
Without this things like rake webpack:compile fail because the binary
can't be found.