### PR TITLE
Blacklist highlight.js npm package

### DIFF
--- a/update-requirements
+++ b/update-requirements
@@ -11,6 +11,7 @@ NPM_BLACKLIST = [
     'babel-eslint',
     'babel-jest',
     'coveralls',
+    'highlight.js',
     'jest',
     'jest-cli',
     'prettier',


### PR DESCRIPTION
It's used only in storybooks: https://github.com/theforeman/foreman/pull/5883

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

