### PR TITLE
Bump Foreman to 1.18

### DIFF
--- a/foreman-installer/foreman-installer.spec
+++ b/foreman-installer/foreman-installer.spec
@@ -5,7 +5,7 @@
 
 Name:       foreman-installer
 Epoch:      1
-Version: 1.17.0
+Version:    1.18.0
 Release:    0.develop%{?dotalphatag}%{?dist}
 Summary:    Puppet-based installer for The Foreman
 Group:      Applications/System

--- a/foreman-proxy/foreman-proxy.spec
+++ b/foreman-proxy/foreman-proxy.spec
@@ -10,7 +10,7 @@
 #global dashalphatag -%{alphatag}
 
 Name:           foreman-proxy
-Version: 1.17.0
+Version:        1.18.0
 Release:        0.develop%{?dotalphatag}%{?dist}
 Summary:        Restful Proxy for DNS, DHCP, TFTP, PuppetCA and Puppet
 

--- a/foreman-selinux/foreman-selinux.spec
+++ b/foreman-selinux/foreman-selinux.spec
@@ -36,7 +36,7 @@
 #global dashalphatag -%{alphatag}
 
 Name:           foreman-selinux
-Version: 1.17.0
+Version:        1.18.0
 Release:        0.develop%{?dotalphatag}%{?dist}
 Summary:        SELinux policy module for Foreman
 

--- a/foreman/foreman.spec
+++ b/foreman/foreman.spec
@@ -13,7 +13,7 @@
 #global dashalphatag -%{alphatag}
 
 Name:   foreman
-Version: 1.17.0
+Version: 1.18.0
 Release: 0.develop%{?dotalphatag}%{?dist}
 Summary:Systems Management web application
 

--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -12,19 +12,19 @@ builder.jenkins_url = http://ci.theforeman.org
 [koji-foreman-plugins]
 releaser = tito.release.KojiReleaser
 autobuild_tags = foreman-plugins-nightly-nonscl-rhel7 foreman-plugins-nightly-rhel7
-builder.rpmbuild_options = --define "foremandist .fm1_17"
+builder.rpmbuild_options = --define "foremandist .fm1_18"
 
 [koji-foreman-plugins-nightly]
 releaser = tito.release.KojiReleaser
 autobuild_tags = foreman-plugins-nightly-nonscl-rhel7 foreman-plugins-nightly-rhel7
 builder = tito.builder.FetchBuilder
-builder.rpmbuild_options = --define "foremandist .fm1_17"
+builder.rpmbuild_options = --define "foremandist .fm1_18"
 
 # Katello Releasers
 [koji-katello]
 releaser = tito.release.KojiReleaser
 autobuild_tags = katello-nightly-rhel7
-builder.rpmbuild_options = --define "foremandist .fm1_17"
+builder.rpmbuild_options = --define "foremandist .fm1_18"
 
 [koji-katello-client]
 releaser = tito.release.KojiReleaser

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -9,7 +9,7 @@ tito=0.6.1
 builder = tito.builder.GitAnnexBuilder
 tagger = tito.tagger.ReleaseTagger
 lib_dir = rel-eng/custom/
-tag_suffix = .fm1_17
+tag_suffix = .fm1_18
 
 [builder]
 fetch_strategy = custom.ForemanSourceStrategy


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.16
* [ ] 1.15
* [ ] 1.14

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
