### PR TITLE
relax smart_proxy_remote_execution_ssh dependency

### DIFF
--- a/plugins/smart_proxy_remote_execution_ssh/changelog
+++ b/plugins/smart_proxy_remote_execution_ssh/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-remote-execution-ssh (0.1.6-2) stable; urgency=low
+
+  * relax dependency on ruby-foreman-remote-execution-core
+
+ -- Michael Moll <mmoll@mmoll.at>  Mon, 22 Jan 2018 23:21:32 +0100
+
 ruby-smart-proxy-remote-execution-ssh (0.1.6-1) stable; urgency=low
 
   * 0.1.6 released

--- a/plugins/smart_proxy_remote_execution_ssh/control
+++ b/plugins/smart_proxy_remote_execution_ssh/control
@@ -12,7 +12,6 @@ Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.11.0~rc3),
   ruby-foreman-remote-execution-core (>= 1.0.0),
-  ruby-foreman-remote-execution-core (<< 1.1.0),
   ruby-smart-proxy-dynflow (>= 0.1.0), ruby-smart-proxy-dynflow (<< 0.2.0)
 Description: SSH remote execution provider for Foreman smart proxy
  SSH remote execution provider for Foreman smart proxy - the API part


### PR DESCRIPTION
this should be built into:

* [x] Nightly
* [x] 1.17