### PR TITLE
gem2rpm: handle nil download path

### DIFF
--- a/gem2rpm/foreman_plugin.spec.erb
+++ b/gem2rpm/foreman_plugin.spec.erb
@@ -34,7 +34,7 @@ License: <%= spec.licenses.join(" and ") %>
 <% if spec.homepage -%>
 URL: <%= spec.homepage %>
 <% end -%>
-Source0: <%= download_path.sub('https:', 'http:') %>%{gem_name}-%{version}.gem
+Source0: <%= download_path %>%{gem_name}-%{version}.gem
 Requires: foreman >= FIXME
 Requires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>

--- a/gem2rpm/hammer_plugin.spec.erb
+++ b/gem2rpm/hammer_plugin.spec.erb
@@ -23,7 +23,7 @@ License: <%= spec.licenses.join(" and ") %>
 <% if spec.homepage -%>
 URL: <%= spec.homepage %>
 <% end -%>
-Source0: <%= download_path.sub('https:', 'http:') %>%{gem_name}-%{version}.gem
+Source0: <%= download_path %>%{gem_name}-%{version}.gem
 Requires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>
 Requires: %{?scl_prefix_ruby}ruby <%= req %>

--- a/gem2rpm/nonscl.spec.erb
+++ b/gem2rpm/nonscl.spec.erb
@@ -10,7 +10,7 @@ License: <%= spec.licenses.join(" and ") %>
 <% if spec.homepage -%>
 URL: <%= spec.homepage %>
 <% end -%>
-Source0: <%= download_path.sub('https:', 'http:') %>%{gem_name}-%{version}.gem
+Source0: <%= download_path %>%{gem_name}-%{version}.gem
 Requires: ruby(release)
 <% for req in spec.required_ruby_version -%>
 Requires: ruby <%= req %>

--- a/gem2rpm/scl.spec.erb
+++ b/gem2rpm/scl.spec.erb
@@ -18,7 +18,7 @@ License: <%= spec.licenses.join(" and ") %>
 <% if spec.homepage -%>
 URL: <%= spec.homepage %>
 <% end -%>
-Source0: <%= download_path.sub('https:', 'http:') %>%{gem_name}-%{version}.gem
+Source0: <%= download_path %>%{gem_name}-%{version}.gem
 Requires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>
 Requires: %{?scl_prefix_ruby}ruby <%= req %>

--- a/gem2rpm/smart_proxy_plugin.spec.erb
+++ b/gem2rpm/smart_proxy_plugin.spec.erb
@@ -19,7 +19,7 @@ License: <%= spec.licenses.join(" and ") %>
 <% if spec.homepage -%>
 URL: <%= spec.homepage %>
 <% end -%>
-Source0: <%= download_path.sub('https:', 'http:') %>%{gem_name}-%{version}.gem
+Source0: <%= download_path %>%{gem_name}-%{version}.gem
 Requires: foreman-proxy >= FIXME
 Requires: ruby(release)
 <% for req in spec.required_ruby_version -%>


### PR DESCRIPTION
If a gem has not been published at rubygems, `download_path` is `nil` and the `sub('https:', 'http:')` fails. This commit defaults the download path to `nil` to avoid the issue.