### PR TITLE
include JS files for webpack assets in foreman-assets package

### DIFF
--- a/debian/stretch/foreman/control
+++ b/debian/stretch/foreman/control
@@ -13,7 +13,7 @@ Package: foreman
 Architecture: any
 Section: web
 Priority: extra
-Depends: ruby2.3, bundler (>= 1.3), zlib1g-dev,
+Depends: ruby, ruby2.3, bundler (>= 1.3), zlib1g-dev,
          ruby2.3-dev, build-essential,
          rake (>=0.8.4), ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug (= ${binary:Version}), python-minimal
@@ -180,7 +180,7 @@ Description: metapackage providing test dependencies for Foreman
  The foreman package should be installed along with this package.
 
 Package: foreman-assets
-Architecture: all
+Architecture: any
 Section: web
 Priority: extra
 Depends: foreman (= ${binary:Version}), nodejs (>= 8.9), ${misc:Depends}

--- a/debian/stretch/foreman/foreman-assets.install
+++ b/debian/stretch/foreman/foreman-assets.install
@@ -1,1 +1,5 @@
 bundler.d/assets.rb /usr/share/foreman/bundler.d
+package.json /usr/share/foreman
+package-lock.json /usr/share/foreman
+node_modules /usr/share/foreman
+webpack /usr/share/foreman

--- a/debian/stretch/foreman/foreman-assets.postinst
+++ b/debian/stretch/foreman/foreman-assets.postinst
@@ -29,6 +29,9 @@ fi
 # Own all the core files
 chown -Rf foreman:foreman '/usr/share/foreman'
 
+# make webpack file executable
+chmod 755 '/usr/share/foreman/node_modules/webpack/bin/webpack.js'
+
 #DEBHELPER#
 
 exit 0

--- a/debian/xenial/foreman/control
+++ b/debian/xenial/foreman/control
@@ -13,7 +13,7 @@ Package: foreman
 Architecture: any
 Section: web
 Priority: extra
-Depends: ruby2.3, bundler (>= 1.3), zlib1g-dev,
+Depends: ruby, ruby2.3, bundler (>= 1.3), zlib1g-dev,
          ruby2.3-dev, build-essential,
          rake (>=0.8.4), ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug (= ${binary:Version}), python-minimal
@@ -180,7 +180,7 @@ Description: metapackage providing test dependencies for Foreman
  The foreman package should be installed along with this package.
 
 Package: foreman-assets
-Architecture: all
+Architecture: any
 Section: web
 Priority: extra
 Depends: foreman (= ${binary:Version}), nodejs (>= 8.9), ${misc:Depends}

--- a/debian/xenial/foreman/foreman-assets.install
+++ b/debian/xenial/foreman/foreman-assets.install
@@ -1,1 +1,5 @@
 bundler.d/assets.rb /usr/share/foreman/bundler.d
+package.json /usr/share/foreman
+package-lock.json /usr/share/foreman
+node_modules /usr/share/foreman
+webpack /usr/share/foreman

--- a/debian/xenial/foreman/foreman-assets.postinst
+++ b/debian/xenial/foreman/foreman-assets.postinst
@@ -29,6 +29,9 @@ fi
 # Own all the core files
 chown -Rf foreman:foreman '/usr/share/foreman'
 
+# make webpack file executable
+chmod 755 '/usr/share/foreman/node_modules/webpack/bin/webpack.js'
+
 #DEBHELPER#
 
 exit 0


### PR DESCRIPTION
this should be built into:

* [x] Nightly
* [x] 1.18

I'm unsure what elso needs to get packaged now for the plugin asset builds with webpack to succeed.