### PR TITLE
Update rubygem-foreman_snapshot_management to 1.4.0

### DIFF
--- a/packages/plugins/rubygem-foreman_snapshot_management/foreman_snapshot_management-1.3.0.gem
+++ b/packages/plugins/rubygem-foreman_snapshot_management/foreman_snapshot_management-1.3.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/M8/4V/SHA256E-s26112--5b3e4933bbebe3b552dd6a41d6dd0c0ac718bbeeb0f58ef25090b087549f2c9c.0.gem/SHA256E-s26112--5b3e4933bbebe3b552dd6a41d6dd0c0ac718bbeeb0f58ef25090b087549f2c9c.0.gem

--- a/packages/plugins/rubygem-foreman_snapshot_management/foreman_snapshot_management-1.4.0.gem
+++ b/packages/plugins/rubygem-foreman_snapshot_management/foreman_snapshot_management-1.4.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/Q5/w4/SHA256E-s26112--0ba43f5ab3ef43311e9c5d0af0d30e63de84bed0bbfdcf632cdd02a2ffa1c165.0.gem/SHA256E-s26112--0ba43f5ab3ef43311e9c5d0af0d30e63de84bed0bbfdcf632cdd02a2ffa1c165.0.gem

--- a/packages/plugins/rubygem-foreman_snapshot_management/rubygem-foreman_snapshot_management.spec
+++ b/packages/plugins/rubygem-foreman_snapshot_management/rubygem-foreman_snapshot_management.spec
@@ -5,8 +5,8 @@
 %global plugin_name snapshot_management
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 1.3.0
-Release: 2%{?foremandist}%{?dist}
+Version: 1.4.0
+Release: 1%{?foremandist}%{?dist}
 Summary: Snapshot Management for VMware vSphere
 Group: Applications/Systems
 License: GPL-3.0
@@ -89,6 +89,9 @@ cp -pa .%{gem_dir}/* \
 exit 0
 
 %changelog
+* Thu Apr 05 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 1.4.0-1
+- Update to 1.4.0
+
 * Wed Jan 10 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 1.3.0-2
 - Bump Foreman plugins release (ericdhelms@gmail.com)
 


### PR DESCRIPTION
@mdellweg I noticed there was a new release. Please ACK if this should go into nightly.