### PR TITLE
Deb/proxy rex 1.5.2

### DIFF
--- a/dependencies/stretch/dynflow/changelog
+++ b/dependencies/stretch/dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-dynflow (1.0.3-1) stable; urgency=low
+
+  * 1.0.3 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Wed, 16 May 2018 12:54:46 +0200
+
 ruby-dynflow (1.0.0-1) stable; urgency=low
 
   * 1.0.0 released

--- a/dependencies/stretch/foreman-tasks-core/changelog
+++ b/dependencies/stretch/foreman-tasks-core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-tasks-core (0.2.5-1) stable; urgency=low
+
+  * 0.2.5 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Wed, 16 May 2018 13:00:03 +0200
+
 ruby-foreman-tasks-core (0.2.4-1) stable; urgency=low
 
   * 0.2.4 released

--- a/dependencies/stretch/foreman_remote_execution_core/changelog
+++ b/dependencies/stretch/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.1.2-1) stable; urgency=low
+
+  * 1.1.2 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Wed, 16 May 2018 13:01:21 +0200
+
 ruby-foreman-remote-execution-core (1.1.1-1) stable; urgency=low
 
   * 1.1.1 released

--- a/dependencies/xenial/dynflow/changelog
+++ b/dependencies/xenial/dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-dynflow (1.0.3-1) stable; urgency=low
+
+  * 1.0.3 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Wed, 16 May 2018 12:54:46 +0200
+
 ruby-dynflow (1.0.0-1) stable; urgency=low
 
   * 1.0.0 released

--- a/dependencies/xenial/foreman-tasks-core/changelog
+++ b/dependencies/xenial/foreman-tasks-core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-tasks-core (0.2.5-1) stable; urgency=low
+
+  * 0.2.5 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Wed, 16 May 2018 13:00:03 +0200
+
 ruby-foreman-tasks-core (0.2.4-1) stable; urgency=low
 
   * 0.2.4 released

--- a/dependencies/xenial/foreman_remote_execution_core/changelog
+++ b/dependencies/xenial/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.1.2-1) stable; urgency=low
+
+  * 1.1.2 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Wed, 16 May 2018 13:01:21 +0200
+
 ruby-foreman-remote-execution-core (1.1.1-1) stable; urgency=low
 
   * 1.1.1 released


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.18
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

Update the proxy rex stack (the foreman part coming in separate PR)