### PR TITLE
Fixes #24422 - k-c-h Check hostname is not current hostname

### DIFF
--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -77,6 +77,11 @@ module KatelloUtilities
         self.fail_with_message("Please specify a hostname.", @opt_parser)
       end
 
+      if @old_hostname == @new_hostname
+        self.fail_with_message("The hostname specified must be different from the current hostname. If you have changed the hostname" \
+                              " with another utility, please change it back to the original hostname before running this tool.")
+      end
+
       STDOUT.puts "\nChecking hostname validity"
       # This regex is an approximation of a hostname, it will handle most invalid hostnames and typos.
       # Taken from https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9781449327453/ch08s15.html
@@ -252,10 +257,10 @@ module KatelloUtilities
         fpc_installer_args = self.get_fpc_answers
       end
 
-      self.precheck
-
       # Get the hostname from your system
       @old_hostname = self.get_hostname
+
+      self.precheck
 
       unless @foreman_proxy_content
         STDOUT.puts "\nUpdating default #{@proxy}"

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -4,7 +4,7 @@
 %global homedir %{_datarootdir}/%{name}
 %global confdir common
 # %%global prerelease .rc1
-%global release 5
+%global release 6
 
 Name:       katello
 Version:    3.9.0
@@ -204,6 +204,9 @@ Useful utilities for managing Katello services
 %{_sysconfdir}/bash_completion.d/katello-service
 
 %changelog
+* Mon Jul 30 2018 John Mitsch <jomitsch@redhat.com> - 3.9.0-6
+- k-c-h Check hostname is not current hostname
+
 * Wed Jul 25 2018 Jonathon Turel <jturel@gmail.com> - 3.9.0-5
 - Obsolete the python-gofer-qpid obsolete
 


### PR DESCRIPTION
For katello-change-hostname, often times users will use
hostnamectl to change the hostname before running k-c-h.
This causes the script to error out and leaves things in
a bad state. This commit adds a check that the hostname
specified is different than the current system's hostname.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
