### PR TITLE
Update rubygem-redhat_access to 2.1.6

### DIFF
--- a/packages/katello/rubygem-redhat_access/redhat_access-2.1.5.gem
+++ b/packages/katello/rubygem-redhat_access/redhat_access-2.1.5.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/Zf/kJ/SHA256E-s9390592--7444e3a0a69fd501e562ae4a687cb61e5342bdcd171df29e615ebddc58dbbaed.5.gem/SHA256E-s9390592--7444e3a0a69fd501e562ae4a687cb61e5342bdcd171df29e615ebddc58dbbaed.5.gem

--- a/packages/katello/rubygem-redhat_access/redhat_access-2.1.6.gem
+++ b/packages/katello/rubygem-redhat_access/redhat_access-2.1.6.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/Wq/1M/SHA256E-s6230016--e6adeb5ff584b2bf5a7c7c6b9651b3685299da277da099c3dcb490ceffd87ed1.6.gem/SHA256E-s6230016--e6adeb5ff584b2bf5a7c7c6b9651b3685299da277da099c3dcb490ceffd87ed1.6.gem

--- a/packages/katello/rubygem-redhat_access/rubygem-redhat_access.spec
+++ b/packages/katello/rubygem-redhat_access/rubygem-redhat_access.spec
@@ -5,7 +5,7 @@
 %global plugin_name redhat_access
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 2.1.5
+Version: 2.1.6
 Release: 1%{?foremandist}%{?dist}
 Summary: Plugin to add Redhat Access to Foreman
 Group: Applications/Systems
@@ -120,6 +120,9 @@ cp -pa $RPM_BUILD_DIR/%{gem_name}-%{version}/config/config.yml.example %{buildro
 exit 0
 
 %changelog
+* Wed Jul 04 2018 Marek Hulan <mhulan@redhat.com> 2.1.6-1
+- Update to 2.1.6
+
 * Tue Jun 12 2018 Marek Hulan <mhulan@redhat.com> 2.1.5-1
 - Update to 2.1.5
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.18 / Katello 3.7 (this is katello plugin)
* [ ] 1.17
* [ ] 1.16

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
