### PR TITLE
Fix katello releasers

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -28,11 +28,11 @@ builder.rpmbuild_options = --define "foremandist .fm1_17"
 
 [koji-katello-client]
 releaser = tito.release.KojiReleaser
-autobuild_tags = katello-3.6-rhel5 katello-3.6-rhel6 katello-3.6-rhel7 katello-3.6-fedora25 katello-3.6-fedora26 katello-3.6-thirdparty-rhel7
+autobuild_tags = katello-3.6-rhel5 katello-3.6-rhel6 katello-3.6-rhel7 katello-3.6-fedora27 katello-3.6-fedora26 katello-3.6-thirdparty-rhel7
 
 [koji-katello-jenkins]
 releaser = tito.release.KojiReleaser
-autobuild_tags = katello-3.6-rhel5 katello-3.6-rhel6 katello-3.6-rhel7 katello-3.6-fedora25 katello-3.6-fedora26 katello-3.6-thirdparty-rhel7
+autobuild_tags = katello-3.6-rhel5 katello-3.6-rhel6 katello-3.6-rhel7 katello-3.6-fedora27 katello-3.6-fedora26 katello-3.6-thirdparty-rhel7
 builder = tito.builder.FetchBuilder
 builder.jenkins_url = http://ci.theforeman.org
 

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -372,15 +372,15 @@ whitelist = puppet-foreman_scap_client
   rubygem-smart_proxy_remote_execution_ssh
   rubygem-smart_proxy_salt
 
-[katello-1.17-rhel5]
+[katello-3.6-rhel5]
 disttag = .el5
 whitelist = katello-repos katello-host-tools
 
-[katello-1.17-rhel6]
+[katello-3.6-rhel6]
 disttag = .el6
 whitelist = katello-repos katello-host-tools
 
-[katello-1.17-rhel7]
+[katello-3.6-rhel7]
 disttag = .el7
 scl = tfm
 whitelist = rubygem-robotex
@@ -406,17 +406,17 @@ whitelist = rubygem-robotex
   rubygem-terminal-table
 
 
-[katello-thirdparty-rhel7]
+[katello-3.6-thirdparty-rhel7]
 disttag = .el7
 scl = tfm
 whitelist = rubygem-jenkins_api_client
   rubygem-mixlib-shellout
   rubygem-terminal-table
 
-[katello-1.17-fedora26]
+[katello-3.6-fedora26]
 disttag = .fc26
 whitelist = katello-repos katello-host-tools
 
-[katello-1.17-fedora25]
-disttag = .fc25
+[katello-3.6-fedora27]
+disttag = .fc27
 whitelist = katello-repos katello-host-tools


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
