### PR TITLE
fixes #23029 - fixes incremental backup of failed online pulp backup

### DIFF
--- a/packages/katello/katello/backup.rb
+++ b/packages/katello/katello/backup.rb
@@ -259,11 +259,18 @@ module KatelloUtilities
         FileUtils.cd '/var/lib/pulp' do
           puts "Backing up Pulp data... "
           matching = false
+          backup_file = File.join(@dir, '.pulp.snar')
+          alternate_backup = File.join(@dir, '.pulp.snar.backup')
           until matching
+            FileUtils.cp backup_file, alternate_backup if File.exist? backup_file
             checksum1 = run_cmd("find . -printf '%T@\n' | md5sum")
             create_pulp_data_tar
             checksum2 = run_cmd("find . -printf '%T@\n' | md5sum")
             matching = (checksum1 == checksum2)
+            FileUtils.rm backup_file unless matching
+            if File.exist? alternate_backup
+              matching ? FileUtils.rm(alternate_backup) : FileUtils.mv(alternate_backup, backup_file)
+            end
           end
         end
         puts "Done."


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
To test: run the backup with pulp and the --online-backup flag, while simultaneously affecting the pulp database. For example, run delete_orphaned_content (with some orphaned content) while running katello-backup --online-backup. Once the backup has been created, run a restore from that full backup and make sure everything is running correctly and that the pulp database is working.