### PR TITLE
Require current selinux policy in foreman-selinux

### DIFF
--- a/packages/foreman/foreman-selinux/foreman-selinux.spec
+++ b/packages/foreman/foreman-selinux/foreman-selinux.spec
@@ -18,19 +18,11 @@
 
 %define selinux_variants targeted
 %define selinux_modules foreman foreman-proxy
-
-%if 0%{?rhel} == 5
-# absolute minimum versions for RHEL 5
-%define selinux_policy_ver 3.11.1-81
-%else
-# absolute minimum versions for RHEL 6
-%define selinux_policy_ver 2.4.6-80
-%endif
-%define selinux_policycoreutils_ver 1.33.12-1
+%global selinux_policy_ver %(rpm --qf "%%{version}-%%{release}" -q selinux-policy)
 
 %define moduletype apps
 
-%global release 1
+%global release 2
 %global prerelease develop
 
 Name:           foreman-selinux
@@ -44,7 +36,7 @@ URL:            https://theforeman.org
 Source0:        https://downloads.theforeman.org/%{name}/%{name}-%{version}%{?prerelease:-}%{?prerelease}.tar.bz2
 
 BuildRequires:  checkpolicy, selinux-policy-devel, hardlink
-BuildRequires:  policycoreutils >= %{selinux_policycoreutils_ver}
+BuildRequires:  policycoreutils
 BuildRequires:  /usr/bin/pod2man
 BuildArch:      noarch
 
@@ -173,6 +165,9 @@ fi
 %{_mandir}/man8/foreman-proxy-selinux-relabel.8.gz
 
 %changelog
+* Wed Sep 05 2018 Lukas Zapletal <lzap+rpm@redhat.com> 1.20.0-0.2.develop
+- Updated selinux_policy_ver macro
+
 * Wed Jul 25 2018 Eric D. Helms <ericdhelms@gmail.com> - 1.20.0-0.1.develop
 - Add prerelease macro
 


### PR DESCRIPTION
https://community.theforeman.org/t/minimum-centos-version-requirement-for-1-18-is-7-5/10908

* [x] Nightly
* [x] 1.19
* [x] 1.18

I am marking also 1.18 but unsure if we are going to do the update so up
to you to decide. The error was reported by 1.18 user.