### PR TITLE
Fix linking of webpack assets on debian

### DIFF
--- a/plugins/ruby-foreman-remote-execution/debian/changelog
+++ b/plugins/ruby-foreman-remote-execution/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution (1.5.3-3) stable; urgency=low
+
+  * Fix links to webpack assets 
+
+ -- Tomer Brisker <tbrisker@gmail.com>  Tue, 03 Jul 2018 15:11:04 +0300
+
 ruby-foreman-remote-execution (1.5.3-2) stable; urgency=low
 
   * add precompiled webpack assets

--- a/plugins/ruby-foreman-remote-execution/debian/postinst
+++ b/plugins/ruby-foreman-remote-execution/debian/postinst
@@ -51,6 +51,10 @@ if [ -f /usr/share/foreman/config/database.yml ]; then
   fi
 fi
 
+PLUGIN_ROOT=`$BUNDLE show $PLUGIN`
+mkdir -p $PLUGIN_ROOT/public
+ln -s /var/lib/foreman/public/webpack/ $PLUGIN_ROOT/public/webpack
+
 # Own all the core files
 chown -Rf foreman:foreman '/usr/share/foreman'
 

--- a/plugins/ruby-foreman-remote-execution/debian/rules
+++ b/plugins/ruby-foreman-remote-execution/debian/rules
@@ -24,7 +24,9 @@ build:
 	)
 	GEM_PATH=$$(cd /usr/share/foreman && /usr/bin/foreman-ruby /usr/bin/bundle show $(PLUGIN)) && \
 		cp -rp $${GEM_PATH}/public/assets/ ./ && \
-		cp -rp $${GEM_PATH}/public/webpack ./
+		mkdir ./webpack && \
+		cp -rp $${GEM_PATH}/public/webpack/$(PLUGIN)-* ./webpack/ && \
+		cp -rp $${GEM_PATH}/public/webpack/manifest.json ./webpack/
 	[ -e apipie-cache ] || mkdir apipie-cache/
 	cp -rp /var/lib/foreman/public/apipie-cache/plugin/$(PLUGIN) ./apipie-cache/
 


### PR DESCRIPTION
Also, only package the files we need from the build.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.18
* [ ] 1.17
* [ ] 1.16

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
