### PR TITLE
Add rubygems-jquery-matchheight-rails package [rpm]

### DIFF
--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -112,6 +112,7 @@
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_ssh</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_tasks</packagereq>
       <packagereq type="default">tfm-rubygem-jgrep</packagereq>
+      <packagereq type="default">tfm-rubygem-jquery-matchheight-rails</packagereq>
       <packagereq type="default">tfm-rubygem-net-ssh-gateway</packagereq>
       <packagereq type="default">tfm-rubygem-net-ssh-krb</packagereq>
       <packagereq type="default">tfm-rubygem-net-ssh-multi</packagereq>
@@ -229,6 +230,7 @@
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_ssh-doc</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_tasks-doc</packagereq>
       <packagereq type="default">tfm-rubygem-jgrep-doc</packagereq>
+      <packagereq type="default">tfm-rubygem-jquery-matchheight-rails-doc</packagereq>
       <packagereq type="default">tfm-rubygem-net-ssh-gateway-doc</packagereq>
       <packagereq type="default">tfm-rubygem-net-ssh-krb-doc</packagereq>
       <packagereq type="default">tfm-rubygem-net-ssh-multi-doc</packagereq>

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -264,6 +264,7 @@ whitelist = rubygem-angular-rails-templates
   rubygem-fog-azure
   rubygem-git
   rubygem-jgrep
+  rubygem-jquery-matchheight-rails
   rubygem-opennebula
   rubygem-systemu
   rubygem-foreman_abrt

--- a/rubygem-jquery-matchheight-rails/jquery-matchheight-rails-0.7.1.gem
+++ b/rubygem-jquery-matchheight-rails/jquery-matchheight-rails-0.7.1.gem
@@ -1,0 +1,1 @@
+../.git/annex/objects/13/3X/SHA256E-s9216--c0dad204a5c681edf5bf225ac1b02a9279787512a7bca4bb7db91fe8302fb121.1.gem/SHA256E-s9216--c0dad204a5c681edf5bf225ac1b02a9279787512a7bca4bb7db91fe8302fb121.1.gem

--- a/rubygem-jquery-matchheight-rails/rubygem-jquery-matchheight-rails.spec
+++ b/rubygem-jquery-matchheight-rails/rubygem-jquery-matchheight-rails.spec
@@ -1,0 +1,80 @@
+%{?scl:%scl_package rubygem-%{gem_name}}
+%{!?scl:%global pkg_name %{name}}
+
+%global gem_name jquery-matchheight-rails
+
+Name: %{?scl_prefix}rubygem-%{gem_name}
+Version: 0.7.1
+Release: 1%{?dist}
+Summary: jquery.matchHeight.js for the Rails Asset Pipeline
+Group: Development/Languages
+License: MIT
+URL: https://github.com/dassump/jquery-matchheight-rails
+Source0: http://rubygems.org/gems/%{gem_name}-%{version}.gem
+Requires: %{?scl_prefix_ruby}ruby(release)
+Requires: %{?scl_prefix_ruby}ruby
+Requires: %{?scl_prefix_ruby}ruby(rubygems)
+BuildRequires: %{?scl_prefix_ruby}ruby(release)
+BuildRequires: %{?scl_prefix_ruby}ruby
+BuildRequires: %{?scl_prefix_ruby}rubygems-devel
+BuildArch: noarch
+Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
+
+%description
+matchHeight makes the height of all selected elements exactly equal.
+
+
+%package doc
+Summary: Documentation for %{pkg_name}
+Group: Documentation
+Requires: %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+BuildArch: noarch
+
+%description doc
+Documentation for %{pkg_name}.
+
+%prep
+%{?scl:scl enable %{scl} - << \EOF}
+gem unpack %{SOURCE0}
+%{?scl:EOF}
+
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+%{?scl:scl enable %{scl} - << \EOF}
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
+%{?scl:EOF}
+
+%build
+# Create the gem as gem install only works on a gem file
+%{?scl:scl enable %{scl} - << \EOF}
+gem build %{gem_name}.gemspec
+%{?scl:EOF}
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%{?scl:scl enable %{scl} - << \EOF}
+%gem_install
+%{?scl:EOF}
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -pa .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+%files
+%dir %{gem_instdir}
+%exclude %{gem_instdir}/.gitignore
+%license %{gem_instdir}/LICENSE
+%exclude %{gem_instdir}/jquery-matchheight-rails.gemspec
+%{gem_libdir}
+%{gem_instdir}/vendor
+%exclude %{gem_cache}
+%{gem_spec}
+
+%files doc
+%doc %{gem_docdir}
+%{gem_instdir}/Gemfile
+%doc %{gem_instdir}/README.md
+%{gem_instdir}/Rakefile
+
+%changelog


### PR DESCRIPTION
Please build for:

* [x] Nightly
* [x] 1.17
* [ ] 1.16
* [ ] 1.15

This is a dependency for foreman_omaha 1.0.0, updating the package in a separate PR.