### PR TITLE
Enable Fedora 28 builds for katello client

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -28,11 +28,11 @@ builder.rpmbuild_options = --define "foremandist .fm1_20"
 
 [koji-katello-client]
 releaser = tito.release.KojiReleaser
-autobuild_tags = katello-nightly-rhel5 katello-nightly-rhel6 katello-nightly-rhel7 katello-nightly-fedora27
+autobuild_tags = katello-nightly-rhel5 katello-nightly-rhel6 katello-nightly-rhel7 katello-nightly-fedora27 katello-nightly-fedora28
 
 [koji-katello-jenkins]
 releaser = tito.release.KojiReleaser
-autobuild_tags = katello-nightly-rhel5 katello-nightly-rhel6 katello-nightly-rhel7 katello-nightly-fedora27
+autobuild_tags = katello-nightly-rhel5 katello-nightly-rhel6 katello-nightly-rhel7 katello-nightly-fedora27 katello-nightly-fedora28
 builder = tito.builder.FetchBuilder
 builder.jenkins_url = http://ci.theforeman.org
 

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -164,3 +164,23 @@ baseurl=http://yum.puppetlabs.com/puppet5/fedora/27/x86_64/
 [f27-katello-client-nightly]
 name=Katello nightly F27
 baseurl=https://fedorapeople.org/groups/katello/releases/yum/nightly/client/f27/x86_64
+
+[f28-base]
+name=BaseOS
+enabled=1
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-28&arch=x86_64
+failovermethod=priority
+
+[f28-updates]
+name=Updates
+enabled=1
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f28&arch=x86_64
+failovermethod=priority
+
+[f28-puppet-5]
+name=f28-puppet-5
+baseurl=http://yum.puppetlabs.com/puppet5/fedora/28/x86_64/
+
+[f28-katello-client-nightly]
+name=Katello nightly F28
+baseurl=https://fedorapeople.org/groups/katello/releases/yum/nightly/client/f28/x86_64


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
