### PR TITLE
Update rubygem-katello dependencies for webpack

### DIFF
--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -59,6 +59,10 @@ BuildRequires: %{?scl_prefix_ruby}rubygem(json)
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildRequires: %{?scl_prefix_ruby}ruby(rubygems)
 BuildRequires: %{?scl_prefix_ruby}ruby(release)
+BuildRequires: npm(react-router-bootstrap) >= 0.24.4
+BuildRequires: npm(react-router-bootstrap-select) >= 1.12.2
+BuildRequires: npm(react-router-dom) >= 4.2.2
+BuildRequires: npm(downshift) >= 1.28.0
 
 Obsoletes: %{?scl_prefix}rubygem-%{gem_name}_ostree
 
@@ -109,6 +113,7 @@ cp -a .%{gem_dir}/* \
 %{foreman_apipie_cache_foreman}
 %{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
+%{foreman_webpack_plugin}
 %{gem_instdir}/public/assets/bastion_katello
 
 %exclude %{gem_cache}


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
