### PR TITLE
Don't rely on 'tito tag' anymore

### DIFF
--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -6,7 +6,7 @@
 tito=0.6.1
 
 [buildconfig]
-builder = tito.builder.GitAnnexBuilder
+builder = obal.tito_extensions.git_annex_spec_builder.GitAnnexSpecBuilder
 tagger = tito.tagger.ReleaseTagger
 lib_dir = rel-eng/custom/
 tag_suffix = .fm1_18


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
