### PR TITLE
Update rubygem-safemode to 1.3.5

### DIFF
--- a/packages/foreman/rubygem-safemode/rubygem-safemode.spec
+++ b/packages/foreman/rubygem-safemode/rubygem-safemode.spec
@@ -6,7 +6,7 @@
 Summary: A library for safe evaluation of Ruby code
 Name: %{?scl_prefix}rubygem-%{gem_name}
 
-Version: 1.3.4
+Version: 1.3.5
 Release: 1%{?dist}
 Group: Development/Ruby
 License: MIT
@@ -86,6 +86,9 @@ rm %{buildroot}%{gem_instdir}/{VERSION,.travis.yml}
 %{gem_docdir}
 
 %changelog
+* Mon Apr 16 2018 Dmitri Dolguikh <dmitri@appliedlogic.ca> 1.3.5-1
+- Update to 1.3.5
+
 * Fri Jan 19 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 1.3.4-1
 - Update rubygem-safemode to 1.3.4 (dmitri@appliedlogic.ca)
 

--- a/packages/foreman/rubygem-safemode/safemode-1.3.4.gem
+++ b/packages/foreman/rubygem-safemode/safemode-1.3.4.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/1Q/9K/SHA256E-s22016--5efd10115d29adebb0f66c8970905d4ca7b6df6bfa3f7ee7565b6f436b9aba49.4.gem/SHA256E-s22016--5efd10115d29adebb0f66c8970905d4ca7b6df6bfa3f7ee7565b6f436b9aba49.4.gem

--- a/packages/foreman/rubygem-safemode/safemode-1.3.5.gem
+++ b/packages/foreman/rubygem-safemode/safemode-1.3.5.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/V5/PX/SHA256E-s22016--ef5d2d74afb45f7469a2520c56afac5749cbedbf52c85352c0a62a3ec6bb98f3.5.gem/SHA256E-s22016--ef5d2d74afb45f7469a2520c56afac5749cbedbf52c85352c0a62a3ec6bb98f3.5.gem


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
