### PR TITLE
[WIP] Rebuild rubygem-foreman_ansible

### DIFF
--- a/packages/plugins/rubygem-foreman_ansible/rubygem-foreman_ansible.spec
+++ b/packages/plugins/rubygem-foreman_ansible/rubygem-foreman_ansible.spec
@@ -7,7 +7,7 @@
 Summary: Ansible integration with Foreman (theforeman.org)
 Name:    %{?scl_prefix}rubygem-%{gem_name}
 Version: 2.2.3
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Group:   Applications/System
 License: GPLv3
 URL:     https://github.com/theforeman/foreman_ansible
@@ -111,6 +111,9 @@ exit 0
 
 
 %changelog
+* Tue Jul 17 2018 Adam Ruzicka <aruzicka@redhat.com> 2.2.3-2
+- Rebuild to 2.2.3-2
+
 * Fri Jul 13 2018 Marek Hulan <mhulan@redhat.com> 2.2.3-1
 - Update to 2.2.3
 


### PR DESCRIPTION
On nightly installed today I'm getting `Component not found: ReportJsonViewer` when looking at ansible's config reports. Trying to rebuild the package to see if it fixes things

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
