### PR TITLE
fixes #23647 - moves cron jobs to cron.d for greater flexibility

### DIFF
--- a/packages/katello/katello/katello-clean-empty-puppet-environments
+++ b/packages/katello/katello/katello-clean-empty-puppet-environments
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Puppet 4
-[ -d /etc/puppetlabs/code/environments ] &&  find /etc/puppetlabs/code/environments/KT* -maxdepth 0 -type d -empty -delete > /dev/null 2>&1
-
-# Puppet 3
-[ -d /etc/puppet/environments ] && find /etc/puppet/environments/KT* -maxdepth 0 -type d -empty -delete > /dev/null 2>&1

--- a/packages/katello/katello/katello-remove-orphans
+++ b/packages/katello/katello/katello-remove-orphans
@@ -1,4 +1,0 @@
-#!/bin/env bash
-# Script for initiating removal of orphaned content
-
-foreman-rake katello:delete_orphaned_content RAILS_ENV=production >/dev/null 2>&1

--- a/packages/katello/katello/katello-repository-publish-check
+++ b/packages/katello/katello/katello-repository-publish-check
@@ -1,5 +1,0 @@
-#!/bin/env bash
-# Script for checking for any repositories that have not been published since
-#  their last sync, and republishing them
-
-foreman-rake katello:publish_unpublished_repositories RAILS_ENV=production >/dev/null 2>&1

--- a/packages/katello/katello/katello.cron
+++ b/packages/katello/katello/katello.cron
@@ -1,0 +1,14 @@
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+# Script for initiating removal of orphaned content
+00 22 * * 0	root	foreman-rake katello:delete_orphaned_content RAILS_ENV=production >/dev/null 2>&1
+
+# cronjob to clean puppet envs for puppet 4
+15 22 * * 0	root	[ -d /etc/puppetlabs/code/environments ] &&  find /etc/puppetlabs/code/environments/KT* -maxdepth 0 -type d -empty -delete > /dev/null 2>&1
+
+# cronjob to clean puppet envs for puppet 3
+20 22 * * 0	root	[ -d /etc/puppet/environments ] && find /etc/puppet/environments/KT* -maxdepth 0 -type d -empty -delete > /dev/null 2>&1
+
+# Script for publishing unpublished repositories
+* 22 * * *     root    foreman-rake katello:publish_unpublished_repositories RAILS_ENV=production >/dev/null 2>&1

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -16,18 +16,16 @@ URL:        https://theforeman.org/plugins/katello
 Source0:    katello-service.8.asciidoc
 Source1:    katello-debug.sh
 Source2:    katello-remove
-Source3:    katello-remove-orphans
 Source4:    katello-service
 Source6:    katello-restore
 Source7:    katello-backup
 Source8:    katello-service-bash_completion.sh
 Source9:    qpid-core-dump
-Source10:   katello-clean-empty-puppet-environments
 Source11:   katello-change-hostname
-Source12:   katello-repository-publish-check
 Source13:   katello-change-hostname.8.asciidoc
 Source16:   hostname-change.rb
 Source17:   helper.rb
+Source18:   katello.cron
 
 BuildRequires: asciidoc
 BuildRequires: util-linux
@@ -86,11 +84,8 @@ popd
 mkdir -p %{buildroot}/%{_mandir}/man8
 
 #copy cron scripts to be scheduled
-install -d -m0755 %{buildroot}%{_sysconfdir}/cron.weekly
-install -d -m0755 %{buildroot}%{_sysconfdir}/cron.daily
-install -m 755 %{SOURCE3} %{buildroot}%{_sysconfdir}/cron.weekly/katello-remove-orphans
-install -m 755 %{SOURCE10} %{buildroot}%{_sysconfdir}/cron.weekly/katello-clean-empty-puppet-environments
-install -m 755 %{SOURCE12} %{buildroot}%{_sysconfdir}/cron.daily/katello-repository-publish-check
+install -d -m0755 %{buildroot}%{_sysconfdir}/cron.d
+install -m 644 %{SOURCE18} %{buildroot}%{_sysconfdir}/cron.d/katello
 
 # symlink script libraries
 mkdir -p %{buildroot}%{_datarootdir}/katello
@@ -148,9 +143,7 @@ Common runtime components of %{name}
 %{_mandir}/man8/katello-change-hostname.8*
 %{_datarootdir}/katello/hostname-change.rb
 %{_datarootdir}/katello/helper.rb
-%config(missingok) %{_sysconfdir}/cron.weekly/katello-clean-empty-puppet-environments
-%config(missingok) %{_sysconfdir}/cron.weekly/katello-remove-orphans
-%config(missingok) %{_sysconfdir}/cron.daily/katello-repository-publish-check
+%config(missingok) %{_sysconfdir}/cron.d/katello
 
 # ------ Debug ----------------
 %package debug
@@ -187,7 +180,7 @@ Obsoletes: katello-capsule
 Provides a federation of katello services
 
 %files -n foreman-proxy-content
-%config(missingok) %{_sysconfdir}/cron.weekly/katello-clean-empty-puppet-environments
+%config(missingok) %{_sysconfdir}/cron.d/katello
 %{_sbindir}/katello-backup
 %{_sbindir}/katello-restore
 %{_sbindir}/katello-change-hostname


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
`katello-remove-orphans` can interrupt and interfere with creating a good backup. Moving this process into cron.d, along with `katello-clean-empty-puppet-environments` will allow for greater control and flexibility.