### PR TITLE
Bump Katello dependencies for Rails 5.2

### DIFF
--- a/packages/katello/rubygem-anemone/rubygem-anemone.spec
+++ b/packages/katello/rubygem-anemone/rubygem-anemone.spec
@@ -6,7 +6,7 @@
 Summary:    Anemone web-spider framework
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    0.7.2
-Release:    15%{?dist}
+Release:    16%{?dist}
 License:    MIT
 Group:      Development/Languages
 URL:        http://anemone.rubyforge.org/
@@ -58,6 +58,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/VERSION
 
 %changelog
+* Fri Sep 07 2018 Eric D. Helms <ericdhelms@gmail.com> - 0.7.2-16
+- Rebuild for Rails 5.2 and Ruby 2.5
+
 * Wed Jan 10 2018 Eric D. Helms <ericdhelms@gmail.com> 0.7.2-15
 - new package built with tito
 

--- a/packages/katello/rubygem-robotex/rubygem-robotex.spec
+++ b/packages/katello/rubygem-robotex/rubygem-robotex.spec
@@ -8,7 +8,7 @@
 Summary:    Ruby library to obey robots.txt
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    1.0.0
-Release:    20%{?dist}
+Release:    21%{?dist}
 License:    MIT
 Group:      Development/Languages
 URL:        https://www.github.com/chriskite/robotex
@@ -79,6 +79,9 @@ popd
 %{gem_instdir}/spec/
 
 %changelog
+* Fri Sep 07 2018 Eric D. Helms <ericdhelms@gmail.com> - 1.0.0-21
+- Rebuild for Rails 5.2 and Ruby 2.5
+
 * Wed Jan 10 2018 Eric D. Helms <ericdhelms@gmail.com> 1.0.0-20
 - new package built with tito
 

--- a/packages/katello/rubygem-runcible/rubygem-runcible.spec
+++ b/packages/katello/rubygem-runcible/rubygem-runcible.spec
@@ -5,7 +5,7 @@
 
 Name:           %{?scl_prefix}rubygem-%{gem_name}
 Version:        2.9.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A gem exposing Pulp's juiciest parts
 Group:          Applications/System
 License:        MIT
@@ -68,6 +68,9 @@ mkdir -p %{buildroot}%{gem_docdir}
 %doc %{gem_instdir}/CONTRIBUTING.md
 
 %changelog
+* Fri Sep 07 2018 Eric D. Helms <ericdhelms@gmail.com> - 2.9.0-2
+- Rebuild for Rails 5.2 and Ruby 2.5
+
 * Tue Sep 04 2018 Justin Sherrill <jsherril@redhat.com> 2.9.0-1
 - Update to 2.9.0
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
