### PR TITLE
Disable Fedora 28 for katello client repos

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -28,11 +28,11 @@ builder.rpmbuild_options = --define "foremandist .fm1_19"
 
 [koji-katello-client]
 releaser = tito.release.KojiReleaser
-autobuild_tags = katello-nightly-rhel5 katello-nightly-rhel6 katello-nightly-rhel7 katello-nightly-fedora27 katello-nightly-fedora28
+autobuild_tags = katello-nightly-rhel5 katello-nightly-rhel6 katello-nightly-rhel7 katello-nightly-fedora27
 
 [koji-katello-jenkins]
 releaser = tito.release.KojiReleaser
-autobuild_tags = katello-nightly-rhel5 katello-nightly-rhel6 katello-nightly-rhel7 katello-nightly-fedora27 katello-nightly-fedora28
+autobuild_tags = katello-nightly-rhel5 katello-nightly-rhel6 katello-nightly-rhel7 katello-nightly-fedora27
 builder = tito.builder.FetchBuilder
 builder.jenkins_url = http://ci.theforeman.org
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.18
* [ ] 1.17
* [ ] 1.16

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
