### PR TITLE
replace net-tools with ss

### DIFF
--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -6,7 +6,7 @@
 
 Name:       katello
 Version:    3.7.0
-Release:    1.nightly%{?dist}
+Release:    2.nightly%{?dist}
 Summary:    A package for managing application life-cycle for Linux systems
 BuildArch:  noarch
 
@@ -196,10 +196,9 @@ Summary: Katello Service utilities
 Group: Applications/System
 
 # service-wait dependency
-Requires:       wget
 Requires:       curl
 Requires:       ruby
-Requires:       net-tools
+Requires:       /usr/sbin/ss
 Requires:       /bin/systemctl
 
 %description service

--- a/packages/katello/katello/service-wait
+++ b/packages/katello/katello/service-wait
@@ -76,7 +76,7 @@ after_start() {
       # RHBZ 800534 for RHEL 6.x - pg sysvinit script return non-zero when PID is not created in 2 seconds
       RETVAL=0
       # and wait until port is really avaiable
-      for i in {1..$WAIT_MAX}; do netstat -ln | grep -q ":$POSTGRES_PORT\s" && break; sleep 1; done
+      for i in {1..$WAIT_MAX}; do ss -ln | grep -q ":$POSTGRES_PORT\s" && break; sleep 1; done
       # and create lock and pid files if they does not exist
       [ -f "/var/lock/subsys/postgresql" ] || touch "/var/lock/subsys/postgresql"
       [ -f "/var/run/postmaster.${POSTGRES_PORT}.pid" ] || head -n 1 "$POSTGRES_DATA/postmaster.pid" > "/var/run/postmaster.${POSTGRES_PORT}.pid"
@@ -92,7 +92,7 @@ before_stop() {
   case "$SERVICE" in
     tomcat6|tomcat)
       # RHBZ 789288 - wait until service port is available
-      for i in {1..$WAIT_MAX}; do netstat -ln | grep -q ":$TOMCAT_SERV_PORT\s" && break; sleep 1; done
+      for i in {1..$WAIT_MAX}; do ss -ln | grep -q ":$TOMCAT_SERV_PORT\s" && break; sleep 1; done
       ;;
   esac
 }


### PR DESCRIPTION
net-tools has been deprecated for a long time now, lets use the new tooling.

wget also doesn't appear to be used by katello-service so I've removed that.

---

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly


See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.


