### PR TITLE
fixes #21899 - permit split of pulp_data.tar

### DIFF
--- a/packages/katello/katello/backup.rb
+++ b/packages/katello/katello/backup.rb
@@ -324,7 +324,17 @@ module KatelloUtilities
     end
 
     def create_pulp_data_tar
-      run_cmd("tar --selinux --create --file=#{File.join(@dir, 'pulp_data.tar')} --exclude=var/lib/pulp/katello-export --listed-incremental=#{File.join(@dir, '.pulp.snar')} --transform 's,^,var/lib/pulp/,S' -S *")
+      archive_size = @options[:split_tar]
+      tar_command = "tar --selinux --create --file=#{File.join(@dir, 'pulp_data.tar')} "
+
+      if archive_size
+        split_tar_script = default_split_tar_script
+        tar_command += "--tape-length=#{archive_size} --new-volume-script=#{split_tar_script} "
+      end
+
+      tar_command += "--exclude=var/lib/pulp/katello-export --listed-incremental=#{File.join(@dir, '.pulp.snar')} --transform 's,^,var/lib/pulp/,S' -S *"
+
+      run_cmd(tar_command)
     end
 
     def backup_config_files
@@ -362,6 +372,11 @@ module KatelloUtilities
           else
             opts.abort("Previous backup directory does not exist: #{dir_path}")
           end
+        end
+
+        opts.on("--split-pulp-tar SIZE", "Split pulp data into files of a specified size, i.e. (100M, 50G). See '--tape-length' in 'info tar' for all sizes") do |size|
+          opts.abort("Please specify size according to 'tar --tape-length' format.") unless size
+          @options[:split_tar] = size
         end
 
         opts.on("--online-backup", "Keep services online during backup") do |online|

--- a/packages/katello/katello/helper.rb
+++ b/packages/katello/katello/helper.rb
@@ -24,6 +24,24 @@ module KatelloUtilities
       "This utility can't run on a non-katello system."
     end
 
+    def default_split_tar_script
+      # check if production install
+      if __FILE__.include?('sbin')
+        utils_path='/usr/share/katello'
+      else
+        utils_path=File.expand_path('..', __FILE__)
+      end
+
+      split_tar_script = File.join(utils_path, 'katello-backup-rotate-tar.sh')
+      if !File.executable?(split_tar_script)
+        puts "**** ERROR: split_tar_script not executable ****"
+        puts split_tar_script
+        exit(-1)
+      end
+
+      split_tar_script
+    end
+
     def foreman_rpm_installed?
       system("rpm -q foreman > /dev/null")
     end

--- a/packages/katello/katello/katello-backup-rotate-tar.sh
+++ b/packages/katello/katello/katello-backup-rotate-tar.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+## For this script it's advisable to use a shell, such as Bash,
+## that supports a TAR_FD value greater than 9.
+
+# This script taken from the tar info doc
+
+name=`expr ${TAR_ARCHIVE} : '\(.*\)\..*'`
+volnum=`printf "%04d" ${TAR_VOLUME}`
+filename="${name:-$TAR_ARCHIVE}.part${volnum:-$TAR_VOLUME}"
+case ${TAR_SUBCOMMAND} in
+-c)       ;;
+-d|-x|-t) test -r ${filename} || exit 1
+          ;;
+*)        exit 1
+esac
+
+echo ${filename} >&${TAR_FD}
+echo " Switched to multi-volume ${filename}"

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -31,6 +31,7 @@ Source14:   restore.rb
 Source15:   backup.rb
 Source16:   hostname-change.rb
 Source17:   helper.rb
+Source18:   katello-backup-rotate-tar.sh
 
 BuildRequires: asciidoc
 BuildRequires: util-linux
@@ -98,6 +99,7 @@ install -m 644 %{SOURCE14} %{buildroot}%{_datarootdir}/katello/restore.rb
 install -m 644 %{SOURCE15} %{buildroot}%{_datarootdir}/katello/backup.rb
 install -m 644 %{SOURCE16} %{buildroot}%{_datarootdir}/katello/hostname-change.rb
 install -m 644 %{SOURCE17} %{buildroot}%{_datarootdir}/katello/helper.rb
+install -m 755 %{SOURCE18} %{buildroot}%{_datarootdir}/katello/katello-backup-rotate-tar.sh
 
 # install important scripts
 mkdir -p %{buildroot}%{_bindir}
@@ -152,6 +154,7 @@ Common runtime components of %{name}
 %{_datarootdir}/katello/backup.rb
 %{_datarootdir}/katello/hostname-change.rb
 %{_datarootdir}/katello/helper.rb
+%{_datarootdir}/katello/katello-backup-rotate-tar.sh
 %config(missingok) %{_sysconfdir}/cron.weekly/katello-clean-empty-puppet-environments
 %config(missingok) %{_sysconfdir}/cron.weekly/katello-remove-orphans
 %config(missingok) %{_sysconfdir}/cron.daily/katello-repository-publish-check
@@ -189,6 +192,7 @@ Provides a federation of katello services
 %{_datarootdir}/katello/backup.rb
 %{_datarootdir}/katello/hostname-change.rb
 %{_datarootdir}/katello/helper.rb
+%{_datarootdir}/katello/katello-backup-rotate-tar.sh
 
 # ------ Service ----------------
 %package service

--- a/packages/katello/katello/restore.rb
+++ b/packages/katello/katello/restore.rb
@@ -144,7 +144,17 @@ module KatelloUtilities
       puts "Logical backup detected, using the standard backup files to restore" if valid_logical_backup
       if @pulp_data_exists
         puts "Restoring Pulp data"
-        run_cmd("tar --selinux --overwrite --listed-incremental=/dev/null -xf pulp_data.tar -C /")
+
+        tar_command = "tar --selinux --overwrite --listed-incremental=/dev/null "
+
+        if File.exist?('pulp_data.part0002')
+          split_tar_script = default_split_tar_script
+          tar_command += "-M --new-volume-script=#{split_tar_script} "
+        end
+
+        tar_command += "-xf pulp_data.tar -C /"
+
+        run_cmd(tar_command)
       end
       if @mongo_data_exists
         run_cmd("tar --selinux --overwrite --listed-incremental=/dev/null -xzf mongo_data.tar.gz -C /")


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.16
* [ ] 1.15
* [ ] 1.14

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
Patch for katello-backup