### PR TITLE
Update tfm to use Rails 5.1 and Ruby 2.4

### DIFF
--- a/tfm/tfm.spec
+++ b/tfm/tfm.spec
@@ -6,10 +6,10 @@
 %{?scl_package:%scl_package %scl}
 
 # Fallback to sclo-ror42 etc. when scldevel's not in the buildroot
-%{!?scl_ror:%global scl_ror sclo-ror42}
-%{!?scl_prefix_ror:%global scl_prefix_ror %{scl_ror}-}
-%{!?scl_ruby:%global scl_ruby rh-ruby22}
-%{!?scl_prefix_ruby:%global scl_prefix_ruby %{scl_ruby}-}
+%global scl_ror tfm-ror51
+%global scl_prefix_ror %{scl_ror}-
+%global scl_ruby rh-ruby24
+%global scl_prefix_ruby %{scl_ruby}-
 
 # Do not produce empty debuginfo package.
 %global debug_package %{nil}
@@ -18,8 +18,8 @@
 
 Summary: Package that installs %scl
 Name: %scl_name
-Version: 3.2
-Release: 10%{?dist}
+Version: 4.0
+Release: 1%{?dist}
 License: GPLv2+
 Group: Applications/File
 Source0: README
@@ -91,6 +91,7 @@ Obsoletes: %{scl_prefix}rubygem-turbolinks < 2.5.3-4
 Obsoletes: %{scl_prefix}rubygem-underscore-rails < 1.8.3-5
 Obsoletes: %{scl_prefix}rubygem-uuid < 2.3.8-2
 Obsoletes: %{scl_prefix}rubygem-uuidtools < 2.1.3-6
+Obsoletes: %{scl_prefix}rubygem-quiet_assets
 
 %description runtime
 Package shipping essential scripts to work with %scl Software Collection.
@@ -222,8 +223,6 @@ for arg in "\$@"; do
 done
 scl enable %{scl_name} "bash \$TMP"
 EOF
-# compatibility symlink
-ln -s %{scl_name}-ruby %{buildroot}%{_root_bindir}/ruby193-ruby
 
 cat >> %{buildroot}%{_root_bindir}/%{scl_name}-rake << EOF
 #!/bin/bash
@@ -274,7 +273,6 @@ selinuxenabled && load_policy || :
 %{_mandir}/man7/%{scl_name}.*
 %attr(755,-,-) %{_root_bindir}/%{scl_name}-rake
 %attr(755,-,-) %{_root_bindir}/%{scl_name}-ruby
-%{_root_bindir}/ruby193-ruby
 
 %files runtime-assets
 %{_scl_scripts}/enable_assets


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.16
* [ ] 1.15
* [ ] 1.14

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
