### PR TITLE
Release katello-host-tools-3.3.4

### DIFF
--- a/packages/katello/katello-host-tools/katello-host-tools-3.3.3.tar.gz
+++ b/packages/katello/katello-host-tools/katello-host-tools-3.3.3.tar.gz
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/2Q/5p/SHA256E-s33856--44f517abffde7f0ad714ef013281fc85c1bace92352b5ea8603759e3d6e972be.tar.gz/SHA256E-s33856--44f517abffde7f0ad714ef013281fc85c1bace92352b5ea8603759e3d6e972be.tar.gz

--- a/packages/katello/katello-host-tools/katello-host-tools-3.3.4.tar.gz
+++ b/packages/katello/katello-host-tools/katello-host-tools-3.3.4.tar.gz
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/Gm/5q/SHA256E-s34255--e9e4824c96e68e6c4ab0691033b2d382729ff73eff31ad2d3d6c6332d60cde0c.tar.gz/SHA256E-s34255--e9e4824c96e68e6c4ab0691033b2d382729ff73eff31ad2d3d6c6332d60cde0c.tar.gz

--- a/packages/katello/katello-host-tools/katello-host-tools.spec
+++ b/packages/katello/katello-host-tools/katello-host-tools.spec
@@ -14,7 +14,7 @@
 %endif
 
 Name: katello-host-tools
-Version: 3.3.3
+Version: 3.3.4
 Release: 1%{?dist}
 Summary: A set of commands and yum plugins that support a Katello host
 Group:   Development/Languages
@@ -358,6 +358,9 @@ exit 0
 %endif #build_tracer
 
 %changelog
+* Mon Jul 23 2018 Jonathon Turel <jturel@gmail.com> - 3.3.4-1
+- Fixes #24353 - handle update all packages
+
 * Fri Jul 20 2018 Jonathon Turel <jturel@gmail.com> - 3.3.3-1
 - Fixes #24270: Handle server errors
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.19
* [x] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
