### PR TITLE
Rename -nightly releasers to -jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ than mock (above).
 
 Using a local git checkout, change `source_dir` as appropriate:
 
-* Core packages: `obal scratch foreman -e "{'releasers':['koji-foreman-nightly'], 'build_package_tito_releaser_args': ['--arg source_dir=~/foreman']}"`
-* Plugins: `obal scratch rubygem-foreman_bootdisk -e "{'releasers': ['koji-foreman-plugins-nightly']}, 'build_package_tito_releaser_args': ['--arg source_dir=~/foreman_bootdisk']}"`
+* Core packages: `obal scratch foreman -e "{'releasers':['koji-foreman-jenkins'], 'build_package_tito_releaser_args': ['--arg source_dir=~/foreman']}"`
+* Plugins: `obal scratch rubygem-foreman_bootdisk -e "{'releasers': ['koji-foreman-plugins-jenkins']}, 'build_package_tito_releaser_args': ['--arg source_dir=~/foreman_bootdisk']}"`
 * Katello: `obal scratch rubygem-katello -e "{'releasers': ['koji-katello-jenkins'], 'build_package_tito_releaser_args': ['--arg source_dir=~/katello']}"`
 
 ## HOWTO: Add a package
@@ -215,8 +215,12 @@ To find tito build targets do this:
 
     $ tito release -l
     [koji-foreman]
-    [koji-foreman-nightly]
+    [koji-foreman-jenkins]
     [koji-foreman-plugins]
+    [koji-foreman-plugins-jenkins]
+    [koji-katello]
+    [koji-katello-client]
+    [koji-katello-jenkins]
 
 To build a new release package for foreman project for example, do this:
 

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -14,24 +14,24 @@ foreman_packages:
   hosts:
     foreman:
       releasers:
-        - koji-foreman-nightly
+        - koji-foreman-jenkins
       build_package_tito_releaser_args:
         - "--arg jenkins_job=test_develop"
     foreman-bootloaders-redhat: {}
     foreman-installer:
       releasers:
-        - koji-foreman-nightly
+        - koji-foreman-jenkins
       build_package_tito_releaser_args:
         - "--arg jenkins_job=packaging_trigger_installer_develop"
     foreman-proxy:
       releasers:
-        - koji-foreman-nightly
+        - koji-foreman-jenkins
       build_package_tito_releaser_args:
         - "--arg jenkins_job=test_proxy_develop"
     foreman-release-scl: {}
     foreman-selinux:
       releasers:
-        - koji-foreman-nightly
+        - koji-foreman-jenkins
       build_package_tito_releaser_args:
         - "--arg jenkins_job=packaging_trigger_selinux_develop"
     nodejs-axios: {}
@@ -190,12 +190,12 @@ foreman_packages:
     rubygem-gridster-rails: {}
     rubygem-hammer_cli:
       releasers:
-        - koji-foreman-nightly
+        - koji-foreman-jenkins
       build_package_tito_releaser_args:
         - "--arg jenkins_job=test_hammer_cli"
     rubygem-hammer_cli_foreman:
       releasers:
-        - koji-foreman-nightly
+        - koji-foreman-jenkins
       build_package_tito_releaser_args:
         - "--arg jenkins_job=test_hammer_cli_foreman"
     rubygem-hashie: {}

--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -3,7 +3,7 @@
 releaser = tito.release.KojiReleaser
 autobuild_tags = foreman-nightly-nonscl-rhel7 foreman-nightly-rhel7
 
-[koji-foreman-nightly]
+[koji-foreman-jenkins]
 releaser = tito.release.KojiReleaser
 autobuild_tags = foreman-nightly-nonscl-rhel7 foreman-nightly-rhel7
 builder = tito.builder.FetchBuilder
@@ -14,7 +14,7 @@ releaser = tito.release.KojiReleaser
 autobuild_tags = foreman-plugins-nightly-nonscl-rhel7 foreman-plugins-nightly-rhel7
 builder.rpmbuild_options = --define "foremandist .fm1_19"
 
-[koji-foreman-plugins-nightly]
+[koji-foreman-plugins-jenkins]
 releaser = tito.release.KojiReleaser
 autobuild_tags = foreman-plugins-nightly-nonscl-rhel7 foreman-plugins-nightly-rhel7
 builder = tito.builder.FetchBuilder


### PR DESCRIPTION
This is in line with katello and makes the releaser name consistent between various releases. Jenkins is not 100% correct since you can still deploy from local git repos but it's closer than the alternatives.