### PR TITLE
Fixes #23059 - foreman-journald package now installable

### DIFF
--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -19,6 +19,7 @@
       <packagereq type="default">foreman-debug</packagereq>
       <packagereq type="default">foreman-ec2</packagereq>
       <packagereq type="default">foreman-gce</packagereq>
+      <packagereq type="default">foreman-journald</packagereq>
       <packagereq type="default">foreman-libvirt</packagereq>
       <packagereq type="default">foreman-mysql2</packagereq>
       <packagereq type="default">foreman-openstack</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -84,6 +84,7 @@ foreman_packages:
     rubygem-hoe: {}
     rubygem-http-cookie: {}
     rubygem-ipaddress: {}
+    rubygem-journald-logger: {}
     rubygem-jquery-turbolinks: {}
     rubygem-jquery-ui-rails: {}
     rubygem-jquery_pwstrength_bootstrap_4: {}
@@ -93,6 +94,7 @@ foreman_packages:
     rubygem-little-plugger: {}
     rubygem-locale: {}
     rubygem-logging: {}
+    rubygem-logging-journald: {}
     rubygem-multi_json: {}
     rubygem-multipart-post: {}
     rubygem-mysql2:

--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -878,8 +878,8 @@ Meta Package to install requirements for telemetry support
 %package journald
 Summary: Foreman journald logging support
 Group:  Applications/System
-Requires: %{?scl_prefix}rubygem(journald-logger) >= 1.0
-Requires: %{?scl_prefix}rubygem(journald-logger) < 2.0
+Requires: %{?scl_prefix}rubygem(logging-journald) >= 1.0
+Requires: %{?scl_prefix}rubygem(logging-journald) < 2.0
 Requires: %{name} = %{version}-%{release}
 
 %description journald

--- a/packages/foreman/rubygem-journald-native/0000-relative-load-native.patch
+++ b/packages/foreman/rubygem-journald-native/0000-relative-load-native.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/journald/native.rb b/lib/journald/native.rb
+index 3b8aa0f..70d80a0 100644
+--- a/lib/journald/native.rb
++++ b/lib/journald/native.rb
+@@ -18,7 +18,7 @@
+ #
+ 
+ require 'journald/native/version'
+-require_relative '../journald_native'
++require 'journald_native'
+ 
+ module Journald
+   module Native

--- a/packages/foreman/rubygem-journald-native/rubygem-journald-native.spec
+++ b/packages/foreman/rubygem-journald-native/rubygem-journald-native.spec
@@ -5,7 +5,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.9
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: systemd-journal logging native lib wrapper
 Group: Development/Languages
 License: LGPL-2.1+
@@ -19,6 +19,7 @@ BuildRequires: %{?scl_prefix_ruby}ruby-devel >= 1.9.2
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildRequires: systemd-devel
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
+Patch0: 0000-relative-load-native.patch
 
 %description
 systemd-journal logging native lib wrapper.
@@ -43,6 +44,8 @@ gem unpack %{SOURCE0}
 %{?scl:scl enable %{scl} - << \EOF}
 gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
 %{?scl:EOF}
+
+%patch0 -p1
 
 %build
 # Create the gem as gem install only works on a gem file
@@ -88,6 +91,9 @@ rm -rf %{buildroot}%{gem_instdir}/ext/
 %{gem_instdir}/spec
 
 %changelog
+* Thu Mar 29 2018 Lukas Zapletal <lzap+rpm@redhat.com> 1.0.9-2
+* added relative loading patch
+
 * Tue Feb 20 2018 Daniel Lobato Garcia <me@daniellobato.me> 1.0.9-1
 - new package built with tito
 


### PR DESCRIPTION
This patch solves the following:
  
  1) The package `foreman-journald` was not in comps, so not available in nightly.
  
  2) There are two gems: `logging-journald` (1.0) and `journald-logger`
  (2.0). We want to depend on the former, which requires the latter. I
  screwed up in the requires, thus the dependency issue during
  installation.
  
  3) Loading of the native version does not work, fixed upstream, creating
  patch:
  
  https://github.com/sandfoxme/journald-native/pull/3

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly