### PR TITLE
Update rubygem-rbovirt to 0.1.6

### DIFF
--- a/packages/foreman/rubygem-rbovirt/rbovirt-0.1.5.gem
+++ b/packages/foreman/rubygem-rbovirt/rbovirt-0.1.5.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/Q8/79/SHA256E-s25600--02073b291821aaf68c1fc5b34b0cde34b768b87e985c38bea133dcce89205bcc.5.gem/SHA256E-s25600--02073b291821aaf68c1fc5b34b0cde34b768b87e985c38bea133dcce89205bcc.5.gem

--- a/packages/foreman/rubygem-rbovirt/rbovirt-0.1.6.gem
+++ b/packages/foreman/rubygem-rbovirt/rbovirt-0.1.6.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/7G/Z8/SHA256E-s25600--032ac9edb1aafeaec2ab61b27e9b4dd7b25af4a10f593dd51fe41b1c034ecdc1.6.gem/SHA256E-s25600--032ac9edb1aafeaec2ab61b27e9b4dd7b25af4a10f593dd51fe41b1c034ecdc1.6.gem

--- a/packages/foreman/rubygem-rbovirt/rubygem-rbovirt.spec
+++ b/packages/foreman/rubygem-rbovirt/rubygem-rbovirt.spec
@@ -6,7 +6,7 @@
 Summary: A Ruby client for oVirt REST API
 Name: %{?scl_prefix}rubygem-%{gem_name}
 
-Version: 0.1.5
+Version: 0.1.6
 Release: 1%{?dist}
 Group: Development/Ruby
 License: MIT
@@ -70,6 +70,9 @@ rm -rf %{buildroot}%{gem_instdir}/.yardoc
 %doc %{gem_docdir}
 
 %changelog
+* Tue Jun 19 2018 Ori Rabin <orrabin@gmail.com> 0.1.6-1
+- Update to 0.1.6
+
 * Tue Mar 20 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 0.1.5-1
 - Update to 0.1.5
 


### PR DESCRIPTION
This needs to be also in 1.18 (related to: https://github.com/theforeman/foreman-packaging/pull/2650)