### PR TITLE
plugin precompile: do not remove tmp directory

### DIFF
--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -994,7 +994,6 @@ sed -i 's/:locations_enabled: false/:locations_enabled: true/' \`pwd\`/config/se
 sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' \`pwd\`/config/settings.yaml \\
 export GEM_PATH=%%{buildroot}%%{gem_dir}:\${GEM_PATH:+\${GEM_PATH}}\${GEM_PATH:-\`%{?scl:scl enable %%{scl_ror} -- }ruby -e "print Gem.path.join(':')"\`} \\
 cp %%{buildroot}%%{%{name}_bundlerd_dir}/%%{gem_name}.rb ./bundler.d/%%{gem_name}.rb \\
-unlink tmp \\
 \\
 rm \`pwd\`/config/initializers/encryption_key.rb \\
 /usr/bin/%%{?scl:%%{scl}-}rake security:generate_encryption_key \\


### PR DESCRIPTION
This fixes a possible bug for me that causes plugins to fail to build. I'm unsure if this is the correct fix or if this breaks anything else. Comments welcome.

Error Message:
```
API controllers newer than Apipie cache! Run apipie:cache rake task to regenerate cache.
2017-11-20 14:16:07  [app] [D] There are 366 pending migrations: CreateHosts, AddAuditsTable, CreateArchitectures, CreateMedia, CreateDomains...
2017-11-20 14:16:07  [app] [D] There are 366 pending migrations: CreateHosts, AddAuditsTable, CreateArchitectures, CreateMedia, CreateDomains...
2017-11-20 14:16:07  [app] [D] There are 366 pending migrations: CreateHosts, AddAuditsTable, CreateArchitectures, CreateMedia, CreateDomains...
2017-11-20 14:16:07  [app] [D] There are 366 pending migrations: CreateHosts, AddAuditsTable, CreateArchitectures, CreateMedia, CreateDomains...
2017-11-20 14:16:07  [app] [D] There are 366 pending migrations: CreateHosts, AddAuditsTable, CreateArchitectures, CreateMedia, CreateDomains...
rake aborted!
Errno::ENOENT: No such file or directory @ rb_sysopen - /root/rpmbuild/BUILD/foreman_dlm-0.0.1/usr/share/foreman/tmp/asset_manifest.json20171120-1327-zwd7ob
/opt/rh/rh-ruby22/root/usr/share/ruby/tempfile.rb:136:in `initialize'
/opt/rh/rh-ruby22/root/usr/share/ruby/tempfile.rb:136:in `open'
/opt/rh/rh-ruby22/root/usr/share/ruby/tempfile.rb:136:in `block in initialize'
/opt/rh/rh-ruby22/root/usr/share/ruby/tmpdir.rb:129:in `create'
/opt/rh/rh-ruby22/root/usr/share/ruby/tempfile.rb:133:in `initialize'
/opt/rh/rh-ruby22/root/usr/share/ruby/tempfile.rb:315:in `new'
/opt/rh/rh-ruby22/root/usr/share/ruby/tempfile.rb:315:in `open'
/root/rpmbuild/BUILD/foreman_dlm-0.0.1/usr/share/foreman/config/initializers/assets.rb:85:in `block (2 levels) in <top (required)>'
/opt/rh/sclo-ror42/root/usr/share/gems/gems/activesupport-4.2.5.1/lib/active_support/lazy_load_hooks.rb:36:in `call'
/opt/rh/sclo-ror42/root/usr/share/gems/gems/activesupport-4.2.5.1/lib/active_support/lazy_load_hooks.rb:36:in `execute_hook'
/opt/rh/sclo-ror42/root/usr/share/gems/gems/activesupport-4.2.5.1/lib/active_support/lazy_load_hooks.rb:45:in `block in run_load_hooks'
/opt/rh/sclo-ror42/root/usr/share/gems/gems/activesupport-4.2.5.1/lib/active_support/lazy_load_hooks.rb:44:in `each'
/opt/rh/sclo-ror42/root/usr/share/gems/gems/activesupport-4.2.5.1/lib/active_support/lazy_load_hooks.rb:44:in `run_load_hooks'
/opt/rh/sclo-ror42/root/usr/share/gems/gems/railties-4.2.5.1/lib/rails/application/finisher.rb:62:in `block in <module:Finisher>'
/opt/rh/sclo-ror42/root/usr/share/gems/gems/railties-4.2.5.1/lib/rails/initializable.rb:30:in `instance_exec'
/opt/rh/sclo-ror42/root/usr/share/gems/gems/railties-4.2.5.1/lib/rails/initializable.rb:30:in `run'
/opt/rh/sclo-ror42/root/usr/share/gems/gems/railties-4.2.5.1/lib/rails/initializable.rb:55:in `block in run_initializers'
/opt/rh/rh-ruby22/root/usr/share/ruby/tsort.rb:226:in `block in tsort_each'
/opt/rh/rh-ruby22/root/usr/share/ruby/tsort.rb:348:in `block (2 levels) in each_strongly_connected_component'
/opt/rh/rh-ruby22/root/usr/share/ruby/tsort.rb:429:in `each_strongly_connected_component_from'
/opt/rh/rh-ruby22/root/usr/share/ruby/tsort.rb:347:in `block in each_strongly_connected_component'
/opt/rh/rh-ruby22/root/usr/share/ruby/tsort.rb:345:in `each'
/opt/rh/rh-ruby22/root/usr/share/ruby/tsort.rb:345:in `call'
/opt/rh/rh-ruby22/root/usr/share/ruby/tsort.rb:345:in `each_strongly_connected_component'
/opt/rh/rh-ruby22/root/usr/share/ruby/tsort.rb:224:in `tsort_each'
```

It tries to create a temporary file in `/root/rpmbuild/BUILD/foreman_dlm-0.0.1/usr/share/foreman/tmp/`. But the temporary directory does not exist, so it cannot create the file.

https://github.com/theforeman/foreman/blob/e69b62cec455e82052d7b78238495166ea9de773/config/initializers/assets.rb#L86-L89

Spec-File:
```spec
%{?scl:%scl_package rubygem-%{gem_name}}
%{!?scl:%global pkg_name %{name}}

%global gem_name foreman_dlm
%global plugin_name dlm

Name: %{?scl_prefix}rubygem-%{gem_name}
Version: 0.0.1
Release: 1%{?foremandist}%{?dist}
Summary: Distributed Lock Manager for Foreman
Group: Applications/Systems
License: GPL-3.0
URL: https://github.com/timogoebel/foreman_dlm
Source0: %{gem_name}-%{version}.gem
Requires: foreman >= 1.15
Requires: %{?scl_prefix_ruby}ruby(release)
Requires: %{?scl_prefix_ruby}ruby
Requires: %{?scl_prefix_ruby}ruby(rubygems)
BuildRequires: foreman-plugin >= 1.15
BuildRequires: %{?scl_prefix_ruby}ruby(release)
BuildRequires: %{?scl_prefix_ruby}ruby
BuildRequires: %{?scl_prefix_ruby}rubygems-devel
BuildArch: noarch
Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
Provides: foreman-plugin-%{plugin_name}

%description
Adds a Distributed Lock Manager to Foreman. This enables painless system
updates for clusters.


%package doc
Summary: Documentation for %{pkg_name}
Group: Documentation
Requires: %{?scl_prefix}%{pkg_name} = %{version}-%{release}
BuildArch: noarch

%description doc
Documentation for %{pkg_name}.

%prep
%{?scl:scl enable %{scl} - << \EOF}
gem unpack %{SOURCE0}
%{?scl:EOF}


%setup -q -D -T -n  %{gem_name}-%{version}


%{?scl:scl enable %{scl} - << \EOF}
gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
%{?scl:EOF}


%build
# Create the gem as gem install only works on a gem file
%{?scl:scl enable %{scl} - << \EOF}
gem build %{gem_name}.gemspec
%{?scl:EOF}

# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
# by default, so that we can move it into the buildroot in %%install
%{?scl:scl enable %{scl} - << \EOF}
%gem_install
%{?scl:EOF}

%install
mkdir -p %{buildroot}%{gem_dir}
cp -pa .%{gem_dir}/* \
        %{buildroot}%{gem_dir}/

%foreman_bundlerd_file
%foreman_precompile_plugin -a

%files
%dir %{gem_instdir}
%license %{gem_instdir}/LICENSE
%{gem_instdir}/app
%{gem_instdir}/config
%{gem_instdir}/db
%{gem_libdir}
%{gem_instdir}/locale
%exclude %{gem_cache}
%{gem_spec}
%{foreman_bundlerd_plugin}
%{foreman_apipie_cache_foreman}
%{foreman_apipie_cache_plugin}

%files doc
%doc %{gem_docdir}
%doc %{gem_instdir}/README.md
%{gem_instdir}/Rakefile
%{gem_instdir}/test

%posttrans
%{foreman_db_migrate}
%{foreman_apipie_cache}
%{foreman_restart}
exit 0

%changelog
```