### PR TITLE
backport patch for katello-host-tools

### DIFF
--- a/packages/katello/katello-host-tools/enabled_repos_format.patch
+++ b/packages/katello/katello-host-tools/enabled_repos_format.patch
@@ -1,0 +1,23 @@
+From d16caad146aecf85353c51bf3453ad27f640c209 Mon Sep 17 00:00:00 2001
+From: Justin Sherrill <jsherril@redhat.com>
+Date: Mon, 30 Apr 2018 13:28:57 -0400
+Subject: [PATCH] Fixes #23456 - send array of urls in repo report
+
+---
+ src/katello/enabled_report.py            | 2 +-
+ test/test_katello/test_enabled_report.py | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/katello/enabled_report.py b/src/katello/enabled_report.py
+index 1c5edaded..1f5d3676a 100755
+--- a/src/katello/enabled_report.py
++++ b/src/katello/enabled_report.py
+@@ -13,7 +13,7 @@ def __generate(self):
+         config = ConfigParser()
+         config.read(self.repofile)
+         enabled_sections = [section for section in config.sections() if config.getboolean(section, "enabled")]
+-        enabled_repos = [{"repositoryid": section,"baseurl": config.get(section, "baseurl")} for section in enabled_sections]
++        enabled_repos = [{"repositoryid": section,"baseurl": [config.get(section, "baseurl")]} for section in enabled_sections]
+         return {"enabled_repos": {"repos": enabled_repos}}
+ 
+     def __init__(self, repo_file = REPOSITORY_PATH):

--- a/packages/katello/katello-host-tools/katello-host-tools.spec
+++ b/packages/katello/katello-host-tools/katello-host-tools.spec
@@ -14,12 +14,13 @@
 
 Name: katello-host-tools
 Version: 3.2.1
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: A set of commands and yum plugins that support a Katello host
 Group:   Development/Languages
 License: LGPLv2
 URL:     https://github.com/Katello/katello-agent
 Source0: https://codeload.github.com/Katello/katello-agent/tar.gz/%{version}#/%{name}-%{version}.tar.gz
+Patch0: enabled_repos_format.patch
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
@@ -124,6 +125,7 @@ Adds Tracer functionality to a client managed by katello-host-tools
 
 %prep
 %setup -q
+%patch0 -p1
 
 %build
 pushd src
@@ -313,6 +315,9 @@ exit 0
 %endif #build_tracer
 
 %changelog
+* Mon Apr 30 2018 Justin Sherrill <jlsherrill@gmail.com> 3.2.1-3
+- Backporting format issue with enabled-repos
+
 * Thu Apr 19 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.2.1-2
 - rebuilt
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
