### PR TITLE
Bump smart-proxy-ansible to 2.0.2

### DIFF
--- a/plugins/smart_proxy_ansible/ansible.rb
+++ b/plugins/smart_proxy_ansible/ansible.rb
@@ -1,2 +1,2 @@
-gem 'smart_proxy_ansible', '2.0.1'
+gem 'smart_proxy_ansible', '2.0.2'
 gem 'foreman_ansible_core', '>= 2.0.2', '< 3.0.0'

--- a/plugins/smart_proxy_ansible/changelog
+++ b/plugins/smart_proxy_ansible/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-ansible (2.0.2-1) stable; urgency=low
+
+  * 2.0.2 released
+
+ -- Daniel Lobato Garcia <me@daniellobato.me>  Thu, 01 Mar 2018 10:05:54 +0100
+
 ruby-smart-proxy-ansible (2.0.1-1) stable; urgency=low
 
   * 2.0.1 released


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.17
* [x] 1.16
* [ ] 1.15
---

This shouldn't change anything for 1.17 and nightly users, the most important change of 2.0.2 has to do with RPMs. However for 1.16 the ansible.cfg roles_path could only be read in the previous version when it had just 1 path ('/etc/ansible/roles') now it supports multiple paths ('/etc/ansible/roles:~/.ansible/roles')