### PR TITLE
Refs #23444 - Update secure_headers to 5.0.5

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -87,8 +87,8 @@ Requires: %{?scl_prefix}rubygem(validates_lengths_from_database) >= 0.5
 Requires: %{?scl_prefix}rubygem(validates_lengths_from_database) < 1.0
 Requires: %{?scl_prefix}rubygem(friendly_id) >= 5.0
 Requires: %{?scl_prefix}rubygem(friendly_id) < 6.0
-Requires: %{?scl_prefix}rubygem(secure_headers) >= 3.4
-Requires: %{?scl_prefix}rubygem(secure_headers) < 4.0
+Requires: %{?scl_prefix}rubygem(secure_headers) >= 5.0
+Requires: %{?scl_prefix}rubygem(secure_headers) < 6.0
 Requires: %{?scl_prefix}rubygem(safemode) >= 1.3.5
 Requires: %{?scl_prefix}rubygem(safemode) < 2
 Requires: %{?scl_prefix}rubygem(fast_gettext) >= 1.4
@@ -176,8 +176,8 @@ BuildRequires: %{?scl_prefix}rubygem(validates_lengths_from_database) >= 0.5
 BuildRequires: %{?scl_prefix}rubygem(validates_lengths_from_database) < 1.0
 BuildRequires: %{?scl_prefix}rubygem(friendly_id) >= 5.0
 BuildRequires: %{?scl_prefix}rubygem(friendly_id) < 6.0
-BuildRequires: %{?scl_prefix}rubygem(secure_headers) >= 3.4
-BuildRequires: %{?scl_prefix}rubygem(secure_headers) < 4.0
+BuildRequires: %{?scl_prefix}rubygem(secure_headers) >= 5.0
+BuildRequires: %{?scl_prefix}rubygem(secure_headers) < 6.0
 BuildRequires: %{?scl_prefix}rubygem(safemode) >= 1.3.5
 BuildRequires: %{?scl_prefix}rubygem(safemode) < 2
 BuildRequires: %{?scl_prefix}rubygem(fast_gettext) >= 1.4

--- a/packages/foreman/rubygem-secure_headers/rubygem-secure_headers.spec
+++ b/packages/foreman/rubygem-secure_headers/rubygem-secure_headers.spec
@@ -5,8 +5,8 @@
 
 Summary: Security related headers all in one gem
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 3.4.1
-Release: 2%{?dist}
+Version: 5.0.5
+Release: 1%{?dist}
 Group: Development/Languages
 License: ASL 2.0
 URL: https://github.com/twitter/secureheaders
@@ -15,7 +15,7 @@ Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
 Requires: %{?scl_prefix_ruby}ruby
-Requires: %{?scl_prefix}rubygem(useragent)
+Requires: %{?scl_prefix}rubygem(useragent) >= 0.15.0
 
 BuildRequires: %{?scl_prefix_ruby}ruby(release)
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
@@ -63,14 +63,19 @@ cp -a .%{gem_dir}/* \
 %files doc
 %doc %{gem_docdir}
 %doc %{gem_instdir}/CHANGELOG.md
+%doc %{gem_instdir}/CODE_OF_CONDUCT.md
+%doc %{gem_instdir}/CONTRIBUTING.md
 %doc %{gem_instdir}/README.md
-%doc %{gem_instdir}/upgrading-to-3-0.md
+%doc %{gem_instdir}/docs
 %{gem_instdir}/Gemfile
 %{gem_instdir}/Guardfile
 %{gem_instdir}/Rakefile
 %{gem_instdir}/spec
 
 %changelog
+* Mon Apr 30 2018 Michael Moll <mmoll@mmoll.at> 5.0.5-1
+- Update secure_headers to 5.0.5
+
 * Fri Jan 05 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 3.4.1-2
 - Final set of rebuilds (ericdhelms@gmail.com)
 - Use HTTPS URLs for github and rubygems (ewoud@kohlvanwijngaarden.nl)

--- a/packages/foreman/rubygem-secure_headers/secure_headers-3.4.1.gem
+++ b/packages/foreman/rubygem-secure_headers/secure_headers-3.4.1.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/FM/jX/SHA256E-s51712--76066d08c112bddfed9c8157dd5e0236fdddc2c0a6650eb7e48ae7bc5f78739e.1.gem/SHA256E-s51712--76066d08c112bddfed9c8157dd5e0236fdddc2c0a6650eb7e48ae7bc5f78739e.1.gem

--- a/packages/foreman/rubygem-secure_headers/secure_headers-5.0.5.gem
+++ b/packages/foreman/rubygem-secure_headers/secure_headers-5.0.5.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/81/Q3/SHA256E-s58880--cf40223ae2b77e37da72772440f230e0dd4d14e4fcb1866396f38ae34baa3cde.5.gem/SHA256E-s58880--cf40223ae2b77e37da72772440f230e0dd4d14e4fcb1866396f38ae34baa3cde.5.gem


### PR DESCRIPTION
this should be built into:
* [x] Nightly

after https://github.com/theforeman/foreman/pull/5509 was merged