### PR TITLE
symlink local_secret_token.rb to /etc/foreman

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -1151,6 +1151,7 @@ rm -rf %{buildroot}
 %{_mandir}/man8
 %config(noreplace) %{_sysconfdir}/%{name}
 %ghost %attr(0640,root,%{name}) %config(noreplace) %{_sysconfdir}/%{name}/encryption_key.rb
+%ghost %attr(0640,root,%{name}) %config(noreplace) %{_sysconfdir}/%{name}/local_secret_token.rb
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 %config %{_sysconfdir}/cron.d/%{name}
@@ -1162,7 +1163,7 @@ rm -rf %{buildroot}
 %attr(-,%{name},root) %{_datadir}/%{name}/config.ru
 %attr(-,%{name},root) %{_datadir}/%{name}/config/environment.rb
 %ghost %{_datadir}/%{name}/config/initializers/encryption_key.rb
-%ghost %attr(0640,root,%{name}) %config(noreplace) %{_datadir}/%{name}/config/initializers/local_secret_token.rb
+%ghost %{_datadir}/%{name}/config/initializers/local_secret_token.rb
 %{_tmpfilesdir}/%{name}.conf
 
 # Service
@@ -1179,12 +1180,20 @@ exit 0
 
 %post
 # secret token used for cookie signing etc.
-if [ ! -f %{_datadir}/%{name}/config/initializers/local_secret_token.rb ]; then
+if [ ! -e %{_datadir}/%{name}/config/initializers/local_secret_token.rb ] ; then
   touch %{_datadir}/%{name}/config/initializers/local_secret_token.rb
   chmod 0660 %{_datadir}/%{name}/config/initializers/local_secret_token.rb
   chgrp foreman %{_datadir}/%{name}/config/initializers/local_secret_token.rb
   %{foreman_rake} security:generate_token >/dev/null 2>&1 || :
   chmod 0640 %{_datadir}/%{name}/config/initializers/local_secret_token.rb
+fi
+if [ -f %{_datadir}/%{name}/config/initializers/local_secret_token.rb ] && \
+   [ ! -L %{_datadir}/%{name}/config/initializers/local_secret_token.rb ] ; then
+  mv %{_datadir}/%{name}/config/initializers/local_secret_token.rb %{_sysconfdir}/%{name}/
+fi
+if [ ! -e %{_datadir}/%{name}/config/initializers/local_secret_token.rb -a \
+    -e %{_sysconfdir}/%{name}/local_secret_token.rb ]; then
+  ln -s %{_sysconfdir}/%{name}/local_secret_token.rb %{_datadir}/%{name}/config/initializers/
 fi
 
 # encryption key used to encrypt DB contents


### PR DESCRIPTION
Currently we have:

```
[root@centos7-foreman ~]# ls -l /etc/foreman
total 20
-rw-r-----. 1 root foreman  684 Jan 16 16:27 database.yml
-rw-r-----. 1 root foreman  450 Jan 15 22:22 encryption_key.rb
-rw-r--r--. 1 root root     691 Nov 29 07:12 foreman-debug.conf
-rw-r--r--. 1 root root    2564 Nov 29 07:12 logging.yaml
drwxr-xr-x. 2 root root      72 Jan 16 16:28 plugins
-rw-r-----. 1 root foreman 1215 Jan 17 13:04 settings.yaml
```

It'd would be nice to also have `local_secret_token.rb`