### PR TITLE
Do not ship ostree repo type as rpm

### DIFF
--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -15,7 +15,6 @@
        <packagereq type="default">katello</packagereq>
        <packagereq type="default">foreman-proxy-content</packagereq>
        <packagereq type="default">tfm-rubygem-katello</packagereq>
-       <packagereq type="default">tfm-rubygem-katello_ostree</packagereq>
        <packagereq type="default">katello-certs-tools</packagereq>
        <packagereq type="default">katello-common</packagereq>
        <packagereq type="default">katello-debug</packagereq>

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -6,8 +6,6 @@
 %global mainver 3.7.0
 %global release 1.nightly
 
-%define katello_ostree %{?scl_prefix}rubygem-%{gem_name}_ostree
-
 Name:    %{?scl_prefix}rubygem-%{gem_name}
 Summary: Katello
 
@@ -62,6 +60,8 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildRequires: %{?scl_prefix_ruby}ruby(rubygems)
 BuildRequires: %{?scl_prefix_ruby}ruby(release)
 
+Obsoletes: %{?scl_prefix}rubygem-%{gem_name}_ostree
+
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(katello) = %{version}
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
@@ -77,13 +77,6 @@ Summary:    Documentation for rubygem-%{gem_name}
 
 %description doc
 This package contains documentation for rubygem-%{gem_name}.
-
-%package -n %{katello_ostree}
-Requires:   %{?scl_prefix}%{pkg_name} = %{version}-%{release}
-Summary:    Katello Ostree Plugin
-
-%description -n %{katello_ostree}
-This package provides the ostree plugin for rubygem-%{gem_name}.
 
 %prep
 %setup -n %{pkg_name}-%{version} -q -c -T
@@ -119,15 +112,11 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/public/assets/bastion_katello
 
 %exclude %{gem_cache}
-%exclude %{gem_instdir}/lib/katello/repository_types/ostree.rb
 
 %license %{gem_instdir}/LICENSE.txt
 
 %files doc
 %doc %{gem_docdir}
 %doc %{gem_instdir}/README.md
-
-%files -n %{katello_ostree}
-%{gem_instdir}/lib/katello/repository_types/ostree.rb
 
 %changelog


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

Corresponds to https://github.com/theforeman/puppet-katello/pull/237
