### PR TITLE
Update katello packages for Rails 5.1

### DIFF
--- a/katello/rubygem-anemone/rubygem-anemone.spec
+++ b/katello/rubygem-anemone/rubygem-anemone.spec
@@ -6,7 +6,7 @@
 Summary:    Anemone web-spider framework
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    0.7.2
-Release:    14%{?dist}
+Release:    15%{?dist}
 License:    MIT
 Group:      Development/Languages
 URL:        http://anemone.rubyforge.org/

--- a/katello/rubygem-hammer_cli_csv/rubygem-hammer_cli_csv.spec
+++ b/katello/rubygem-hammer_cli_csv/rubygem-hammer_cli_csv.spec
@@ -9,7 +9,7 @@
 Summary: CSV input/output command plugin for the Hammer CLI
 Name:    %{?scl_prefix}rubygem-%{gem_name}
 Version: 2.3.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Group:   Development/Languages
 License: GPLv3
 URL:     https://github.com/Katello/hammer-cli-csv

--- a/katello/rubygem-hammer_cli_foreman_virt_who_configure/rubygem-hammer_cli_foreman_virt_who_configure.spec
+++ b/katello/rubygem-hammer_cli_foreman_virt_who_configure/rubygem-hammer_cli_foreman_virt_who_configure.spec
@@ -9,7 +9,7 @@
 Summary: Hammer CLI commands for configuring Virt Who for Katello
 Name:    %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.0.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Group:   Development/Languages
 License: GPLv3
 URL:     https://github.com/theforeman/hammer-cli-foreman-virt-who-configure

--- a/katello/rubygem-hammer_cli_katello/rubygem-hammer_cli_katello.spec
+++ b/katello/rubygem-hammer_cli_katello/rubygem-hammer_cli_katello.spec
@@ -9,7 +9,7 @@
 Summary: Katello command plugin for the Hammer CLI
 Name:    %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.11.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Group:   Development/Languages
 License: GPLv3
 URL:     https://github.com/theforeman/hammer-cli-katello

--- a/katello/rubygem-robotex/rubygem-robotex.spec
+++ b/katello/rubygem-robotex/rubygem-robotex.spec
@@ -8,7 +8,7 @@
 Summary:    Ruby library to obey robots.txt
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    1.0.0
-Release:    19%{?dist}
+Release:    20%{?dist}
 License:    MIT
 Group:      Development/Languages
 URL:        https://www.github.com/chriskite/robotex

--- a/katello/rubygem-runcible/rubygem-runcible.spec
+++ b/katello/rubygem-runcible/rubygem-runcible.spec
@@ -5,7 +5,7 @@
 
 Name:           %{?scl_prefix}rubygem-%{gem_name}
 Version:        2.6.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A gem exposing Pulp's juiciest parts
 Group:          Applications/System
 License:        MIT


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.16
* [ ] 1.15
* [ ] 1.14

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
