### PR TITLE
Fixes #24213 - Upgrade fog-vsphere gem version to 2.3.0

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -579,7 +579,7 @@ Meta package to install requirements for Rackspace compute resource support.
 Summary: Foreman VMware support
 Group:  Applications/System
 # start specfile vmware Requires
-Requires: %{?scl_prefix}rubygem(fog-vsphere) >= 2.1.1
+Requires: %{?scl_prefix}rubygem(fog-vsphere) >= 2.3.0
 Requires: %{?scl_prefix}rubygem(rbvmomi) >= 1.9.0
 # end specfile vmware Requires
 Requires: %{name} = %{version}-%{release}


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.18
* [ ] 1.17
* [ ] 1.16

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
