### PR TITLE
Fix Fedora repoclosures

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -385,9 +385,11 @@ katello_client_packages:
       - el5-qpid
       - el5-katello-client-nightly
       - f28-base
+      - f28-updates
       - f28-puppet-5
       - f28-katello-client-nightly
       - f27-base
+      - f27-updates
       - f27-puppet-5
       - f27-katello-client-nightly
   hosts:

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -151,6 +151,12 @@ enabled=1
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-27&arch=x86_64
 failovermethod=priority
 
+[f27-updates]
+name=Updates
+enabled=1
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-27&arch=x86_64
+failovermethod=priority
+
 [f27-puppet-5]
 name=f27-puppet-5
 baseurl=http://yum.puppetlabs.com/puppet5/fedora/27/x86_64/

--- a/repoclosure/yum_f27.conf
+++ b/repoclosure/yum_f27.conf
@@ -17,6 +17,12 @@ enabled=1
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-27&arch=x86_64
 failovermethod=priority
 
+[f27-updates]
+name=Updates
+enabled=1
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-27&arch=x86_64
+failovermethod=priority
+
 [f27-puppet-5]
 name=f27-puppet-5
 baseurl=http://yum.puppetlabs.com/puppet5/fedora/27/x86_64/

--- a/repoclosure/yum_f28.conf
+++ b/repoclosure/yum_f28.conf
@@ -14,13 +14,19 @@ syslog_device=
 [f28-base]
 name=BaseOS
 enabled=1
-mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-26&arch=x86_64
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-28&arch=x86_64
+failovermethod=priority
+
+[f27-updates]
+name=Updates
+enabled=1
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-28&arch=x86_64
 failovermethod=priority
 
 [f28-puppet-5]
 name=f28-puppet-5
-baseurl=http://yum.puppetlabs.com/puppet5/fedora/26/x86_64/
+baseurl=http://yum.puppetlabs.com/puppet5/fedora/28/x86_64/
 
 [f28-katello-client-nightly]
-name=Katello nightly F26
+name=Katello nightly F28
 baseurl=https://fedorapeople.org/groups/katello/releases/yum/nightly/client/f28/x86_64


### PR DESCRIPTION
This defines the Fedora update repos and fixes some copy-paste errors
from f26 -> f28.