### PR TITLE
Update foreman-release repos to simplify releases

### DIFF
--- a/packages/foreman/foreman/foreman.repo
+++ b/packages/foreman/foreman/foreman.repo
@@ -1,13 +1,13 @@
 [foreman]
 name=Foreman nightly
-baseurl=http://yum.theforeman.org/nightly/$DIST/$basearch
+baseurl=http://yum.theforeman.org/releases/nightly/$DIST/$basearch
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 
 [foreman-source]
 name=Foreman nightly - source
-baseurl=http://yum.theforeman.org/nightly/$DIST/source
+baseurl=http://yum.theforeman.org/releases/nightly/$DIST/source
 enabled=0
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman

--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -943,6 +943,10 @@ install -Dp -m0644 %{SOURCE5} %{buildroot}%{_tmpfilesdir}/%{name}.conf
 install -Dpm0644 %{SOURCE6} %{buildroot}%{_sysconfdir}/yum.repos.d/%{name}.repo
 install -Dpm0644 %{SOURCE7} %{buildroot}%{_sysconfdir}/yum.repos.d/%{name}-plugins.repo
 sed "s/\$DIST/$(echo %{?dist} | cut -d. -f2)/g" -i %{buildroot}%{_sysconfdir}/yum.repos.d/%{name}*.repo
+if [[ '%{release}' != *"develop"* ]];then
+	VERSION="%{version}"
+	sed "s/nightly/${VERSION%.*}/g" -i %{buildroot}%{_sysconfdir}/yum.repos.d/%{name}*.repo
+fi
 install -Dpm0644 %{SOURCE8} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman
 
 cp -p Gemfile.in %{buildroot}%{_datadir}/%{name}/Gemfile.in


### PR DESCRIPTION
This should now automatically pick up releases when we drop the develop part from versions.

Note: didn't have a chance to test this yet.