### PR TITLE
Build hammer using the regular releaser

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -211,15 +211,9 @@ foreman_packages:
     rubygem-google-api-client: {}
     rubygem-gridster-rails: {}
     rubygem-hammer_cli:
-      releasers:
-        - "{{ nightly_releaser }}"
-      build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
       nightly_package_tito_releaser_args:
         - "--arg jenkins_job=test_hammer_cli"
     rubygem-hammer_cli_foreman:
-      releasers:
-        - "{{ nightly_releaser }}"
-      build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
       nightly_package_tito_releaser_args:
         - "--arg jenkins_job=test_hammer_cli_foreman"
     rubygem-hashie: {}


### PR DESCRIPTION
This allows us to properly release hammer while still building nightly packages.