### PR TITLE
Update rubygem-fog-ovirt to 1.0.4

### DIFF
--- a/packages/foreman/rubygem-fog-ovirt/fog-ovirt-1.0.3.gem
+++ b/packages/foreman/rubygem-fog-ovirt/fog-ovirt-1.0.3.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/4f/Jk/SHA256E-s34304--afe22e0c6dc4eb4fec9ed9a5182244940b653cddcea46c18778f4b01da0ce093.3.gem/SHA256E-s34304--afe22e0c6dc4eb4fec9ed9a5182244940b653cddcea46c18778f4b01da0ce093.3.gem

--- a/packages/foreman/rubygem-fog-ovirt/fog-ovirt-1.0.4.gem
+++ b/packages/foreman/rubygem-fog-ovirt/fog-ovirt-1.0.4.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/3G/jg/SHA256E-s34304--3b77c1bd50644b84ed79aba4dbbf2d84c8db9904ca0477e4d6e4cb7e060240b0.4.gem/SHA256E-s34304--3b77c1bd50644b84ed79aba4dbbf2d84c8db9904ca0477e4d6e4cb7e060240b0.4.gem

--- a/packages/foreman/rubygem-fog-ovirt/rubygem-fog-ovirt.spec
+++ b/packages/foreman/rubygem-fog-ovirt/rubygem-fog-ovirt.spec
@@ -4,7 +4,7 @@
 %global gem_name fog-ovirt
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 1.0.3
+Version: 1.0.4
 Release: 1%{?dist}
 Summary: Module for the 'fog' gem to support Ovirt
 Group: Development/Languages
@@ -92,6 +92,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/tests
 
 %changelog
+* Thu Jun 14 2018 Ori Rabin <orrabin@gmail.com> 1.0.4-1
+- Update to 1.0.4
+
 * Wed Apr 11 2018 Ori Rabin <orabin@redhat.com> 1.0.3-1
 - Update to 1.0.3
 


### PR DESCRIPTION
(cherry picked from commit ed75d76eb564e27e616d0252601e608ba8ad038f)

For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [x] 1.18
* [ ] 1.17
* [ ] 1.16

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

Already built in nightly.