### PR TITLE
update smart_proxy_dhcp_device42 to 1.0.6 ( rpm )

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_dhcp_device42/rubygem-smart_proxy_dhcp_device42.spec
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_device42/rubygem-smart_proxy_dhcp_device42.spec
@@ -85,9 +85,8 @@ mv %{buildroot}%{gem_instdir}/config/dhcp_device42.yml \
 %doc %{gem_instdir}/README.md
 
 %changelog
-* Thu Apr 19 2018 vagrant 1.0.6-1
+* Thu Apr 19 2018 Anatolii Chmykhalo <anatolii.chmykhalo@device42.com> 1.0.6-1
 - Update to 1.0.6
 
 * Wed Feb 14 2018 Daniel Lobato Garcia <me@daniellobato.me> 1.0.4-1
 - new package built with tito
-

--- a/packages/plugins/rubygem-smart_proxy_dhcp_device42/rubygem-smart_proxy_dhcp_device42.spec
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_device42/rubygem-smart_proxy_dhcp_device42.spec
@@ -6,7 +6,7 @@
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
 Name: rubygem-%{gem_name}
-Version: 1.0.4
+Version: 1.0.6
 Release: 1%{?foremandist}%{?dist}
 Summary: Device42 DHCP provider plugin for Foreman's smart proxy
 Group: Applications/Internet
@@ -85,6 +85,9 @@ mv %{buildroot}%{gem_instdir}/config/dhcp_device42.yml \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Thu Apr 19 2018 vagrant 1.0.6-1
+- Update to 1.0.6
+
 * Wed Feb 14 2018 Daniel Lobato Garcia <me@daniellobato.me> 1.0.4-1
 - new package built with tito
 

--- a/packages/plugins/rubygem-smart_proxy_dhcp_device42/smart_proxy_dhcp_device42-1.0.4.gem
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_device42/smart_proxy_dhcp_device42-1.0.4.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/QQ/vx/SHA256E-s19456--c35c2ccebf9c21d46922d59183b4565eded72c14cdc562d4e5a051c69b75bbd7.4.gem/SHA256E-s19456--c35c2ccebf9c21d46922d59183b4565eded72c14cdc562d4e5a051c69b75bbd7.4.gem

--- a/packages/plugins/rubygem-smart_proxy_dhcp_device42/smart_proxy_dhcp_device42-1.0.6.gem
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_device42/smart_proxy_dhcp_device42-1.0.6.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/J5/1z/SHA256E-s19968--e6a5c86b8b471acea4d5ec11cb113cb54daf73cebced68314dce67d78aab3053.6.gem/SHA256E-s19968--e6a5c86b8b471acea4d5ec11cb113cb54daf73cebced68314dce67d78aab3053.6.gem


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
