### PR TITLE
Remove the dependency on SCLo

### DIFF
--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -7,7 +7,6 @@
     <description>Packages for the Foreman</description>
     <uservisible>true</uservisible>
     <packagelist>
-      <packagereq type="default">centos-release-scl</packagereq>
       <packagereq type="default">centos-release-scl-rh</packagereq>
       <packagereq type="default">foreman</packagereq>
       <packagereq type="default">foreman-assets</packagereq>

--- a/extras/extras-foreman-rhel7-x86_64
+++ b/extras/extras-foreman-rhel7-x86_64
@@ -1,2 +1,1 @@
-http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-2-2.el7.centos.noarch.rpm
 http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-rh-2-2.el7.centos.noarch.rpm

--- a/mock/el7-scl.cfg
+++ b/mock/el7-scl.cfg
@@ -47,10 +47,6 @@ failovermethod=priority
 name=sclo-rh
 baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/rh/
 
-[sclo-sclo]
-name=sclo-sclo
-baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/sclo/
-
 [foreman]
 name=foreman
 baseurl=https://yum.theforeman.org/nightly/el7/x86_64/

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -23,7 +23,6 @@ foreman_packages:
       - el7-epel
       - el7-extras
       - el7-scl
-      - el7-scl-sclo
       - el7-puppet-5
       - el7-foreman-rails-nightly
       - el7-foreman-nightly
@@ -360,7 +359,6 @@ katello_packages:
       - el7-epel
       - el7-extras
       - el7-scl
-      - el7-scl-sclo
       - el7-puppet-5
       - el7-foreman-rails-nightly
       - el7-foreman-nightly
@@ -472,7 +470,6 @@ plugins_packages:
       - el7-epel
       - el7-extras
       - el7-scl
-      - el7-scl-sclo
       - el7-puppet-5
       - el7-foreman-rails-nightly
       - el7-foreman-nightly
@@ -606,7 +603,6 @@ repoclosures:
         - el7-epel
         - el7-extras
         - el7-scl
-        - el7-scl-sclo
         - el7-puppet-5
         - el7-foreman-rails-nightly
     plugins-repoclosure-el7:
@@ -617,7 +613,6 @@ repoclosures:
         - el7-epel
         - el7-extras
         - el7-scl
-        - el7-scl-sclo
         - el7-puppet-5
         - el7-foreman-rails-nightly
         - el7-foreman-nightly
@@ -629,7 +624,6 @@ repoclosures:
         - el7-epel
         - el7-extras
         - el7-scl
-        - el7-scl-sclo
         - el7-puppet-5
         - el7-foreman-rails-nightly
         - el7-foreman-nightly

--- a/packages/foreman/foreman-release-scl/foreman-release-scl.spec
+++ b/packages/foreman/foreman-release-scl/foreman-release-scl.spec
@@ -1,6 +1,6 @@
 Name:     foreman-release-scl
 Version:  7
-Release:  1%{?dist}
+Release:  2%{?dist}
 
 Summary:  Foreman Software Collections repositories meta-package
 Group:    Applications/System
@@ -9,7 +9,7 @@ URL:      https://theforeman.org
 
 BuildArch: noarch
 
-Requires: centos-release-scl
+Requires: centos-release-scl-rh
 
 %description
 Software Collection repositories provide additional sets of software packages,
@@ -28,6 +28,9 @@ Enterprise Linux rebuilds, such as CentOS.
 %files
 
 %changelog
+* Tue Aug 21 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 7-2
+- Switch dependency to centos-release-scl-rh
+
 * Wed Aug 01 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 7-1
 - Move the foreman-rails repository definition from foreman-release-scl to foreman-release
 

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -36,10 +36,6 @@ failovermethod=priority
 name=el7-scl
 baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/rh/
 
-[el7-scl-sclo]
-name=el7-scl-sclo
-baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/sclo/
-
 [el7-puppet-4]
 name=el7-puppet-4
 baseurl=https://yum.puppetlabs.com/el/7/PC1/x86_64/

--- a/repoclosure/yum_el7.conf
+++ b/repoclosure/yum_el7.conf
@@ -36,10 +36,6 @@ failovermethod=priority
 name=el7-scl
 baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/rh/
 
-[el7-scl-sclo]
-name=el7-scl-sclo
-baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/sclo/
-
 [el7-puppet-4]
 name=el7-puppet-4
 baseurl=https://yum.puppetlabs.com/el/7/PC1/x86_64/


### PR DESCRIPTION
We used to depend on SCLo for sclo-ror42 but we've now moved to tfm-ror*
so we can depend only on sclo-rh which includes rh-ruby24 which we
depend on. This is not a hard dependency because RHEL users can use the
Ruby SCL from another repository.