### PR TITLE
Fixes #23595 - Set ruby-sequel-pg to conflicting

### DIFF
--- a/debian/stretch/foreman/control
+++ b/debian/stretch/foreman/control
@@ -17,7 +17,7 @@ Depends: ruby2.3, bundler (>= 1.3), zlib1g-dev,
          ruby2.3-dev, build-essential,
          rake (>=0.8.4), ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug (= ${binary:Version}), python-minimal
-Conflicts: ruby-activerecord-deprecated-finders, ruby-foreman-tasks (<< 0.10.1)
+Conflicts: ruby-activerecord-deprecated-finders, ruby-foreman-tasks (<< 0.10.1), ruby-sequel-pg
 Description: Systems management web interface
  Foreman is aimed to be a single address for all machines life cycle management.
  .

--- a/debian/xenial/foreman/control
+++ b/debian/xenial/foreman/control
@@ -17,7 +17,7 @@ Depends: ruby2.3, bundler (>= 1.3), zlib1g-dev,
          ruby2.3-dev, build-essential,
          rake (>=0.8.4), ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug (= ${binary:Version}), python-minimal
-Conflicts: ruby-activerecord-deprecated-finders, ruby-foreman-tasks (<< 0.10.1)
+Conflicts: ruby-activerecord-deprecated-finders, ruby-foreman-tasks (<< 0.10.1), ruby-sequel-pg
 Description: Systems management web interface
  Foreman is aimed to be a single address for all machines life cycle management.
  .


### PR DESCRIPTION
Don't allow ruby-sequel-pg to be installed that the
db:migrate task can run properly.
