### PR TITLE
Add Fedora 27 comp for Katello rel-eng

### DIFF
--- a/comps/comps-katello-client-fedora27.xml
+++ b/comps/comps-katello-client-fedora27.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!DOCTYPE comps PUBLIC "-//Red Hat, Inc.//DTD Comps info//EN" "comps.dtd">
+
+<comps>
+<!--  <meta> -->
+<!-- Meta information will go here eventually -->
+<!--  </meta> -->
+  <group>
+    <id>katello-client</id>
+    <name>Katello Client</name>
+    <description>Katello Client Packages</description>
+    <uservisible>true</uservisible>
+    <packagelist>
+       <packagereq type="default">katello-agent</packagereq>
+       <packagereq type="default">katello-host-tools</packagereq>
+       <packagereq type="default">katello-host-tools-fact-plugin</packagereq>
+       <packagereq type="default">katello-host-tools-tracer</packagereq>
+       <packagereq type="default">katello-client-repos</packagereq>
+    </packagelist>
+  </group>
+</comps>


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
