### PR TITLE
Add rubygem-fast_gettext to plugins nonscl

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -180,7 +180,10 @@ foreman_packages:
     rubygem-extlib: {}
     rubygem-facter: {}
     rubygem-faraday: {}
-    rubygem-fast_gettext: {}
+    rubygem-fast_gettext:
+      releasers:
+        - koji-foreman
+        - koji-foreman-plugins
     rubygem-fog-aws: {}
     rubygem-fog-core: {}
     rubygem-fog-digitalocean: {}

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -371,6 +371,7 @@ whitelist = ansiblerole-insights-client
   rubygem-chef-api
   rubygem-faraday
   rubygem-faraday_middleware
+  rubygem-fast_gettext
   rubygem-foreman_scap_client
   rubygem-infoblox
   rubygem-logify


### PR DESCRIPTION
This package is used by foreman-discovery-image.