### PR TITLE
Update apipie-bindings to 0.2.2

### DIFF
--- a/dependencies/jessie/apipie-bindings/changelog
+++ b/dependencies/jessie/apipie-bindings/changelog
@@ -1,3 +1,9 @@
+ruby-apipie-bindings (0.2.2-1) stable; urgency=low
+
+  * 0.2.2 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Tue, 09 Jan 2018 19:42:40 +0100
+
 ruby-apipie-bindings (0.2.0-1) stable; urgency=low
 
   * 0.2.0 released

--- a/dependencies/stretch/apipie-bindings/changelog
+++ b/dependencies/stretch/apipie-bindings/changelog
@@ -1,3 +1,9 @@
+ruby-apipie-bindings (0.2.2-1) stable; urgency=low
+
+  * 0.2.2 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Tue, 09 Jan 2018 19:42:40 +0100
+
 ruby-apipie-bindings (0.2.0-1) stable; urgency=low
 
   * 0.2.0 released

--- a/dependencies/xenial/apipie-bindings/changelog
+++ b/dependencies/xenial/apipie-bindings/changelog
@@ -1,3 +1,9 @@
+ruby-apipie-bindings (0.2.2-1) stable; urgency=low
+
+  * 0.2.2 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Tue, 09 Jan 2018 19:42:40 +0100
+
 ruby-apipie-bindings (0.2.0-1) stable; urgency=low
 
   * 0.2.0 released


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
