### PR TITLE
Release remote execution 1.5.1

### DIFF
--- a/plugins/ruby-foreman-remote-execution/debian/changelog
+++ b/plugins/ruby-foreman-remote-execution/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution (1.5.1-1) stable; urgency=low
+
+  * 1.5.1 released
+
+ -- Daniel Lobato Garcia <me@daniellobato.me>  Thu, 19 Apr 2018 18:51:03 +0200
+
 ruby-foreman-remote-execution (1.5.0-1) stable; urgency=low
 
   * 1.5.0 released

--- a/plugins/ruby-foreman-remote-execution/debian/control
+++ b/plugins/ruby-foreman-remote-execution/debian/control
@@ -2,14 +2,14 @@ Source: ruby-foreman-remote-execution
 Section: ruby
 Priority: extra
 Maintainer: Stephen Benjamin <stephen@redhat.com>
-Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.17.0~rc1), foreman (>= 1.17.0~rc1),
-  foreman-sqlite3 (>= 1.17.0~rc1), ruby-foreman-tasks (>= 0.12.0), ruby-foreman-deface
+Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.18.0~rc1), foreman (>= 1.18.0~rc1),
+  foreman-sqlite3 (>= 1.18.0~rc1), ruby-foreman-tasks (>= 0.12.0), ruby-foreman-deface
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_remote_execution
 
 Package: ruby-foreman-remote-execution
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.17.0~rc1), ruby-foreman-tasks (>= 0.12.0),
+Depends: ${misc:Depends}, bundler, foreman (>= 1.18.0~rc1), ruby-foreman-tasks (>= 0.12.0),
   ruby-foreman-deface
 Description: Foreman Remote Execution Plugin
   A plugin bringing remote execution to the Foreman, completing the config management functionality with remote management functionality

--- a/plugins/ruby-foreman-remote-execution/debian/gem.list
+++ b/plugins/ruby-foreman-remote-execution/debian/gem.list
@@ -1,3 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.5.0.gem"
+GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.5.1.gem"
 GEMS="$GEMS https://rubygems.org/downloads/foreman_remote_execution_core-1.1.1.gem"

--- a/plugins/ruby-foreman-remote-execution/debian/install
+++ b/plugins/ruby-foreman-remote-execution/debian/install
@@ -1,4 +1,5 @@
 foreman_remote_execution.rb           usr/share/foreman/bundler.d
 cache                                 usr/share/foreman/vendor
 assets                                var/lib/foreman/public
+webpack                               var/lib/foreman/public
 apipie-cache/foreman_remote_execution var/lib/foreman/public/apipie-cache/plugin

--- a/plugins/ruby-foreman-remote-execution/debian/rules
+++ b/plugins/ruby-foreman-remote-execution/debian/rules
@@ -22,9 +22,10 @@ build:
 			OUT=/var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) RAILS_ENV=development \
 	)
 	GEM_PATH=$$(cd /usr/share/foreman && /usr/bin/foreman-ruby /usr/bin/bundle show $(PLUGIN)) && \
-		cp -rp $${GEM_PATH}/public/assets/ ./
+		cp -rp $${GEM_PATH}/public/assets/ ./ && \
+		cp -rp $${GEM_PATH}/public/webpack/ ./
 	[ -e apipie-cache ] || mkdir apipie-cache/
 	cp -rp /var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) ./apipie-cache/
 
 %:
-	dh $@ 
+	dh $@

--- a/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
+++ b/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
@@ -1,1 +1,1 @@
-gem 'foreman_remote_execution', '1.5.0'
+gem 'foreman_remote_execution', '1.5.1'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

This ought to add the webpack compiled bundle to the package, still untested though

