### PR TITLE
Update rubygem-foreman_ansible_core to 2.1.0

### DIFF
--- a/packages/plugins/rubygem-foreman_ansible_core/foreman_ansible_core-2.0.2.gem
+++ b/packages/plugins/rubygem-foreman_ansible_core/foreman_ansible_core-2.0.2.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/pw/1m/SHA256E-s18944--4faead17ead656446a49318193ee33c0cc280cbdd65793348f7a6e2b9bb5b8ed.2.gem/SHA256E-s18944--4faead17ead656446a49318193ee33c0cc280cbdd65793348f7a6e2b9bb5b8ed.2.gem

--- a/packages/plugins/rubygem-foreman_ansible_core/foreman_ansible_core-2.1.0.gem
+++ b/packages/plugins/rubygem-foreman_ansible_core/foreman_ansible_core-2.1.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/wv/g7/SHA256E-s19456--d0161cd1cc827d2b913df962f456b0a8a6d57a6d0bbbb6536ad2fd0a1de5652d.0.gem/SHA256E-s19456--d0161cd1cc827d2b913df962f456b0a8a6d57a6d0bbbb6536ad2fd0a1de5652d.0.gem

--- a/packages/plugins/rubygem-foreman_ansible_core/rubygem-foreman_ansible_core.spec
+++ b/packages/plugins/rubygem-foreman_ansible_core/rubygem-foreman_ansible_core.spec
@@ -4,7 +4,7 @@
 %global gem_name foreman_ansible_core
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 2.0.2
+Version: 2.1.0
 Release: 1%{?foremandist}%{?dist}
 Summary: Ansible integration with Foreman (theforeman.org): core bits
 Group: Development/Languages
@@ -18,6 +18,8 @@ Requires: %{?scl_prefix}rubygem(foreman-tasks-core) >= 0.1
 Requires: %{?scl_prefix}rubygem(foreman-tasks-core) < 1.0
 Requires: %{?scl_prefix}rubygem(foreman_remote_execution_core) >= 1.1
 Requires: %{?scl_prefix}rubygem(foreman_remote_execution_core) < 2.0
+Requires: %{?scl_prefix}rubygem(net-ssh) >= 4.0
+Requires: %{?scl_prefix}rubygem(net-ssh) < 5.0
 BuildRequires: %{?scl_prefix_ruby}ruby(release)
 BuildRequires: %{?scl_prefix_ruby}ruby
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
@@ -79,6 +81,9 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 %doc %{gem_docdir}
 
 %changelog
+* Fri Jun 15 2018 Daniel Lobato Garcia <me@daniellobato.me> 2.1.0-1
+- Update to 2.1.0
+
 * Fri Feb 02 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 2.0.2-1
 - Bump foreman_ansible_core to 2.0.2 (me@daniellobato.me)
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.18
* [ ] 1.17
* [ ] 1.16

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
