### PR TITLE
Point repoclosure to releases/nightly

### DIFF
--- a/repoclosure/yum_el7.conf
+++ b/repoclosure/yum_el7.conf
@@ -55,7 +55,7 @@ baseurl=https://yum.theforeman.org/rails/foreman-nightly/el7/x86_64
 # Used as lookaside repos for layered repos (plugins)
 [el7-foreman-nightly]
 name=Foreman nightly EL7
-baseurl=https://yum.theforeman.org/nightly/el7/x86_64
+baseurl=https://yum.theforeman.org/releases/nightly/el7/x86_64
 
 [el7-foreman-plugins-nightly]
 name=Foreman Plugins nightly EL7


### PR DESCRIPTION
This is no difference for nightly because of the symlink on the webserver but prepares for an actual release.

This should prevent a0dbb84eb68862e31faa64e79ae33ef3ab49ba66 and a similar PR to 1.19.