### PR TITLE
Update foreman-docker to 4.1.0

### DIFF
--- a/plugins/ruby-foreman-docker/debian/changelog
+++ b/plugins/ruby-foreman-docker/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-docker (4.1.0-1) stable; urgency=low
+
+  * Update foreman_docker to 4.1.0
+
+ -- Marek Hulan <mhulan@redhat.com>  Thu, 21 Jun 2018 14:03:31 +0200
+
 ruby-foreman-docker (4.0.0-1) stable; urgency=low
 
   * 4.0.0 released

--- a/plugins/ruby-foreman-docker/debian/gem.list
+++ b/plugins/ruby-foreman-docker/debian/gem.list
@@ -1,4 +1,4 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_docker-4.0.0.gem"
+GEMS="https://rubygems.org/downloads/foreman_docker-4.1.0.gem"
 GEMS="$GEMS https://rubygems.org/downloads/docker-api-1.34.0.gem"
 GEMS="$GEMS https://rubygems.org/downloads/wicked-1.3.1.gem"

--- a/plugins/ruby-foreman-docker/foreman_docker.rb
+++ b/plugins/ruby-foreman-docker/foreman_docker.rb
@@ -1,1 +1,1 @@
-gem 'foreman_docker', '4.0.0'
+gem 'foreman_docker', '4.1.0'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.18
* [ ] 1.17
* [ ] 1.16

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

docker has been bumped in RPM (by accident?)  when the template was regenerated in https://github.com/theforeman/foreman-packaging/commit/2f19c395004ab5c01c8dd43fd1c62fe42f62b8be#diff-93dd9b365378866aa3a2eb74ba14ee7b so this PR is to catch up with RPM