### PR TITLE
Update foreman_remote_execution to 1.6.1

### DIFF
--- a/plugins/ruby-foreman-remote-execution/debian/changelog
+++ b/plugins/ruby-foreman-remote-execution/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution (1.6.1-1) stable; urgency=low
+
+  * 1.6.1 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Tue, 14 Aug 2018 10:38:46 +0200
+
 ruby-foreman-remote-execution (1.5.5-1) stable; urgency=low
 
   * 1.5.5 released

--- a/plugins/ruby-foreman-remote-execution/debian/control
+++ b/plugins/ruby-foreman-remote-execution/debian/control
@@ -2,14 +2,14 @@ Source: ruby-foreman-remote-execution
 Section: ruby
 Priority: extra
 Maintainer: Stephen Benjamin <stephen@redhat.com>
-Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.20.0), foreman (>= 1.20.0),
-  foreman-sqlite3 (>= 1.20.0), ruby-foreman-tasks (>= 0.12.0), ruby-foreman-deface
+Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.20.0~rc1), foreman (>= 1.20.0~rc1),
+  foreman-sqlite3 (>= 1.20.0~rc1), ruby-foreman-tasks (>= 0.12.0), ruby-foreman-deface
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_remote_execution
 
 Package: ruby-foreman-remote-execution
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.20.0), ruby-foreman-tasks (>= 0.12.0),
+Depends: ${misc:Depends}, bundler, foreman (>= 1.20.0~rc1), ruby-foreman-tasks (>= 0.12.0),
   ruby-foreman-deface
 Description: Foreman Remote Execution Plugin
   A plugin bringing remote execution to the Foreman, completing the config management functionality with remote management functionality

--- a/plugins/ruby-foreman-remote-execution/debian/control
+++ b/plugins/ruby-foreman-remote-execution/debian/control
@@ -2,14 +2,14 @@ Source: ruby-foreman-remote-execution
 Section: ruby
 Priority: extra
 Maintainer: Stephen Benjamin <stephen@redhat.com>
-Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.18.0~rc2), foreman (>= 1.18.0~rc2),
-  foreman-sqlite3 (>= 1.18.0~rc2), ruby-foreman-tasks (>= 0.12.0), ruby-foreman-deface
+Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.20.0), foreman (>= 1.20.0),
+  foreman-sqlite3 (>= 1.20.0), ruby-foreman-tasks (>= 0.12.0), ruby-foreman-deface
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_remote_execution
 
 Package: ruby-foreman-remote-execution
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.18.0~rc2), ruby-foreman-tasks (>= 0.12.0),
+Depends: ${misc:Depends}, bundler, foreman (>= 1.20.0), ruby-foreman-tasks (>= 0.12.0),
   ruby-foreman-deface
 Description: Foreman Remote Execution Plugin
   A plugin bringing remote execution to the Foreman, completing the config management functionality with remote management functionality

--- a/plugins/ruby-foreman-remote-execution/debian/gem.list
+++ b/plugins/ruby-foreman-remote-execution/debian/gem.list
@@ -1,3 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.5.5.gem"
+GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.6.1.gem"
 GEMS="$GEMS https://rubygems.org/downloads/foreman_remote_execution_core-1.1.3.gem"

--- a/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
+++ b/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
@@ -1,1 +1,1 @@
-gem 'foreman_remote_execution', '1.5.5'
+gem 'foreman_remote_execution', '1.6.1'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
