### PR TITLE
Move dalli to plugins comps

### DIFF
--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -53,6 +53,7 @@
       <packagereq type="default">tfm-rubygem-bastion-devel</packagereq>
       <packagereq type="default">tfm-rubygem-bootstrap-datepicker-rails</packagereq>
       <packagereq type="default">tfm-rubygem-commonjs</packagereq>
+      <packagereq type="default">tfm-rubygem-dalli</packagereq>
       <packagereq type="default">tfm-rubygem-deface</packagereq>
       <packagereq type="default">tfm-rubygem-diffy</packagereq>
       <packagereq type="default">tfm-rubygem-docker-api</packagereq>
@@ -171,6 +172,7 @@
       <packagereq type="default">tfm-rubygem-bastion-doc</packagereq>
       <packagereq type="default">tfm-rubygem-bootstrap-datepicker-rails-doc</packagereq>
       <packagereq type="default">tfm-rubygem-commonjs-doc</packagereq>
+      <packagereq type="default">tfm-rubygem-dalli-doc</packagereq>
       <packagereq type="default">tfm-rubygem-deface-doc</packagereq>
       <packagereq type="default">tfm-rubygem-diffy-doc</packagereq>
       <packagereq type="default">tfm-rubygem-docker-api-doc</packagereq>

--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -35,7 +35,6 @@
       <packagereq type="default">foreman-vmware</packagereq>
       <packagereq type="default">http-parser</packagereq>
       <packagereq type="default">http-parser-devel</packagereq>
-      <packagereq type="default">rubygem-dalli</packagereq>
       <packagereq type="default">rubygem-foreman_maintain</packagereq>
       <packagereq type="default">tfm</packagereq>
       <packagereq type="default">tfm-build</packagereq>
@@ -293,7 +292,6 @@
       <packagereq type="default">rubygem-bundler_ext-doc</packagereq>
       <packagereq type="default">rubygem-clamp-doc</packagereq>
       <packagereq type="default">rubygem-concurrent-ruby-doc</packagereq>
-      <packagereq type="default">rubygem-dalli-doc</packagereq>
       <packagereq type="default">rubygem-foreman_api-doc</packagereq>
       <packagereq type="default">rubygem-foreman_maintain-doc</packagereq>
       <packagereq type="default">rubygem-hashie-doc</packagereq>

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -140,7 +140,6 @@ whitelist = foreman
   rubygem-concurrent-ruby-edge
   rubygem-css_parser
   rubygem-daemons
-  rubygem-dalli
   rubygem-deacon
   rubygem-deep_cloneable
   rubygem-domain_name
@@ -256,6 +255,7 @@ whitelist = rubygem-angular-rails-templates
   rubygem-bootstrap-datepicker-rails
   rubygem-commonjs
   rubygem-concurrent-ruby
+  rubygem-dalli
   rubygem-deface
   rubygem-diffy
   rubygem-docker-api


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.16
* [ ] 1.15
* [ ] 1.14

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
