### PR TITLE
Refs #21736 - Bump mail gem to 2.7[rpm]

### DIFF
--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -115,7 +115,7 @@ Requires: %{?scl_prefix}rubygem(deacon) >= 1.0
 Requires: %{?scl_prefix}rubygem(deacon) < 2.0
 Requires: %{?scl_prefix}rubygem(webpack-rails) >= 0.9.7
 Requires: %{?scl_prefix}rubygem(webpack-rails) < 1.0.0
-Requires: %{?scl_prefix_ror}rubygem(mail) >= 2.6
+Requires: %{?scl_prefix_ror}rubygem(mail) >= 2.7
 Requires: %{?scl_prefix_ror}rubygem(mail) < 3.0
 Requires: %{?scl_prefix}rubygem(sshkey) >= 1.9
 Requires: %{?scl_prefix}rubygem(sshkey) < 2.0
@@ -201,7 +201,7 @@ BuildRequires: %{?scl_prefix}rubygem(deacon) >= 1.0
 BuildRequires: %{?scl_prefix}rubygem(deacon) < 2.0
 BuildRequires: %{?scl_prefix}rubygem(webpack-rails) >= 0.9.7
 BuildRequires: %{?scl_prefix}rubygem(webpack-rails) < 1.0.0
-BuildRequires: %{?scl_prefix_ror}rubygem(mail) >= 2.6
+BuildRequires: %{?scl_prefix_ror}rubygem(mail) >= 2.7
 BuildRequires: %{?scl_prefix_ror}rubygem(mail) < 3.0
 BuildRequires: %{?scl_prefix}rubygem(sshkey) >= 1.9
 BuildRequires: %{?scl_prefix}rubygem(sshkey) < 2.0


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.16
* [ ] 1.15
* [ ] 1.14

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
