### PR TITLE
Fixes #24312 - Remove Pulp Resource Manager Qpid command.

### DIFF
--- a/packages/katello/katello/katello-debug.sh
+++ b/packages/katello/katello/katello-debug.sh
@@ -82,7 +82,6 @@ fi
 add_cmd "qpid-stat -q --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671" "qpid-stat-q"
 add_cmd "qpid-stat -u --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671" "qpid-stat-u"
 add_cmd "qpid-stat -c --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671" "qpid-stat-c"
-add_cmd "qpid-stat --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt  -b amqps://localhost:5671 -q resource_manager" "qpid-stat-resource_manager"
 add_cmd "ps -awfux" "ps-awfux"
 add_cmd "ps -efLm" "ps-elfm"
 

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -3,7 +3,7 @@
 
 %global homedir %{_datarootdir}/%{name}
 %global confdir common
-%global release 1.nightly
+%global release 2.nightly
 
 Name:       katello
 Version:    3.9.0
@@ -203,6 +203,9 @@ Useful utilities for managing Katello services
 %{_sysconfdir}/bash_completion.d/katello-service
 
 %changelog
+* Thu Jul 19 2018 Chris Roberts <chrobert@redhat.com> - 3.9.0-2.nightly
+- Updated katello-debug to remove qpid resource mgr command
+
 * Wed Jul 18 2018 Eric D. Helms <ericdhelms@gmail.com> 3.9.0-1.nightly
 - Bump to 3.9
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
