### PR TITLE
Update rubygem-hammer_cli_foreman to 0.13.0

### DIFF
--- a/packages/foreman/rubygem-hammer_cli_foreman/hammer_cli_foreman-0.12.1.gem
+++ b/packages/foreman/rubygem-hammer_cli_foreman/hammer_cli_foreman-0.12.1.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/wk/qm/SHA256E-s370688--352479c43fab6fb1aac52fe43bc56f4a8d70cc9ccd1e4dea4fd42f793eb5e11a.1.gem/SHA256E-s370688--352479c43fab6fb1aac52fe43bc56f4a8d70cc9ccd1e4dea4fd42f793eb5e11a.1.gem

--- a/packages/foreman/rubygem-hammer_cli_foreman/hammer_cli_foreman-0.13.0.gem
+++ b/packages/foreman/rubygem-hammer_cli_foreman/hammer_cli_foreman-0.13.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/Mq/11/SHA256E-s432640--bbb17dff76f973deeeff233fe43c676b8ced83f27f034d0c62f4c4625c11c470.0.gem/SHA256E-s432640--bbb17dff76f973deeeff233fe43c676b8ced83f27f034d0c62f4c4625c11c470.0.gem

--- a/packages/foreman/rubygem-hammer_cli_foreman/rubygem-hammer_cli_foreman.spec
+++ b/packages/foreman/rubygem-hammer_cli_foreman/rubygem-hammer_cli_foreman.spec
@@ -8,7 +8,7 @@
 
 Summary: Universal command-line interface for Foreman
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 0.12.1
+Version: 0.13.0
 Release: 1%{?dist}
 Group: Development/Languages
 License: GPLv3
@@ -17,7 +17,7 @@ Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
-Requires: %{?scl_prefix}rubygem(hammer_cli) >= 0.12.0
+Requires: %{?scl_prefix}rubygem(hammer_cli) >= 0.13.0
 Requires: %{?scl_prefix}rubygem(apipie-bindings) >= 0.2.2
 Requires: %{?scl_prefix}rubygem(rest-client) >= 1.8.0
 Requires: %{?scl_prefix}rubygem(rest-client) < 3.0.0
@@ -81,6 +81,9 @@ install -m 755 .%{gem_instdir}/config/foreman.yml \
 %{gem_instdir}/test
 
 %changelog
+* Thu May 10 2018 Martin Bacovsky <mbacovsk@redhat.com> 0.13.0-1
+- Update to 0.13.0
+
 * Mon Mar 05 2018 Martin Bacovsky <martin.bacovsky@gmail.com> 0.12.1-1
 - Update rubygem-hammer_cli_foreman to 0.12.1 (martin.bacovsky@gmail.com)
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.18
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
