### PR TITLE
Add nightly back to katello-repos

### DIFF
--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -16,8 +16,8 @@
 %define repo_dist %{dist}
 %endif
 
-# %%global prerelease .rc1
-%global release 2
+%global prerelease .nightly
+%global release 3
 
 Name:           katello-repos
 Version:        3.9.0
@@ -112,6 +112,9 @@ rm -rf %{buildroot}
 %endif
 
 %changelog
+* Wed Jul 25 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.9.0-0.3.nightly
+- Add nightly back to release
+
 * Tue Jul 24 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.9.0-2
 - Add prerelease macro support
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
