### PR TITLE
Improve compare-with-tags.rb

### DIFF
--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -385,11 +385,15 @@ whitelist = puppet-foreman_scap_client
 
 [katello-nightly-rhel5]
 disttag = .el5
-whitelist = katello-repos katello-host-tools
+whitelist = katello-host-tools
+  katello-repos
+  python-rhsm
+  subscription-manager
 
 [katello-nightly-rhel6]
 disttag = .el6
-whitelist = katello-repos katello-host-tools
+whitelist = katello-host-tools
+  katello-repos
 
 [katello-nightly-rhel7]
 disttag = .el7
@@ -397,6 +401,7 @@ scl = tfm
 whitelist = katello
   katello-certs-tools
   katello-client-bootstrap
+  katello-host-tools
   katello-installer-base
   katello-repos
   katello-selinux


### PR DESCRIPTION
It now:
* Is callable from any directory
* Handles all sections with the whitelist key
* Prints single koji commands

The current output:

 # Packages not expected in katello-nightly-rhel5
 * [x] python-rhsm
 * [x] subscription-manager
```shell
koji remove-pkg katello-nightly-rhel5 python-rhsm subscription-manager
```

 # Packages not expected in katello-nightly-rhel7
 * [x] katello-host-tools
 * [x] katello-installer
 * [x] tfm-rubygem-foreman_pipeline
 * [x] tfm-rubygem-hammer_cli_import
```shell
koji remove-pkg katello-nightly-rhel7 katello-host-tools katello-installer tfm-rubygem-foreman_pipeline tfm-rubygem-hammer_cli_import
```

 # Packages not expected in katello-thirdparty-rhel7
 * [x] tfm-rubygem-anemone
 * [x] tfm-rubygem-qpid_messaging
 * [x] tfm-rubygem-robotex
```shell
koji remove-pkg katello-thirdparty-rhel7 tfm-rubygem-anemone tfm-rubygem-qpid_messaging tfm-rubygem-robotex
```