### PR TITLE
Fix fedora comps for katello client

### DIFF
--- a/comps/comps-katello-client-fedora27.xml
+++ b/comps/comps-katello-client-fedora27.xml
@@ -17,6 +17,9 @@
       <packagereq type="default">katello-host-tools-fact-plugin</packagereq>
       <packagereq type="default">katello-host-tools-tracer</packagereq>
       <packagereq type="default">katello-host-tools</packagereq>
+      <packagereq type="default">python3-gofer</packagereq>
+      <packagereq type="default">python3-gofer-proton</packagereq>
+      <packagereq type="default">python-gofer</packagereq>
     </packagelist>
   </group>
 </comps>

--- a/comps/comps-katello-client-fedora28.xml
+++ b/comps/comps-katello-client-fedora28.xml
@@ -17,6 +17,9 @@
       <packagereq type="default">katello-host-tools-fact-plugin</packagereq>
       <packagereq type="default">katello-host-tools-tracer</packagereq>
       <packagereq type="default">katello-host-tools</packagereq>
+      <packagereq type="default">python3-gofer</packagereq>
+      <packagereq type="default">python3-gofer-proton</packagereq>
+      <packagereq type="default">python-gofer</packagereq>
     </packagelist>
   </group>
 </comps>


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.18
* [ ] 1.17
* [ ] 1.16

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
