### PR TITLE
Fix rubygem-smart_proxy_dynflow_core dependencies

### DIFF
--- a/rubygem-smart_proxy_dynflow_core/rubygem-smart_proxy_dynflow_core.spec
+++ b/rubygem-smart_proxy_dynflow_core/rubygem-smart_proxy_dynflow_core.spec
@@ -15,22 +15,21 @@
 Summary: Core Smart Proxy Dynflow Service
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.1.10
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Group: Development/Libraries
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_dynflow
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 Source1: logrotate.conf
-Requires: foreman-proxy >= 1.11.0
+Requires: foreman-proxy >= 1.12.0
 
 Requires: %{?scl_prefix}rubygem(bundler_ext)
-Requires: %{?scl_prefix}rubygem(dynflow) >= 0.8.4
+Requires: %{?scl_prefix}rubygem(dynflow) >= 0.8.29
 Requires: %{?scl_prefix}rubygem(dynflow) < 0.9.0
-Requires: %{?scl_prefix}rubygem(foreman-tasks-core) >= 0.1
+Requires: %{?scl_prefix}rubygem(foreman-tasks-core) >= 0.1.7
 Requires: %{?scl_prefix}rubygem(sequel)
 Requires: %{?scl_prefix}rubygem(rest-client)
-Requires: %{?scl_prefix_ror}rubygem(sinatra) >= 1.4
-Requires: %{?scl_prefix_ror}rubygem(sinatra) < 2.0
+Requires: %{?scl_prefix_ror}rubygem(sinatra)
 Requires: %{?scl_prefix_ror}rubygem(rack)
 Requires: %{?scl_prefix_ror}rubygem(sqlite3)
 Requires: %{?scl_prefix_ruby}ruby(release)


### PR DESCRIPTION
These were missed while cherry picking to the 1.17 branch.