### PR TITLE
Use pkill instead of systemctl kill after logrotate for smart-proxy

### DIFF
--- a/debian/bionic/foreman-proxy/logrotate
+++ b/debian/bionic/foreman-proxy/logrotate
@@ -10,7 +10,7 @@
 	daily
   postrotate
     if [ -d /run/systemd/system ] ; then
-      /bin/systemctl kill --signal=SIGUSR1 foreman-proxy >/dev/null 2>&1 || true
+      pkill --signal SIGUSR1 --full /usr/share/foreman-proxy/bin/smart-proxy >/dev/null 2>&1 || true
     elif [ -e /etc/init.d/foreman-proxy ] ; then
       /etc/init.d/foreman-proxy logrotate >/dev/null 2>&1 || true
     fi

--- a/debian/stretch/foreman-proxy/logrotate
+++ b/debian/stretch/foreman-proxy/logrotate
@@ -10,7 +10,7 @@
 	daily
   postrotate
     if [ -d /run/systemd/system ] ; then
-      /bin/systemctl kill --signal=SIGUSR1 foreman-proxy >/dev/null 2>&1 || true
+      pkill --signal SIGUSR1 --full /usr/share/foreman-proxy/bin/smart-proxy >/dev/null 2>&1 || true
     elif [ -e /etc/init.d/foreman-proxy ] ; then
       /etc/init.d/foreman-proxy logrotate >/dev/null 2>&1 || true
     fi

--- a/debian/xenial/foreman-proxy/logrotate
+++ b/debian/xenial/foreman-proxy/logrotate
@@ -10,7 +10,7 @@
 	daily
   postrotate
     if [ -d /run/systemd/system ] ; then
-      /bin/systemctl kill --signal=SIGUSR1 foreman-proxy >/dev/null 2>&1 || true
+      pkill --signal SIGUSR1 --full /usr/share/foreman-proxy/bin/smart-proxy >/dev/null 2>&1 || true
     elif [ -e /etc/init.d/foreman-proxy ] ; then
       /etc/init.d/foreman-proxy logrotate >/dev/null 2>&1 || true
     fi


### PR DESCRIPTION
While systemctl kill delivered the signal reliably, it delivered the
signal to every process in the service's control group. The issue was
when the service forked more processes (for example when running
ansible-playbook). pkill signals only the processes with matching
name.

Ansible-playbook reacts to SIGUSR{1,2} by printing "User defined signal
1" and exiting, which is undesired.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
