### PR TITLE
Update rubygem-apipie-rails to 0.5.9

### DIFF
--- a/packages/foreman/rubygem-apipie-rails/apipie-rails-0.5.7.gem
+++ b/packages/foreman/rubygem-apipie-rails/apipie-rails-0.5.7.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/zp/jZ/SHA256E-s342016--4fe1289ea5f3959212a3f31a8ac1252feb5d2d90b775db701d9ea09bb081ce4e.7.gem/SHA256E-s342016--4fe1289ea5f3959212a3f31a8ac1252feb5d2d90b775db701d9ea09bb081ce4e.7.gem

--- a/packages/foreman/rubygem-apipie-rails/apipie-rails-0.5.9.gem
+++ b/packages/foreman/rubygem-apipie-rails/apipie-rails-0.5.9.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/XG/2Z/SHA256E-s363520--5669a4ef64fecc4066d27b5b038bf8e8e78816ffdfb3b4c858a91ebf8eb2f080.9.gem/SHA256E-s363520--5669a4ef64fecc4066d27b5b038bf8e8e78816ffdfb3b4c858a91ebf8eb2f080.9.gem

--- a/packages/foreman/rubygem-apipie-rails/rubygem-apipie-rails.spec
+++ b/packages/foreman/rubygem-apipie-rails/rubygem-apipie-rails.spec
@@ -5,7 +5,7 @@
 
 Summary: Rails API documentation tool and client generator
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 0.5.7
+Version: 0.5.9
 Release: 1%{?dist}
 Group: Development/Libraries
 #This gem is released under MIT license. Copy is included in file MIT-LICENSE.
@@ -72,6 +72,7 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/.rspec
 %exclude %{gem_instdir}/.travis.yml
 %exclude %{gem_instdir}/Gemfile*
+%exclude %{gem_instdir}/PROPOSAL_FOR_RESPONSE_DESCRIPTIONS.md
 
 %files doc
 %doc %{gem_docdir}
@@ -84,6 +85,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/%{gem_name}.gemspec
 
 %changelog
+* Fri Jun 29 2018 Andrew Kofink <akofink@redhat.com> 0.5.9-1
+- Update to 0.5.9
+
 * Thu Mar 29 2018 Amit Karsale <karsale.amit@gmail.com> 0.5.7-1
 - Update to 0.5.7
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.18
* [ ] 1.17
* [ ] 1.16

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
