### PR TITLE
katello-host-tools 3.3.3

### DIFF
--- a/packages/katello/katello-host-tools/katello-host-tools-3.3.2.tar.gz
+++ b/packages/katello/katello-host-tools/katello-host-tools-3.3.2.tar.gz
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/Jz/2G/SHA256E-s33787--7f0c0731f89fdbf03e232d09d2bd569fd5d626e501ad7cb7fedf3dd0d8e7515d.tar.gz/SHA256E-s33787--7f0c0731f89fdbf03e232d09d2bd569fd5d626e501ad7cb7fedf3dd0d8e7515d.tar.gz

--- a/packages/katello/katello-host-tools/katello-host-tools-3.3.3.tar.gz
+++ b/packages/katello/katello-host-tools/katello-host-tools-3.3.3.tar.gz
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/2Q/5p/SHA256E-s33856--44f517abffde7f0ad714ef013281fc85c1bace92352b5ea8603759e3d6e972be.tar.gz/SHA256E-s33856--44f517abffde7f0ad714ef013281fc85c1bace92352b5ea8603759e3d6e972be.tar.gz

--- a/packages/katello/katello-host-tools/katello-host-tools.spec
+++ b/packages/katello/katello-host-tools/katello-host-tools.spec
@@ -14,8 +14,8 @@
 %endif
 
 Name: katello-host-tools
-Version: 3.3.2
-Release: 2%{?dist}
+Version: 3.3.3
+Release: 1%{?dist}
 Summary: A set of commands and yum plugins that support a Katello host
 Group:   Development/Languages
 License: LGPLv2
@@ -358,6 +358,9 @@ exit 0
 %endif #build_tracer
 
 %changelog
+* Fri Jul 20 2018 Jonathon Turel <jturel@gmail.com> - 3.3.3-1
+- Fixes #24270: Handle server errors
+
 * Tue Jul 17 2018 Jonathon Turel <jturel@gmail.com> - 3.3.2-2
 - Fix obsoletes
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.19
* [x] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
