### PR TITLE
Remove foreman-installer-katello-devel sub-package

### DIFF
--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -26,7 +26,6 @@
        <packagereq type="default">pulp-katello</packagereq>
        <packagereq type="default">katello-installer-base</packagereq>
        <packagereq type="default">foreman-installer-katello</packagereq>
-       <packagereq type="default">foreman-installer-katello-devel</packagereq>
        <packagereq type="default">tfm-rubygem-foreman_virt_who_configure</packagereq>
        <packagereq type="default">tfm-rubygem-hammer_cli_katello</packagereq>
        <packagereq type="default">tfm-rubygem-hammer_cli_import</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -270,7 +270,11 @@ katello_packages:
     katello: {}
     katello-certs-tools: {}
     katello-client-bootstrap: {}
-    katello-installer: {}
+    katello-installer:
+      releasers:
+        - koji-katello-jenkins
+      build_package_tito_releaser_args:
+        - "--arg jenkins_job=katello-installer-nightly-release"
     katello-selinux: {}
     pulp-katello: {}
     rubygem-anemone: {}

--- a/packages/katello/katello-installer/katello-installer-base.spec
+++ b/packages/katello/katello-installer/katello-installer-base.spec
@@ -59,25 +59,6 @@ foreman-installer --scenario foreman-proxy-content --migrations-only > /dev/null
 %{_sbindir}/foreman-proxy-certs-generate
 %{_sbindir}/katello-certs-check
 
-%package -n foreman-installer-katello-devel
-Summary:   Installer scenario for Katello development setup from git
-Group:	   Applications/System
-Requires:  %{name} = %{version}-%{release}
-Requires:  foreman-installer-katello
-
-%description -n foreman-installer-katello-devel
-A set of tools for installation of a Katello development environment using
-Katello and Foreman from git.
-
-%posttrans -n foreman-installer-katello-devel
-foreman-installer --scenario katello-devel --migrations-only > /dev/null
-
-%files -n foreman-installer-katello-devel
-%config(noreplace) %attr(600, root, root) %{_sysconfdir}/foreman-installer/scenarios.d/katello-devel-answers.yaml
-%config(noreplace) %attr(600, root, root) %{_sysconfdir}/foreman-installer/scenarios.d/katello-devel.yaml
-%dir %{_sysconfdir}/foreman-installer/scenarios.d/katello-devel.migrations
-%{_sysconfdir}/foreman-installer/scenarios.d/katello-devel.migrations
-
 %description
 A set of tools for installation of Katello and Katello Capsule,
 including Foreman and Foreman Proxy.
@@ -91,7 +72,6 @@ sed -ri '1sX(/usr/bin/ruby|/usr/bin/env ruby)X%{scl_ruby}X' bin/*
 
 #configure the paths
 sed -ri 'sX\./configX%{_sysconfdir}/foreman-installer/scenarios.dXg' config/katello-answers.yaml config/katello.yaml bin/foreman-proxy-certs-generate
-sed -ri 'sX\./configX%{_sysconfdir}/foreman-installer/scenarios.dXg' config/katello-devel.yaml
 sed -ri 'sX\./configX%{_sysconfdir}/foreman-installer/scenarios.dXg' config/foreman-proxy-content.yaml
 
 sed -ri 'sX  INSTALLER_DIR.*$X  INSTALLER_DIR = "%{_datadir}/katello-installer-base"Xg' bin/foreman-proxy-certs-generate
@@ -109,7 +89,6 @@ install -d -m0755 %{buildroot}%{_sysconfdir}/foreman-installer/scenarios.d
 
 install -d -m0755 %{buildroot}/%{_datadir}/katello-installer-base
 install -d -m0755 %{buildroot}/%{_datadir}/foreman-installer-katello/bin
-install -d -m0755 %{buildroot}/%{_datadir}/foreman-installer-katello-devel
 
 install -d -m0755 %{buildroot}/%{_sbindir}
 
@@ -119,13 +98,10 @@ cp -dpR bin/foreman-proxy-certs-generate %{buildroot}/%{_datadir}/foreman-instal
 cp -dpR bin/katello-certs-check %{buildroot}/%{_datadir}/foreman-installer-katello/bin/katello-certs-check
 
 cp -dpR config/katello-answers.yaml %{buildroot}/%{_sysconfdir}/foreman-installer/scenarios.d
-cp -dpR config/katello-devel-answers.yaml %{buildroot}/%{_sysconfdir}/foreman-installer/scenarios.d
 cp -dpR config/foreman-proxy-content-answers.yaml %{buildroot}/%{_sysconfdir}/foreman-installer/scenarios.d
 
 cp -dpR config/katello.yaml %{buildroot}/%{_sysconfdir}/foreman-installer/scenarios.d
 cp -dpR config/katello.migrations %{buildroot}/%{_sysconfdir}/foreman-installer/scenarios.d
-cp -dpR config/katello-devel.yaml %{buildroot}/%{_sysconfdir}/foreman-installer/scenarios.d
-cp -dpR config/katello-devel.migrations %{buildroot}/%{_sysconfdir}/foreman-installer/scenarios.d
 cp -dpR config/foreman-proxy-content.yaml %{buildroot}/%{_sysconfdir}/foreman-installer/scenarios.d
 cp -dpR config/foreman-proxy-content.migrations %{buildroot}/%{_sysconfdir}/foreman-installer/scenarios.d
 

--- a/rel-eng/custom/custom.py
+++ b/rel-eng/custom/custom.py
@@ -121,6 +121,7 @@ class ForemanSourceStrategy(SourceStrategy):
         job_url_base = "%s/job/%s/%s" % (url_base, job_name, job_id)
         json_url = "%s/api/json" % job_url_base
 
+        debug(json_url)
         job_info = json.loads(urlopen(json_url).read().decode("utf-8"))
         if "number" in job_info:
             job_id = job_info["number"]


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
