### PR TITLE
Set TMPDIR in repoclosure.sh

### DIFF
--- a/repoclosure/repoclosure.sh
+++ b/repoclosure/repoclosure.sh
@@ -11,13 +11,13 @@ yumorig=$1
 url=$2
 shift; shift
 
-TEMPDIR=$(mktemp -d)
-trap "rm -rf $TEMPDIR" EXIT
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
 
 # repo names must be unique, or yum will get confused between different OSes and URLs
 reponame=undertest-$(basename $yumorig .conf)-$(echo $url | cksum | sed 's/ /-/g')
 
-yumconf=$TEMPDIR/yum.conf
+yumconf=$TMPDIR/yum.conf
 cat $yumorig > $yumconf
 cat >> $yumconf << EOF
 
@@ -28,9 +28,9 @@ baseurl=$url
 
 EOF
 
-repoclosure -c $yumconf -t -r $reponame $* 2>&1 | tee $TEMPDIR/repoclosure.log
+repoclosure -c $yumconf -t -r $reponame $* 2>&1 | tee $TMPDIR/repoclosure.log
 
-if tail -n1 $TEMPDIR/repoclosure.log | grep -q "Num Packages"; then
+if tail -n1 $TMPDIR/repoclosure.log | grep -q "Num Packages"; then
   exit 0
 else
   exit 1


### PR DESCRIPTION
Repoclosure creates $TMPDIR/$repo which means if multiple processes share the same $TMPDIR you get concurrency issues when they share repos (like el7-epel). Even if the actual repo definitions are the same, then one process might delete a repo the other is still using. By setting a custom TMPDIR we are less efficient but guarantee it does work.

Note that I didn't test this theory yet. Can we replicate the Jenkins setup or should we just apply this?