### PR TITLE
Package katello repo types as seperate rpms

### DIFF
--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -16,6 +16,10 @@
        <packagereq type="default">foreman-proxy-content</packagereq>
        <packagereq type="default">tfm-rubygem-katello</packagereq>
        <packagereq type="default">tfm-rubygem-katello_ostree</packagereq>
+       <packagereq type="default">tfm-rubygem-katello_yum</packagereq>
+       <packagereq type="default">tfm-rubygem-katello_puppet</packagereq>
+       <packagereq type="default">tfm-rubygem-katello_docker</packagereq>
+       <packagereq type="default">tfm-rubygem-katello_deb</packagereq>
        <packagereq type="default">katello-certs-tools</packagereq>
        <packagereq type="default">katello-common</packagereq>
        <packagereq type="default">katello-debug</packagereq>

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -7,6 +7,10 @@
 %global release 1.nightly
 
 %define katello_ostree %{?scl_prefix}rubygem-%{gem_name}_ostree
+%define katello_yum %{?scl_prefix}rubygem-%{gem_name}_yum
+%define katello_puppet %{?scl_prefix}rubygem-%{gem_name}_puppet
+%define katello_docker %{?scl_prefix}rubygem-%{gem_name}_docker
+%define katello_deb %{?scl_prefix}rubygem-%{gem_name}_deb
 
 Name:    %{?scl_prefix}rubygem-%{gem_name}
 Summary: Katello
@@ -85,6 +89,34 @@ Summary:    Katello Ostree Plugin
 %description -n %{katello_ostree}
 This package provides the ostree plugin for rubygem-%{gem_name}.
 
+%package -n %{katello_yum}
+Requires:   %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+Summary:    Katello Yum Plugin
+
+%description -n %{katello_yum}
+This package provides the Yum plugin for rubygem-%{gem_name}.
+
+%package -n %{katello_puppet}
+Requires:   %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+Summary:    Katello Puppet Plugin
+
+%description -n %{katello_puppet}
+This package provides the puppet plugin for rubygem-%{gem_name}.
+
+%package -n %{katello_docker}
+Requires:   %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+Summary:    Katello Docker Plugin
+
+%description -n %{katello_docker}
+This package provides the Docker plugin for rubygem-%{gem_name}.
+
+%package -n %{katello_deb}
+Requires:   %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+Summary:    Katello Debian Plugin
+
+%description -n %{katello_deb}
+This package provides the Debian plugin for rubygem-%{gem_name}.
+
 %prep
 %setup -n %{pkg_name}-%{version} -q -c -T
 %{?scl:scl enable %{scl} - <<EOF}
@@ -120,6 +152,11 @@ cp -a .%{gem_dir}/* \
 
 %exclude %{gem_cache}
 %exclude %{gem_instdir}/lib/katello/repository_types/ostree.rb
+%exclude %{gem_instdir}/lib/katello/repository_types/yum.rb
+%exclude %{gem_instdir}/lib/katello/repository_types/file.rb
+%exclude %{gem_instdir}/lib/katello/repository_types/puppet.rb
+%exclude %{gem_instdir}/lib/katello/repository_types/docker.rb
+%exclude %{gem_instdir}/lib/katello/repository_types/deb.rb
 
 %license %{gem_instdir}/LICENSE.txt
 
@@ -129,5 +166,18 @@ cp -a .%{gem_dir}/* \
 
 %files -n %{katello_ostree}
 %{gem_instdir}/lib/katello/repository_types/ostree.rb
+
+%files -n %{katello_yum}
+%{gem_instdir}/lib/katello/repository_types/yum.rb
+%{gem_instdir}/lib/katello/repository_types/file.rb
+
+%files -n %{katello_puppet}
+%{gem_instdir}/lib/katello/repository_types/puppet.rb
+
+%files -n %{katello_docker}
+%{gem_instdir}/lib/katello/repository_types/docker.rb
+
+%files -n %{katello_deb}
+%{gem_instdir}/lib/katello/repository_types/deb.rb
 
 %changelog


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
