### PR TITLE
add smart_proxy_realm_ad_plugin 0.1 [rpm]

### DIFF
--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -42,6 +42,7 @@
       <packagereq type="default">rubygem-smart_proxy_omaha</packagereq>
       <packagereq type="default">rubygem-smart_proxy_openscap</packagereq>
       <packagereq type="default">rubygem-smart_proxy_pulp</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_realm_ad_plugin</packagereq>
       <packagereq type="default">rubygem-smart_proxy_remote_execution_ssh</packagereq>
       <packagereq type="default">rubygem-smart_proxy_salt</packagereq>
       <packagereq type="default">tfm-rubygem-angular-rails-templates</packagereq>
@@ -158,6 +159,7 @@
       <packagereq type="default">rubygem-smart_proxy_omaha-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_openscap-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_pulp-doc</packagereq>
+      <packagereq type="default">rubygem-smart_proxy_realm_ad_plugin-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_remote_execution_ssh-doc</packagereq>
       <packagereq type="default">rubygem-smart_proxy_salt-doc</packagereq>
       <packagereq type="default">tfm-rubygem-angular-rails-templates-doc</packagereq>

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -355,6 +355,7 @@ whitelist = puppet-foreman_scap_client
   rubygem-smart_proxy_omaha
   rubygem-smart_proxy_openscap
   rubygem-smart_proxy_pulp
+  rubygem-smart_proxy_realm_ad_plugin
   rubygem-smart_proxy_remote_execution_ssh
   rubygem-smart_proxy_salt
 

--- a/rubygem-smart_proxy_realm_ad_plugin/rubygem-smart_proxy_realm_ad_plugin-0.1.spec
+++ b/rubygem-smart_proxy_realm_ad_plugin/rubygem-smart_proxy_realm_ad_plugin-0.1.spec
@@ -1,0 +1,88 @@
+%global gem_name smart_proxy_realm_ad_plugin
+%global plugin_name realm_ad_plugin
+
+%global foreman_proxy_dir %{_datarootdir}/foreman-proxy
+%global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
+%global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
+
+Name: rubygem-%{gem_name}
+Version: 0.1
+Release: 1%{?foremandist}%{?dist}
+Summary: A realm ad provider plugin for Foreman's smart proxy
+Group: Applications/Internet
+License: GPL-3.0
+URL: https://github.com/martencassel/smart_proxy_realm_ad_plugin
+Source0: https://rubygems.org/downloads/%{gem_name}-%{version}.gem
+Requires: foreman-proxy >= 1.15
+Requires: ruby(release)
+Requires: ruby
+Requires: ruby(rubygems)
+Requires: rubygem(rkerberos)
+Requires: rubygem(radcli)
+BuildRequires: ruby(release)
+BuildRequires: ruby
+BuildRequires: rubygems-devel
+BuildArch: noarch
+Provides: rubygem(%{gem_name}) = %{version}
+Provides: foreman-proxy-plugin-%{plugin_name}
+
+%description
+A realm ad provider plugin for Foreman's smart proxy.
+
+
+%package doc
+Summary: Documentation for %{name}
+Group: Documentation
+Requires: %{name} = %{version}-%{release}
+BuildArch: noarch
+
+%description doc
+Documentation for %{name}.
+
+%prep
+gem unpack %{SOURCE0}
+
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
+
+%build
+# Create the gem as gem install only works on a gem file
+gem build %{gem_name}.gemspec
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%gem_install
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -a .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+# bundler file
+mkdir -p %{buildroot}%{foreman_proxy_bundlerd_dir}
+mv %{buildroot}%{gem_instdir}/bundler.d/%{plugin_name}.rb \
+   %{buildroot}%{foreman_proxy_bundlerd_dir}
+
+# sample config
+mkdir -p %{buildroot}%{foreman_proxy_settingsd_dir}
+mv %{buildroot}%{gem_instdir}/config/realm_ad.yml.example \
+   %{buildroot}%{foreman_proxy_settingsd_dir}/realm_ad.yml
+
+%files
+%dir %{gem_instdir}
+%config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/realm_ad.yml
+%license %{gem_instdir}/LICENSE
+%{gem_instdir}/bundler.d
+%{gem_instdir}/config
+%{gem_libdir}
+%{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
+%exclude %{gem_cache}
+%{gem_spec}
+
+%files doc
+%doc %{gem_docdir}
+%doc %{gem_instdir}/README.md
+%{gem_instdir}/test
+
+%changelog

--- a/rubygem-smart_proxy_realm_ad_plugin/smart_proxy_realm_ad_plugin-0.1.gem
+++ b/rubygem-smart_proxy_realm_ad_plugin/smart_proxy_realm_ad_plugin-0.1.gem
@@ -1,0 +1,1 @@
+../.git/annex/objects/V8/65/SHA256E-s20992--34a9fc9aed255f71b18f2286e36b4366afacc2fb0f8fbe97316fd33d40af7bd1.1.gem/SHA256E-s20992--34a9fc9aed255f71b18f2286e36b4366afacc2fb0f8fbe97316fd33d40af7bd1.1.gem


### PR DESCRIPTION
Packaging for [smart_proxy_realm_ad_plugin](https://rubygems.org/gems/smart_proxy_realm_ad_plugin). Please see https://github.com/theforeman/smart-proxy/pull/557 for discussion.
This needs #2007.

Please build for:

* [x] Nightly
* [x] 1.16
* [x] 1.15
* [ ] 1.14