### PR TITLE
Update rubygem-hammer_cli_foreman_remote_execution to 0.1.0

### DIFF
--- a/packages/plugins/rubygem-hammer_cli_foreman_remote_execution/hammer_cli_foreman_remote_execution-0.0.6.gem
+++ b/packages/plugins/rubygem-hammer_cli_foreman_remote_execution/hammer_cli_foreman_remote_execution-0.0.6.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/Kw/Gv/SHA256E-s56832--064d3043c392c1b2d0fdfcfd2ff07d2f3870253e0a9676954b8fd0165c6c9abf.6.gem/SHA256E-s56832--064d3043c392c1b2d0fdfcfd2ff07d2f3870253e0a9676954b8fd0165c6c9abf.6.gem

--- a/packages/plugins/rubygem-hammer_cli_foreman_remote_execution/hammer_cli_foreman_remote_execution-0.1.0.gem
+++ b/packages/plugins/rubygem-hammer_cli_foreman_remote_execution/hammer_cli_foreman_remote_execution-0.1.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/jg/GQ/SHA256E-s131584--8be499dfbfc90538a3a6d2e40fddfb8f2ce914f1543617bffec7262a69d36b68.0.gem/SHA256E-s131584--8be499dfbfc90538a3a6d2e40fddfb8f2ce914f1543617bffec7262a69d36b68.0.gem

--- a/packages/plugins/rubygem-hammer_cli_foreman_remote_execution/rubygem-hammer_cli_foreman_remote_execution.spec
+++ b/packages/plugins/rubygem-hammer_cli_foreman_remote_execution/rubygem-hammer_cli_foreman_remote_execution.spec
@@ -8,8 +8,8 @@
 
 Summary: Foreman Remote Execution commands for Hammer CLI
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 0.0.6
-Release: 2%{?foremandist}%{?dist}
+Version: 0.1.0
+Release: 1%{?foremandist}%{?dist}
 Group: Applications/System
 License: GPLv3
 URL: https://github.com/theforeman/hammer_cli_foreman_remote_execution
@@ -71,6 +71,9 @@ cp -pa .%{gem_instdir}/config/foreman_remote_execution.yml %{buildroot}%{_root_s
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jun 04 2018 Adam Ruzicka <aruzicka@redhat.com> 0.1.0-1
+- Update to 0.1.0
+
 * Tue Jan 09 2018 Eric D. Helms <ericdhelms@gmail.com> 0.0.6-2
 - Bump releases for base foreman plugins packages (ericdhelms@gmail.com)
 - Use HTTPS URLs for github and rubygems (ewoud@kohlvanwijngaarden.nl)


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.18
* [ ] 1.17
* [ ] 1.16

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
