### PR TITLE
[DEB] Update ruby-dynflow to 0.8.37

### DIFF
--- a/dependencies/stretch/dynflow/changelog
+++ b/dependencies/stretch/dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-dynflow (0.8.36-1) stable; urgency=low
+
+  * 0.8.36 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Tue, 06 Mar 2018 14:23:25 +0100
+
 ruby-dynflow (0.8.32-1) stable; urgency=low
 
   * 0.8.32 released

--- a/dependencies/stretch/dynflow/changelog
+++ b/dependencies/stretch/dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-dynflow (0.8.37-1) stable; urgency=low
+
+  * 0.8.37 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Mon, 12 Mar 2018 15:29:28 +0100
+
 ruby-dynflow (0.8.36-1) stable; urgency=low
 
   * 0.8.36 released

--- a/dependencies/xenial/dynflow/changelog
+++ b/dependencies/xenial/dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-dynflow (0.8.37-1) stable; urgency=low
+
+  * 0.8.37 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Mon, 12 Mar 2018 15:29:28 +0100
+
 ruby-dynflow (0.8.36-1) stable; urgency=low
 
   * 0.8.36 released

--- a/dependencies/xenial/dynflow/changelog
+++ b/dependencies/xenial/dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-dynflow (0.8.36-1) stable; urgency=low
+
+  * 0.8.36 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Tue, 06 Mar 2018 14:23:23 +0100
+
 ruby-dynflow (0.8.32-1) stable; urgency=low
 
   * 0.8.32 released


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
