### PR TITLE
Update Dynflow to 1.0.5

### DIFF
--- a/dependencies/stretch/dynflow/changelog
+++ b/dependencies/stretch/dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-dynflow (1.0.5-1) stable; urgency=low
+
+  * 1.0.5 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Wed, 13 Jun 2018 14:07:36 +0200
+
 ruby-dynflow (1.0.4-1) stable; urgency=low
 
   * 1.0.4 released

--- a/dependencies/xenial/dynflow/changelog
+++ b/dependencies/xenial/dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-dynflow (1.0.5-1) stable; urgency=low
+
+  * 1.0.5 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Wed, 13 Jun 2018 14:07:36 +0200
+
 ruby-dynflow (1.0.4-1) stable; urgency=low
 
   * 1.0.4 released


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.18
* [ ] 1.17
* [ ] 1.16

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
