### PR TITLE
Use pkill instead of systemctl kill after logrotate for SPDC

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_dynflow_core/logrotate.conf
+++ b/packages/plugins/rubygem-smart_proxy_dynflow_core/logrotate.conf
@@ -7,6 +7,6 @@
   compress
     daily
   postrotate
-    /bin/systemctl kill --signal=SIGUSR1 smart_proxy_dynflow_core >/dev/null 2>&1 || true
+    pkill --signal SIGUSR1 --full /usr/bin/smart_proxy_dynflow_core >/dev/null 2>&1 || true
   endscript
 }

--- a/packages/plugins/rubygem-smart_proxy_dynflow_core/rubygem-smart_proxy_dynflow_core.spec
+++ b/packages/plugins/rubygem-smart_proxy_dynflow_core/rubygem-smart_proxy_dynflow_core.spec
@@ -15,7 +15,7 @@
 Summary: Core Smart Proxy Dynflow Service
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.2.0
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Group: Development/Libraries
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_dynflow
@@ -34,6 +34,7 @@ Requires: %{?scl_prefix_ror}rubygem(rack)
 Requires: %{?scl_prefix_ror}rubygem(sqlite3)
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}rubygems
+Requires: /usr/bin/pkill
 Requires(post): systemd-sysv
 Requires(post): systemd-units
 Requires(preun): systemd-units
@@ -119,6 +120,9 @@ install -Dp -m0644 %{SOURCE1} %{buildroot}%{root_sysconfdir}/logrotate.d/%{name}
 %doc %{gem_instdir}/LICENSE
 
 %changelog
+* Wed Sep 12 2018 Adam Ruzicka <aruzicka@redhat.com> 0.2.0-3
+- Fix signal sending after logrotate
+
 * Fri Sep 07 2018 Eric D. Helms <ericdhelms@gmail.com> - 0.2.0-2
 - Rebuild for Rails 5.2 and Ruby 2.5
 


### PR DESCRIPTION
While systemctl kill delivered the signal reliably, it delivered the
signal to every process in the service's control group. The issue was
when the service forked more processes (for example when running
ansible-playbook). pkill signals only the processes with matching
name.

Ansible-playbook reacts to SIGUSR{1,2} by printing "User defined signal
1" and exiting, which is undesired.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
