### PR TITLE
bump rubygem-katello requires on foreman-tasks

### DIFF
--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -26,7 +26,7 @@ Requires: %{?scl_prefix}rubygem(oauth)
 Requires: %{?scl_prefix}rubygem(rest-client)
 Requires: %{?scl_prefix}rubygem(rabl)
 Requires: %{?scl_prefix}rubygem(foreman_docker) >= 0.2.0
-Requires: %{?scl_prefix}rubygem(foreman-tasks) >= 0.8.0
+Requires: %{?scl_prefix}rubygem(foreman-tasks) >= 0.12.2
 Requires: %{?scl_prefix}rubygem(foreman-tasks) < 1.0.0
 Requires: %{?scl_prefix}rubygem(gettext_i18n_rails)
 Requires: %{?scl_prefix}rubygem(apipie-rails) >= 0.1.1
@@ -45,7 +45,7 @@ BuildRequires: %{?scl_prefix}rubygem(foreman_docker) >= 0.2.0
 BuildRequires: %{?scl_prefix}rubygem(angular-rails-templates) >= 0.0.4
 BuildRequires: %{?scl_prefix}rubygem(bastion) >= 6.1.2
 BuildRequires: %{?scl_prefix}rubygem(bastion) < 7.0.0
-BuildRequires: %{?scl_prefix}rubygem(foreman-tasks) >= 0.8.0
+BuildRequires: %{?scl_prefix}rubygem(foreman-tasks) >= 0.12.2
 BuildRequires: %{?scl_prefix}rubygem(foreman-tasks) < 1.0.0
 BuildRequires: %{?scl_prefix}rubygem(gettext_i18n_rails)
 BuildRequires: %{?scl_prefix}rubygem(apipie-rails) >= 0.1.1


### PR DESCRIPTION
since 59e3a1a4fbdb4665e47258e15dc1fb6b6ff999f5, katello requires the
Actions::Middleware::KeepCurrentTaxonomies from foreman-tasks which was
introduced there in 8e9e7daaac397a4a6dca3c91a046926dc6fbae42 and thus is
only available in 0.12.2 or newer. bump the (build)requires accordingly.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
