### PR TITLE
Update foreman_remote_execution to 1.5.5

### DIFF
--- a/plugins/ruby-foreman-remote-execution/debian/changelog
+++ b/plugins/ruby-foreman-remote-execution/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution (1.5.5-1) stable; urgency=low
+
+  * 1.5.5 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Tue, 14 Aug 2018 10:45:42 +0200
+
 ruby-foreman-remote-execution (1.5.4-3) stable; urgency=low
 
   * Change webpack link creation to use -nf

--- a/plugins/ruby-foreman-remote-execution/debian/gem.list
+++ b/plugins/ruby-foreman-remote-execution/debian/gem.list
@@ -1,3 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.5.4.gem"
+GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.5.5.gem"
 GEMS="$GEMS https://rubygems.org/downloads/foreman_remote_execution_core-1.1.3.gem"

--- a/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
+++ b/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
@@ -1,1 +1,1 @@
-gem 'foreman_remote_execution', '1.5.4'
+gem 'foreman_remote_execution', '1.5.5'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [x] 1.19
* [x] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
