### PR TITLE
Fix dynflow dependency for ansible proxy

### DIFF
--- a/plugins/smart_proxy_ansible/changelog
+++ b/plugins/smart_proxy_ansible/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-ansible (2.0.3-2) stable; urgency=low
+
+  * Fix smart-proxy-dynflow dependency
+
+ -- Ondrej Prazak <oprazak@redhat.com>  Thu, 23 May 2018 14:02:37 +0200
+
 ruby-smart-proxy-ansible (2.0.3-1) stable; urgency=low
 
   * 2.0.3 released

--- a/plugins/smart_proxy_ansible/control
+++ b/plugins/smart_proxy_ansible/control
@@ -11,6 +11,6 @@ Package: ruby-smart-proxy-ansible
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.11.0~rc3),
-  ruby-smart-proxy-dynflow (>= 0.1.0), ruby-smart-proxy-dynflow (<< 0.2.0),
+  ruby-smart-proxy-dynflow (>= 0.1.0), ruby-smart-proxy-dynflow (<< 1.0.0),
   ansible (>= 2.2.0)
 Description: Ansible support for Foreman smart proxy


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.19
* [x] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
