### PR TITLE
Put python-gofer-qpid back in katello server comps

### DIFF
--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -26,6 +26,7 @@
       <packagereq type="default">katello-service</packagereq>
       <packagereq type="default">katello-utils</packagereq>
       <packagereq type="default">python-gofer</packagereq>
+      <packagereq type="default">python-gofer-qpid</packagereq>
       <packagereq type="default">pulp-katello</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_virt_who_configure</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_virt_who_configure</packagereq>

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -4,7 +4,7 @@
 %global homedir %{_datarootdir}/%{name}
 %global confdir common
 # %%global prerelease .rc1
-%global release 4
+%global release 5
 
 Name:       katello
 Version:    3.9.0
@@ -63,8 +63,6 @@ Requires: java-openjdk < 1:1.8.0.45
 Requires: /usr/bin/psql
 Requires: /usr/bin/pg_dump
 Requires: /usr/bin/pg_dumpall
-
-Obsoletes: python-gofer-qpid < 2.8
 
 %description
 Provides a package for managing application life-cycle for Linux systems.
@@ -206,6 +204,9 @@ Useful utilities for managing Katello services
 %{_sysconfdir}/bash_completion.d/katello-service
 
 %changelog
+* Wed Jul 25 2018 Jonathon Turel <jturel@gmail.com> - 3.9.0-5
+- Obsolete the python-gofer-qpid obsolete
+
 * Wed Jul 25 2018 Jonathon Turel <jturel@gmail.com> - 3.9.0-4
 - Obsolete python-gofer-qpid
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.19
* [x] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
