### PR TITLE
Fixes #22340 - remove --program/--scenario from k-c-hostname

### DIFF
--- a/katello/katello/hostname-change.rb
+++ b/katello/katello/hostname-change.rb
@@ -199,14 +199,6 @@ module KatelloUtilities
           @options[:password] = password
         end
 
-        opt.on("-g","--program program","name of the program you are modifying (defaults to #{@default_program})") do |program|
-          @options[:program] = program
-        end
-
-        opt.on("-s","--scenario scenario","name of the scenario you are modifying (defaults to #{@last_scenario})") do |scenario|
-          @options[:scenario] = scenario
-        end
-
         opt.on("-y", "--assumeyes", "answer yes for all questions") do |confirm|
           @options[:confirm] = confirm
         end


### PR DESCRIPTION
This isn't a necessary option to expose to the user and is only
used for branding/naming conventions when backporting.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
