### PR TITLE
Fix plugin repoclosure

### DIFF
--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -350,10 +350,12 @@ whitelist = rubygem-angular-rails-templates
 disttag = .el7
 whitelist = puppet-foreman_scap_client
   rubygem-chef-api
+  rubygem-faraday
   rubygem-faraday_middleware
   rubygem-foreman_scap_client
   rubygem-infoblox
   rubygem-logify
+  rubygem-mysql2
   rubygem-newt
   rubygem-openscap
   rubygem-radcli


### PR DESCRIPTION
e6d1a925989d417b7b08019d3a05ab128b10516e removed these from the plugins repositories but they are in fact needed for repoclosure.