### PR TITLE
Fixes #23651 - correct binary dependencies

### DIFF
--- a/plugins/smart_proxy_ansible/changelog
+++ b/plugins/smart_proxy_ansible/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-ansible (2.0.2-2) stable; urgency=low
+
+  * Fix conflicts with ruby-foreman-ansible-core
+
+ -- Maksim Malchuk <maksim.malchuk@gmail.com>  Fri, 18 May 2018 22:39:15 +0300
+
 ruby-smart-proxy-ansible (2.0.2-1) stable; urgency=low
 
   * 2.0.2 released

--- a/plugins/smart_proxy_ansible/control
+++ b/plugins/smart_proxy_ansible/control
@@ -11,7 +11,9 @@ Package: ruby-smart-proxy-ansible
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.11.0~rc3),
-  ruby-foreman-ansible-core (>= 2.0.2), ruby-foreman-ansible-core (<< 3.0.0),
   ruby-smart-proxy-dynflow (>= 0.1.0), ruby-smart-proxy-dynflow (<< 0.2.0),
   ansible (>= 2.2.0)
+Provides: ruby-foreman-ansible-core (= 2.0.2)
+Conflicts: ruby-foreman-ansible-core (>= 2.0.2)
+Replaces: ruby-foreman-ansible-core (>= 2.0.2)
 Description: Ansible support for Foreman smart proxy


### PR DESCRIPTION
Since 2.0.2 version ruby-smart-proxy-ansible package already contains
the foreman_ansible_core gem so it should set correct dependencies
with the ruby-foreman-ansible-core package.

Signed-off-by: Maksim Malchuk <maksim.malchuk@gmail.com>

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
