### PR TITLE
Update rubygem-foreman_virt_who_configure to 0.2.0

### DIFF
--- a/packages/katello/rubygem-foreman_virt_who_configure/foreman_virt_who_configure-0.1.9.gem
+++ b/packages/katello/rubygem-foreman_virt_who_configure/foreman_virt_who_configure-0.1.9.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/P5/qf/SHA256E-s45056--ea24cbd605d8b9e18709bbfba68b8a620638d1fd9189249b9c34aa7bdb4fb44c.9.gem/SHA256E-s45056--ea24cbd605d8b9e18709bbfba68b8a620638d1fd9189249b9c34aa7bdb4fb44c.9.gem

--- a/packages/katello/rubygem-foreman_virt_who_configure/foreman_virt_who_configure-0.2.0.gem
+++ b/packages/katello/rubygem-foreman_virt_who_configure/foreman_virt_who_configure-0.2.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/z8/3w/SHA256E-s46080--29fadcfcd0a4749817511fd98197d9ff16be55d944e9efd4002b7539ec94ecce.0.gem/SHA256E-s46080--29fadcfcd0a4749817511fd98197d9ff16be55d944e9efd4002b7539ec94ecce.0.gem

--- a/packages/katello/rubygem-foreman_virt_who_configure/rubygem-foreman_virt_who_configure.spec
+++ b/packages/katello/rubygem-foreman_virt_who_configure/rubygem-foreman_virt_who_configure.spec
@@ -5,7 +5,7 @@
 %global plugin_name virt_who_configure
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 0.1.9
+Version: 0.2.0
 Release: 1%{?foremandist}%{?dist}
 Summary: A plugin to make virt-who configuration easy
 Group: Applications/Systems
@@ -85,6 +85,9 @@ cp -pa .%{gem_dir}/* \
 exit 0
 
 %changelog
+* Tue Apr 10 2018 Marek Hulan <mhulan@redhat.com> 0.2.0-1
+- Update to 0.2.0
+
 * Thu Dec 28 2017 Daniel Lobato Garcia <me@daniellobato.me> 0.1.9-1
 - new package built with tito
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
