### PR TITLE
Fix plugin repo names

### DIFF
--- a/foreman/foreman-plugins.repo
+++ b/foreman/foreman-plugins.repo
@@ -1,12 +1,12 @@
 [foreman-plugins]
-name=Foreman plugins nightly
+name=Foreman plugins 1.17
 baseurl=http://yum.theforeman.org/plugins/1.17/$DIST/$basearch
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 
 [foreman-plugins-source]
-name=Foreman plugins nightly - source
+name=Foreman plugins 1.17 - source
 baseurl=http://yum.theforeman.org/plugins/1.17/$DIST/source
 enabled=0
 gpgcheck=0


### PR DESCRIPTION
This doesn't require an update for the 1.17.0 RC1 since it's just names and the next RC will include it.