### PR TITLE
Update smart_proxy_ansible to 2.0.3

### DIFF
--- a/plugins/smart_proxy_ansible/ansible.rb
+++ b/plugins/smart_proxy_ansible/ansible.rb
@@ -1,2 +1,1 @@
-gem 'smart_proxy_ansible', '2.0.2'
-gem 'foreman_ansible_core', '>= 2.0.2', '< 3.0.0'
+gem 'smart_proxy_ansible', '2.0.3'

--- a/plugins/smart_proxy_ansible/changelog
+++ b/plugins/smart_proxy_ansible/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-ansible (2.0.3-1) stable; urgency=low
+
+  * 2.0.3 released
+
+ -- Daniel Lobato Garcia <me@daniellobato.me>  Wed, 23 May 2018 17:20:26 +0200
+
 ruby-smart-proxy-ansible (2.0.2-1) stable; urgency=low
 
   * 2.0.2 released

--- a/plugins/smart_proxy_ansible/control
+++ b/plugins/smart_proxy_ansible/control
@@ -11,7 +11,6 @@ Package: ruby-smart-proxy-ansible
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.11.0~rc3),
-  ruby-foreman-ansible-core (>= 2.0.2), ruby-foreman-ansible-core (<< 3.0.0),
   ruby-smart-proxy-dynflow (>= 0.1.0), ruby-smart-proxy-dynflow (<< 0.2.0),
   ansible (>= 2.2.0)
 Description: Ansible support for Foreman smart proxy


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.17
* [x] 1.16
* [ ] 1.15

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

This PR ought to replace https://github.com/theforeman/foreman-packaging/pull/2506 - the dependency has been removed. 