### PR TITLE
Fix repoclosure for 1.17

### DIFF
--- a/repoclosure/yum_el7.conf
+++ b/repoclosure/yum_el7.conf
@@ -59,7 +59,7 @@ baseurl=http://yum.theforeman.org/plugins/1.17/el7/x86_64
 
 [el7-foreman-rails-1.17]
 name=Foreman Rails 1.17 EL7
-baseurl=http://yum.theforeman.org/rails/1.17/el7/x86_64
+baseurl=http://yum.theforeman.org/rails/foreman-1.17/el7/x86_64
 
 # Katello repos for lookaside
 [el7-katello-3.6]


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [ ] 1.18
* [x] 1.17
* [ ] 1.16

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
