### PR TITLE
Fix katello-repos building on EL5

### DIFF
--- a/katello/katello-repos/katello-repos.spec
+++ b/katello/katello-repos/katello-repos.spec
@@ -1,6 +1,6 @@
 Name:           katello-repos
 Version:        3.6.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Definition of yum repositories for Katello
 
 Group:          Applications/Internet
@@ -55,7 +55,12 @@ install -m 644 %{SOURCE3} %{buildroot}%{_sysconfdir}/yum.repos.d/
 
 install -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-katello
 
-REPO_VERSION=$(python -c "print 'nightly' if 'nightly' in '%{release}' else '.'.join('%{version}'.split('.', 2)[:2])")
+if [[ '%{release}' == *"nightly"* ]];then
+REPO_VERSION='nightly'
+else
+REPO_VERSION=$(python -c "'.'.join('%{version}'.split('.', 2)[:2])")
+fi
+
 REPO_NAME=$(python -c  "print '${REPO_VERSION}'.title()")
 
 for repofile in %{buildroot}%{_sysconfdir}/yum.repos.d/*.repo; do


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
