### PR TITLE
Rebuild gettext_i18n_rails_js with Rails 5.1

### DIFF
--- a/packages/foreman/rubygem-gettext_i18n_rails_js/rubygem-gettext_i18n_rails_js.spec
+++ b/packages/foreman/rubygem-gettext_i18n_rails_js/rubygem-gettext_i18n_rails_js.spec
@@ -6,7 +6,7 @@
 Summary: Extends gettext_i18n_rails making your .po files available to client side javascript as JSON
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.3
-Release: 3%{?dist}
+Release: 4%{?dist}
 Group: Development/Languages
 License: MIT
 URL: https://github.com/nubis/gettext_i18n_rails_js
@@ -69,6 +69,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/spec
 
 %changelog
+* Sun Jun 03 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.0.3-4
+- Rebuilt with rails 5.1
+
 * Wed May 04 2016 Dominic Cleal <dominic@cleal.org> 1.0.3-3
 - Use gem_install macro (dominic@cleal.org)
 


### PR DESCRIPTION
This still pulls in Ruby 2.2 and Rails 4.2 while the rest of the stack is 2.4 and 5.1 respectively.