### PR TITLE
Create proxy etc and var directories

### DIFF
--- a/packages/foreman/foreman-proxy/foreman-proxy.spec
+++ b/packages/foreman/foreman-proxy/foreman-proxy.spec
@@ -140,6 +140,7 @@ ln -sv %{_tmppath} %{buildroot}%{_datadir}/%{name}/tmp
 %config(noreplace) %{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 %attr(-,%{name},%{name}) %{_localstatedir}/log/%{name}
+%attr(-,%{name},%{name}) %{_localstatedir}/lib/%{name}
 %attr(-,%{name},%{name}) %{_rundir}/%{name}
 %attr(-,%{name},root) %{_datadir}/%{name}/config.ru
 %exclude %{_datadir}/%{name}/bundler.d/development.rb

--- a/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
+++ b/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
@@ -52,7 +52,26 @@ This package contains documentation for rubygem-%{gem_name}.
 
 %build
 
+%pre
+for i in ansible ansible_galaxy; do
+  if [ -d %{foreman_proxy_dir}/.$i ]; then
+    mv %{foreman_proxy_dir}/.$i %{buildroot}%{_localstatedir}/lib/foreman-proxy/$i
+  else
+    mkdir -p %{buildroot}%{_localstatedir}/lib/foreman-proxy/$i
+  fi
+done
+
+if [-f %{foreman_proxy_dir}/.ansible.cfg ]; then
+  mv %{foreman_proxy_dir}/.ansible.cfg %{buildroot}%{_sysconfdir}/foreman-proxy/ansible.cfg
+else
+  touch %{buildroot}%{_sysconfdir}/foreman-proxy/ansible.cfg
+fi
+
 %install
+ln -sv %{buildroot}%{_localstatedir}/lib/foreman-proxy/$i %{buildroot}%{foreman_proxy_dir}/.ansible
+ln -sv %{buildroot}%{_localstatedir}/lib/foreman-proxy/$i %{buildroot}%{foreman_proxy_dir}/.ansible_galaxy
+ln -sv %{buildroot}%{_sysconfdir}/foreman-proxy/ansible.cfg %{buildroot}%{foreman_proxy_dir}/.ansible.cfg
+
 mkdir -p %{buildroot}%{gem_dir}
 
 cp -pa .%{gem_dir}/* \
@@ -75,6 +94,12 @@ EOF
 %{gem_instdir}/settings.d
 %{foreman_proxy_bundlerd_dir}/smart_proxy_ansible.rb
 %config %{foreman_proxy_settingsd_dir}/ansible.yml
+%attr(-,root,root) %{foreman_proxy_dir}/.ansible
+%attr(-,root,root) %{foreman_proxy_dir}/.ansible_galaxy
+%attr(-,root,root) %{foreman_proxy_dir}/.ansible.cfg
+%attr(-,foreman-proxy,foreman-proxy) %{_localstatedir}/lib/foreman_proxy/ansible
+%attr(-,foreman-proxy,foreman-proxy) %{_localstatedir}/lib/foreman_proxy/ansible_galaxy
+%attr(-,root,foreman-proxy) %{_sysconfdir}/foreman-proxy/ansible.cfg
 %doc %{gem_instdir}/LICENSE
 %{smart_proxy_dynflow_bundlerd_dir}/foreman_ansible_core.rb
 

--- a/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
+++ b/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
@@ -1,5 +1,4 @@
 %global gem_name smart_proxy_remote_execution_ssh
-
 %global foreman_proxy_dir /usr/share/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
@@ -56,7 +55,16 @@ This package contains documentation for rubygem-%{gem_name}.
 
 %build
 
+%pre
+if [ -d %{foreman_proxy_dir}/.ssh ]; then
+  mv %{foreman_proxy_dir}/.ssh %{_localstatedir}/lib/foreman-proxy/ssh
+else
+  mkdir -p %{_localstatedir}/lib/foreman-proxy/ssh
+fi
+
 %install
+ln -sv %{_localstatedir}/lib/foreman-proxy/ssh %{foreman_proxy_dir}/.ssh
+
 mkdir -p %{buildroot}%{gem_dir}
 
 cp -pa .%{gem_dir}/* \
@@ -81,7 +89,8 @@ EOF
 %config %{foreman_proxy_settingsd_dir}/remote_execution_ssh.yml
 %doc %{gem_instdir}/LICENSE
 %{smart_proxy_dynflow_bundlerd_dir}/foreman_remote_execution_core.rb
-
+%attr(-,root,root) %{foreman_proxy_dir}/.ssh
+%attr(-,foreman-proxy,foreman-proxy) %{_localstatedir}/lib/foreman_proxy/ssh
 %exclude %{gem_instdir}/bundler.plugins.d
 %exclude %{gem_cache}
 %{gem_spec}


### PR DESCRIPTION
@ekohl I recall you mentioned something about migrating files in packaging, if it was about https://github.com/theforeman/puppet-foreman_proxy/pull/415 ,  `ansible.cfg`, `.ansible`, and `.ansible_galaxy` are good candidates. But also `.ssh` as that's likely setup by REX.

I think the foreman-proxy package itself is probably not the best place to do the migration, in fact I'm not sure if moving files around during `yum install` is going to be expected by any user. Shouldn't that belong in the installer? I'm OK with doing it here, but I think it's really unexpected to see files disappear during `yum install` - whereas the installer at least logs that clearly.

If we have to migrate any files in `/usr/share/foreman-proxy`, I would say that should be done by the  `foreman_ansible` and `foreman_remote_execution` packages, instead of this one.