### PR TITLE
Add fast_gettext back to foreman-plugins

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -431,6 +431,7 @@ plugins_packages:
     rubygem-deface: {}
     rubygem-diffy: {}
     rubygem-docker-api: {}
+    rubygem-fast_gettext: {}
     rubygem-faraday_middleware: {}
     rubygem-ffi: {}
     rubygem-foreman-tasks-core: {}

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -290,6 +290,7 @@ whitelist = rubygem-angular-rails-templates
   rubygem-diffy
   rubygem-docker-api
   rubygem-faraday_middleware
+  rubygem-fast_gettext
   rubygem-ffi
   rubygem-foreman_ansible
   rubygem-foreman_ansible_core


### PR DESCRIPTION
It was there, but it was removed some time ago. It is already present in
compose XML. I hope this is all I need, Jenkins will hopefully tell.

* [x] Nightly
* [x] 1.19