### PR TITLE
Remove extra package http-parser

### DIFF
--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -35,8 +35,6 @@
       <packagereq type="default">foreman-sqlite</packagereq>
       <packagereq type="default">foreman-telemetry</packagereq>
       <packagereq type="default">foreman-vmware</packagereq>
-      <packagereq type="default">http-parser</packagereq>
-      <packagereq type="default">http-parser-devel</packagereq>
       <packagereq type="default">rubygem-foreman_maintain</packagereq>
       <packagereq type="default">tfm</packagereq>
       <packagereq type="default">tfm-build</packagereq>

--- a/extras/extras-foreman-rhel7-x86_64
+++ b/extras/extras-foreman-rhel7-x86_64
@@ -1,4 +1,2 @@
 http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-2-2.el7.centos.noarch.rpm
 http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-rh-2-2.el7.centos.noarch.rpm
-https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
-https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-devel-2.7.1-3.el7.x86_64.rpm


### PR DESCRIPTION
This was pulled in from EPEL because of a past issue when it wasn't available yet. Now that an even newer version is in EPEL this workaround is no longer needed.