### PR TITLE
Update rubygem-hammer_cli_foreman_remote_execution to 0.1.0

### DIFF
--- a/dependencies/stretch/hammer_cli_foreman_remote_execution/changelog
+++ b/dependencies/stretch/hammer_cli_foreman_remote_execution/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-remote-execution (0.1.0-1) stable; urgency=low
+
+  * 0.1.0 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Mon, 04 Jun 2018 12:17:21 +0200
+
 ruby-hammer-cli-foreman-remote-execution (0.0.6-1) stable; urgency=low
 
   * 0.0.6 released

--- a/dependencies/xenial/hammer_cli_foreman_remote_execution/changelog
+++ b/dependencies/xenial/hammer_cli_foreman_remote_execution/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-remote-execution (0.1.0-1) stable; urgency=low
+
+  * 0.1.0 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Mon, 04 Jun 2018 12:17:21 +0200
+
 ruby-hammer-cli-foreman-remote-execution (0.0.6-1) stable; urgency=low
 
   * 0.0.6 released


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.18
* [ ] 1.17
* [ ] 1.16

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
