### PR TITLE
Katello server requires python-gofer-qpid

### DIFF
--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -25,6 +25,7 @@
       <packagereq type="default">katello-selinux</packagereq>
       <packagereq type="default">katello-service</packagereq>
       <packagereq type="default">katello-utils</packagereq>
+      <packagereq type="default">python-gofer-qpid</packagereq>
       <packagereq type="default">pulp-katello</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_virt_who_configure</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_virt_who_configure</packagereq>


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.18
* [ ] 1.17
* [ ] 1.16

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
