### PR TITLE
Refs #23217 - Exclude package.json and webpack in RPM

### DIFF
--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -112,6 +112,8 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/public/assets/bastion_katello
 
 %exclude %{gem_cache}
+%exclude %{gem_instdir}/package.json
+%exclude %{gem_instdir}/webpack
 
 %license %{gem_instdir}/LICENSE.txt
 


### PR DESCRIPTION
Katello includes package.json and the webpack folder in their gem since
https://github.com/Katello/katello/commit/2e19c47513122cfa706f2af4002e9b47310de2a2

These however are not needed inside the built RPM (only to build the RPM). So let's exclude them.