### PR TITLE
Remove reference to unused babel-es2015

### DIFF
--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -31,7 +31,6 @@ whitelist = foreman-bootloaders-redhat
   nodejs-babel-plugin-transform-object-rest-spread
   nodejs-babel-polyfill
   nodejs-babel-preset-env
-  nodejs-babel-preset-es2015
   nodejs-babel-preset-react
   nodejs-babel-register
   nodejs-brace


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.16
* [ ] 1.15
* [ ] 1.14

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
