### PR TITLE
katello-host-tools 3.3.5 release

### DIFF
--- a/packages/katello/katello-host-tools/katello-host-tools-3.3.4.tar.gz
+++ b/packages/katello/katello-host-tools/katello-host-tools-3.3.4.tar.gz
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/Gm/5q/SHA256E-s34255--e9e4824c96e68e6c4ab0691033b2d382729ff73eff31ad2d3d6c6332d60cde0c.tar.gz/SHA256E-s34255--e9e4824c96e68e6c4ab0691033b2d382729ff73eff31ad2d3d6c6332d60cde0c.tar.gz

--- a/packages/katello/katello-host-tools/katello-host-tools-3.3.5.tar.gz
+++ b/packages/katello/katello-host-tools/katello-host-tools-3.3.5.tar.gz
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/1x/W0/SHA256E-s35313--9acf1bdb94a858424f81cd10724b6c2ace615e1e08830899dad86f30455af6da.tar.gz/SHA256E-s35313--9acf1bdb94a858424f81cd10724b6c2ace615e1e08830899dad86f30455af6da.tar.gz

--- a/packages/katello/katello-host-tools/katello-host-tools.spec
+++ b/packages/katello/katello-host-tools/katello-host-tools.spec
@@ -14,7 +14,7 @@
 %endif
 
 Name: katello-host-tools
-Version: 3.3.4
+Version: 3.3.5
 Release: 1%{?dist}
 Summary: A set of commands and yum plugins that support a Katello host
 Group:   Development/Languages
@@ -358,6 +358,11 @@ exit 0
 %endif #build_tracer
 
 %changelog
+* Wed Aug 29 2018 Jonathon Turel <jturel@gmail.com> - 3.3.5-1
+- Fixes #24500 - prevent exceptions through registerCommand
+- Remove old makefile syntax from readme
+- Add a readme, makefile help, other small fixes
+
 * Mon Jul 23 2018 Jonathon Turel <jturel@gmail.com> - 3.3.4-1
 - Fixes #24353 - handle update all packages
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
