### PR TITLE
Update foreman-tasks to 0.11.2 (1.17 DEB)

### DIFF
--- a/plugins/ruby-foreman-tasks/debian/changelog
+++ b/plugins/ruby-foreman-tasks/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-tasks (0.11.2-1) stable; urgency=low
+
+  * 0.11.2 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Fri, 23 Mar 2018 10:56:30 +0100
+
 ruby-foreman-tasks (0.11.1-1) stable; urgency=low
 
   * 0.11.1 released

--- a/plugins/ruby-foreman-tasks/debian/gem.list
+++ b/plugins/ruby-foreman-tasks/debian/gem.list
@@ -1,5 +1,5 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman-tasks-0.11.1.gem"
+GEMS="https://rubygems.org/downloads/foreman-tasks-0.11.2.gem"
 GEMS="$GEMS https://rubygems.org/downloads/foreman-tasks-core-0.2.4.gem"
 GEMS="$GEMS https://rubygems.org/downloads/parse-cron-0.1.4.gem"
 GEMS="$GEMS https://rubygems.org/downloads/sinatra-2.0.1.gem"

--- a/plugins/ruby-foreman-tasks/foreman-tasks.rb
+++ b/plugins/ruby-foreman-tasks/foreman-tasks.rb
@@ -1,1 +1,1 @@
-gem 'foreman-tasks', '0.11.1'
+gem 'foreman-tasks', '0.11.2'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [x] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
This is 1.17 only release, stability cherry-picks