### PR TITLE
add ansiblerole-insights-client

### DIFF
--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -7,6 +7,7 @@
     <description>Plugin packages for the Foreman</description>
     <uservisible>true</uservisible>
     <packagelist>
+      <packagereq type="default">ansiblerole-insights-client</packagereq>
       <packagereq type="default">ipxe-bootimgs</packagereq>
       <packagereq type="default">nodejs-react-json-tree</packagereq>
       <packagereq type="default">puppet-foreman_scap_client</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -335,6 +335,7 @@ plugins_packages:
     releasers:
     - koji-foreman-plugins
   hosts:
+    ansiblerole-insights-client: {}
     nodejs-react-json-tree: {}
     puppet-foreman_scap_client: {}
     rubygem-angular-rails-templates: {}

--- a/packages/plugins/ansiblerole-insights-client/ansiblerole-insights-client.spec
+++ b/packages/plugins/ansiblerole-insights-client/ansiblerole-insights-client.spec
@@ -1,0 +1,42 @@
+%global repo_orgname RedHatInsights
+%global repo_name insights-client-role
+
+%global role_orgname %{repo_orgname}
+%global role_name insights-client
+
+Name: ansiblerole-insights-client
+Summary: Packaging of the insights-client Ansible role
+Version: 1.5
+Release: 1%{?dist}
+License: ASL 2.0
+
+Source0: https://github.com/%{repo_orgname}/%{repo_name}/archive/v%{version}.tar.gz#/%{role_name}-%{version}.tar.gz
+Url: https://github.com/%{repo_orgname}/%{repo_name}/
+BuildArch: noarch
+
+Requires: ansible
+
+%description
+This package installs the insights-client Ansibile role.
+
+Make sure that "/usr/share/ansible/roles" is on your Ansible role_path.
+
+%prep
+
+%setup -qc
+
+%build
+
+%install
+mkdir -p %{buildroot}%{_datadir}/ansible/roles
+cp -pR %{repo_name}-%{version} %{buildroot}%{_datadir}/ansible/roles/%{role_orgname}.%{role_name}
+
+%files
+%{_datadir}/ansible/roles/%{role_orgname}.%{role_name}
+%doc %{repo_name}-%{version}/examples/*.yml
+%doc %{repo_name}-%{version}/README.md
+%license %{repo_name}-%{version}/LICENSE
+
+%changelog
+* Thu Mar 15 2018 Gavin Romig-Koch <gavin@redhat.com> - 1.5-1
+- Initial release.  Based largely on the pattern of rhel-system-roles.spec

--- a/packages/plugins/ansiblerole-insights-client/insights-client-1.5.tar.gz
+++ b/packages/plugins/ansiblerole-insights-client/insights-client-1.5.tar.gz
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/5z/M8/SHA256E-s6814--96b60e44c5aa1ee6153757d7f348ba6118bbc800426bfb2ef8f7bcdc6fddb4c7.tar.gz/SHA256E-s6814--96b60e44c5aa1ee6153757d7f348ba6118bbc800426bfb2ef8f7bcdc6fddb4c7.tar.gz

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -358,7 +358,8 @@ whitelist = rubygem-angular-rails-templates
 
 [foreman-plugins-nightly-nonscl-rhel7]
 disttag = .el7
-whitelist = nodejs-react-json-tree
+whitelist = ansiblerole-insights-client
+  nodejs-react-json-tree
   puppet-foreman_scap_client
   rubygem-chef-api
   rubygem-faraday


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
This RPM contains an Ansible Role, which once installed on a system can be used to install, configure, register other remote systems with Red Hat Insights.  The role also improves the integration between insights on the remote system and Ansible on connecting systems.

This SRPM largely follows the design of rhel-system-roles.spec, though it packages many roles into one rpm, where as this rpm only packages one role.

I choose the 'ansiblerole-' prefix following the pattern of the 'rubygem-' prefix.

I tested the built RPMs on F27 and RHEL7.4.   The test rpms were built with el7-noscl mock config and with 'f27' (default) mock config.  I could not get el7-scl config to build, something was missing from the root .... 

I'm completely new to tito, and sorta new to packaging in general. I did some packaging for Fedora and RHEL back in the olden days, back before git saved us from svn, so if I've messed up something just let me know.