### PR TITLE
Correct comps

### DIFF
--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -53,6 +53,7 @@
       <packagereq type="default">tfm-rubygem-bastion</packagereq>
       <packagereq type="default">tfm-rubygem-bastion-devel</packagereq>
       <packagereq type="default">tfm-rubygem-bootstrap-datepicker-rails</packagereq>
+      <packagereq type="default">tfm-rubygem-chunky_png</packagereq>
       <packagereq type="default">tfm-rubygem-commonjs</packagereq>
       <packagereq type="default">tfm-rubygem-dalli</packagereq>
       <packagereq type="default">tfm-rubygem-deface</packagereq>
@@ -121,10 +122,13 @@
       <packagereq type="default">tfm-rubygem-opennebula</packagereq>
       <packagereq type="default">tfm-rubygem-ovirt_provision_plugin</packagereq>
       <packagereq type="default">tfm-rubygem-parse-cron</packagereq>
+      <packagereq type="default">tfm-rubygem-pdf-core</packagereq>
       <packagereq type="default">tfm-rubygem-polyglot</packagereq>
+      <packagereq type="default">tfm-rubygem-prawn</packagereq>
       <packagereq type="default">tfm-rubygem-puppetdb_foreman</packagereq>
       <packagereq type="default">tfm-rubygem-rainbow</packagereq>
       <packagereq type="default">tfm-rubygem-redhat_access_lib</packagereq>
+      <packagereq type="default">tfm-rubygem-rqrcode</packagereq>
       <packagereq type="default">tfm-rubygem-safe_yaml</packagereq>
       <packagereq type="default">tfm-rubygem-smart_proxy_dynflow_core</packagereq>
       <packagereq type="default">tfm-rubygem-systemu</packagereq>
@@ -176,6 +180,7 @@
       <packagereq type="default">tfm-rubygem-azure-doc</packagereq>
       <packagereq type="default">tfm-rubygem-bastion-doc</packagereq>
       <packagereq type="default">tfm-rubygem-bootstrap-datepicker-rails-doc</packagereq>
+      <packagereq type="default">tfm-rubygem-chunky_png-doc</packagereq>
       <packagereq type="default">tfm-rubygem-commonjs-doc</packagereq>
       <packagereq type="default">tfm-rubygem-dalli-doc</packagereq>
       <packagereq type="default">tfm-rubygem-deface-doc</packagereq>
@@ -233,6 +238,7 @@
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_salt-doc</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_ssh-doc</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_tasks-doc</packagereq>
+      <packagereq type="default">tfm-rubygem-hammer_cli_foreman_templates-doc</packagereq>
       <packagereq type="default">tfm-rubygem-jgrep-doc</packagereq>
       <packagereq type="default">tfm-rubygem-jquery-matchheight-rails-doc</packagereq>
       <packagereq type="default">tfm-rubygem-net-ssh-gateway-doc</packagereq>
@@ -241,10 +247,13 @@
       <packagereq type="default">tfm-rubygem-opennebula-doc</packagereq>
       <packagereq type="default">tfm-rubygem-ovirt_provision_plugin-doc</packagereq>
       <packagereq type="default">tfm-rubygem-parse-cron-doc</packagereq>
+      <packagereq type="default">tfm-rubygem-pdf-core-doc</packagereq>
       <packagereq type="default">tfm-rubygem-polyglot-doc</packagereq>
+      <packagereq type="default">tfm-rubygem-prawn-doc</packagereq>
       <packagereq type="default">tfm-rubygem-puppetdb_foreman-doc</packagereq>
       <packagereq type="default">tfm-rubygem-rainbow-doc</packagereq>
       <packagereq type="default">tfm-rubygem-redhat_access_lib-doc</packagereq>
+      <packagereq type="default">tfm-rubygem-rqrcode-doc</packagereq>
       <packagereq type="default">tfm-rubygem-safe_yaml-doc</packagereq>
       <packagereq type="default">tfm-rubygem-smart_proxy_dynflow_core-doc</packagereq>
       <packagereq type="default">tfm-rubygem-systemu-doc</packagereq>

--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -53,9 +53,7 @@
       <packagereq type="default">tfm-rubygem-awesome_print</packagereq>
       <packagereq type="default">tfm-rubygem-bootstrap-sass</packagereq>
       <packagereq type="default">tfm-rubygem-bundler_ext</packagereq>
-      <packagereq type="default">tfm-rubygem-chunky_png</packagereq>
       <packagereq type="default">tfm-rubygem-clamp</packagereq>
-      <packagereq type="default">tfm-rubygem-concurrent-ruby</packagereq>
       <packagereq type="default">tfm-rubygem-concurrent-ruby-edge</packagereq>
       <packagereq type="default">tfm-rubygem-css_parser</packagereq>
       <packagereq type="default">tfm-rubygem-daemons</packagereq>
@@ -127,11 +125,9 @@
       <packagereq type="default">tfm-rubygem-passenger-native</packagereq>
       <packagereq type="default">tfm-rubygem-passenger-native-libs</packagereq>
       <packagereq type="default">tfm-rubygem-patternfly-sass</packagereq>
-      <packagereq type="default">tfm-rubygem-pdf-core</packagereq>
       <packagereq type="default">tfm-rubygem-pg</packagereq>
       <packagereq type="default">tfm-rubygem-po_to_json</packagereq>
       <packagereq type="default">tfm-rubygem-powerbar</packagereq>
-      <packagereq type="default">tfm-rubygem-prawn</packagereq>
       <packagereq type="default">tfm-rubygem-rabl</packagereq>
       <packagereq type="default">tfm-rubygem-rack-jsonp</packagereq>
       <packagereq type="default">tfm-rubygem-rails-i18n</packagereq>
@@ -143,7 +139,6 @@
       <packagereq type="default">tfm-rubygem-retriable</packagereq>
       <packagereq type="default">tfm-rubygem-roadie</packagereq>
       <packagereq type="default">tfm-rubygem-roadie-rails</packagereq>
-      <packagereq type="default">tfm-rubygem-rqrcode</packagereq>
       <packagereq type="default">tfm-rubygem-ruby-libvirt</packagereq>
       <packagereq type="default">tfm-rubygem-ruby2ruby</packagereq>
       <packagereq type="default">tfm-rubygem-ruby_parser</packagereq>
@@ -160,7 +155,6 @@
       <packagereq type="default">tfm-rubygem-syntax</packagereq>
       <packagereq type="default">tfm-rubygem-text</packagereq>
       <packagereq type="default">tfm-rubygem-trollop</packagereq>
-      <packagereq type="default">tfm-rubygem-ttfunk</packagereq>
       <packagereq type="default">tfm-rubygem-unf</packagereq>
       <packagereq type="default">tfm-rubygem-unf_ext</packagereq>
       <packagereq type="default">tfm-rubygem-unicode</packagereq>
@@ -275,11 +269,9 @@
       <packagereq type="default">puppet-agent-oauth</packagereq>
       <packagereq type="default">puppet-agent-puppet-strings</packagereq>
       <packagereq type="default">puppet-agent-yard</packagereq>
-      <packagereq type="default">rubygem-apipie-bindings</packagereq>
       <packagereq type="default">rubygem-bundler_ext</packagereq>
       <packagereq type="default">rubygem-clamp</packagereq>
       <packagereq type="default">rubygem-concurrent-ruby</packagereq>
-      <packagereq type="default">rubygem-foreman_api</packagereq>
       <packagereq type="default">rubygem-hashie</packagereq>
       <packagereq type="default">rubygem-highline</packagereq>
       <packagereq type="default">rubygem-kafo</packagereq>
@@ -293,7 +285,6 @@
       <packagereq type="default">rubygem-passenger-native-libs</packagereq>
       <packagereq type="default">rubygem-powerbar</packagereq>
       <packagereq type="default">rubygem-rb-inotify</packagereq>
-      <packagereq type="default">rubygem-rdoc</packagereq>
       <packagereq type="default">rubygem-rsec</packagereq>
       <packagereq type="default">rubygem-rubyipmi</packagereq>
       <!--
@@ -313,7 +304,6 @@
       <packagereq type="default">nodejs-multiselect-doc</packagereq>
       <packagereq type="default">nodejs-select2-doc</packagereq>
       <packagereq type="default">nodejs-url-loader-doc</packagereq>
-      <packagereq type="default">rubygem-apipie-bindings-doc</packagereq>
       <packagereq type="default">rubygem-bundler_ext-doc</packagereq>
       <packagereq type="default">rubygem-clamp-doc</packagereq>
       <packagereq type="default">rubygem-concurrent-ruby-doc</packagereq>
@@ -344,9 +334,7 @@
       <packagereq type="default">tfm-rubygem-awesome_print-doc</packagereq>
       <packagereq type="default">tfm-rubygem-bootstrap-sass-doc</packagereq>
       <packagereq type="default">tfm-rubygem-bundler_ext-doc</packagereq>
-      <packagereq type="default">tfm-rubygem-chunky_png-doc</packagereq>
       <packagereq type="default">tfm-rubygem-clamp-doc</packagereq>
-      <packagereq type="default">tfm-rubygem-concurrent-ruby-doc</packagereq>
       <packagereq type="default">tfm-rubygem-concurrent-ruby-edge-doc</packagereq>
       <packagereq type="default">tfm-rubygem-css_parser-doc</packagereq>
       <packagereq type="default">tfm-rubygem-daemons-doc</packagereq>
@@ -416,11 +404,9 @@
       <packagereq type="default">tfm-rubygem-paint-doc</packagereq>
       <packagereq type="default">tfm-rubygem-passenger-doc</packagereq>
       <packagereq type="default">tfm-rubygem-patternfly-sass-doc</packagereq>
-      <packagereq type="default">tfm-rubygem-pdf-core-doc</packagereq>
       <packagereq type="default">tfm-rubygem-pg-doc</packagereq>
       <packagereq type="default">tfm-rubygem-po_to_json-doc</packagereq>
       <packagereq type="default">tfm-rubygem-powerbar-doc</packagereq>
-      <packagereq type="default">tfm-rubygem-prawn-doc</packagereq>
       <packagereq type="default">tfm-rubygem-rabl-doc</packagereq>
       <packagereq type="default">tfm-rubygem-rack-jsonp-doc</packagereq>
       <packagereq type="default">tfm-rubygem-rails-i18n-doc</packagereq>
@@ -432,7 +418,6 @@
       <packagereq type="default">tfm-rubygem-retriable-doc</packagereq>
       <packagereq type="default">tfm-rubygem-roadie-doc</packagereq>
       <packagereq type="default">tfm-rubygem-roadie-rails-doc</packagereq>
-      <packagereq type="default">tfm-rubygem-rqrcode-doc</packagereq>
       <packagereq type="default">tfm-rubygem-ruby2ruby-doc</packagereq>
       <packagereq type="default">tfm-rubygem-ruby-libvirt-doc</packagereq>
       <packagereq type="default">tfm-rubygem-ruby_parser-doc</packagereq>
@@ -447,7 +432,6 @@
       <packagereq type="default">tfm-rubygem-sshkey-doc</packagereq>
       <packagereq type="default">tfm-rubygem-text-doc</packagereq>
       <packagereq type="default">tfm-rubygem-trollop-doc</packagereq>
-      <packagereq type="default">tfm-rubygem-ttfunk-doc</packagereq>
       <packagereq type="default">tfm-rubygem-unf-doc</packagereq>
       <packagereq type="default">tfm-rubygem-unf_ext-doc</packagereq>
       <packagereq type="default">tfm-rubygem-unicode-display_width-doc</packagereq>


### PR DESCRIPTION
Various packages were added to the main comps rather than the plugins.  It also removes packages (rubygem-rdoc, rubygem-apipie-bindings, rubygem-foreman_api) that we no longer build.

This is based on the warnings generated during mashing:

```
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: tfm-rubygem-chunky_png
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: rubygem-foreman_api
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: tfm-rubygem-ttfunk-doc
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: tfm-rubygem-chunky_png-doc
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: tfm-rubygem-rqrcode-doc
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: rubygem-rdoc
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: tfm-rubygem-pdf-core-doc
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: rubygem-apipie-bindings
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: tfm-rubygem-prawn
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: tfm-rubygem-pdf-core
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: tfm-rubygem-concurrent-ruby
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: tfm-rubygem-prawn-doc
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: tfm-rubygem-concurrent-ruby-doc
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: rubygem-apipie-bindings-doc
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: tfm-rubygem-ttfunk
2018-04-05 13:33:43 [WARNING ] In comps but not in foreman-nightly/RHEL/7 tree: tfm-rubygem-rqrcode
2018-04-05 13:33:43 [WARNING ] rubygem-passenger-devel not in comps-foreman-rhel7.xml
2018-04-05 13:33:43 [WARNING ] tfm-rubygem-passenger-devel not in comps-foreman-rhel7.xml
2018-04-05 13:33:43 [WARNING ] foreman-telemetry not in comps-foreman-rhel7.xml
```