### PR TITLE
Drop packages from comps not used anymore

### DIFF
--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -12,10 +12,7 @@
       <packagereq type="default">nodejs-react-json-tree</packagereq>
       <packagereq type="default">puppet-foreman_scap_client</packagereq>
       <packagereq type="default">rubygem-algebrick</packagereq>
-      <packagereq type="default">rubygem-apipie-params</packagereq>
       <packagereq type="default">rubygem-chef-api</packagereq>
-      <packagereq type="default">rubygem-concurrent-ruby-edge</packagereq>
-      <packagereq type="default">rubygem-dynflow</packagereq>
       <packagereq type="default">rubygem-faraday</packagereq>
       <packagereq type="default">rubygem-faraday_middleware</packagereq>
       <packagereq type="default">rubygem-fast_gettext</packagereq>
@@ -138,10 +135,7 @@
       -->
       <!--RGD-START-->
       <packagereq type="default">rubygem-algebrick-doc</packagereq>
-      <packagereq type="default">rubygem-apipie-params-doc</packagereq>
       <packagereq type="default">rubygem-chef-api-doc</packagereq>
-      <packagereq type="default">rubygem-concurrent-ruby-edge-doc</packagereq>
-      <packagereq type="default">rubygem-dynflow-doc</packagereq>
       <packagereq type="default">rubygem-faraday-doc</packagereq>
       <packagereq type="default">rubygem-faraday_middleware-doc</packagereq>
       <packagereq type="default">rubygem-fast_gettext-doc</packagereq>


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.17
* [ ] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
