### PR TITLE
[DEB] Update hammer_cli_foreman to 0.12.1

### DIFF
--- a/dependencies/stretch/hammer_cli_foreman/changelog
+++ b/dependencies/stretch/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.12.1-1) stable; urgency=low
+
+  * 0.12.1 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Mon, 05 Mar 2018 23:30:23 +0100
+
 ruby-hammer-cli-foreman (0.12.0-1) stable; urgency=low
 
   * 0.12.0 released

--- a/dependencies/xenial/hammer_cli_foreman/changelog
+++ b/dependencies/xenial/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.12.1-1) stable; urgency=low
+
+  * 0.12.1 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Mon, 05 Mar 2018 23:30:23 +0100
+
 ruby-hammer-cli-foreman (0.12.0-1) stable; urgency=low
 
   * 0.12.0 released


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
Fixes for regressions with Foreman 1.17.