### PR TITLE
Refs #24874 - update secure_headers to 6.0.0

### DIFF
--- a/packages/foreman/rubygem-secure_headers/rubygem-secure_headers.spec
+++ b/packages/foreman/rubygem-secure_headers/rubygem-secure_headers.spec
@@ -5,8 +5,8 @@
 
 Summary: Security related headers all in one gem
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 5.0.5
-Release: 2%{?dist}
+Version: 6.0.0
+Release: 1%{?dist}
 Group: Development/Languages
 License: ASL 2.0
 URL: https://github.com/twitter/secureheaders
@@ -15,7 +15,6 @@ Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
 Requires: %{?scl_prefix_ruby}ruby
-Requires: %{?scl_prefix}rubygem(useragent) >= 0.15.0
 
 BuildRequires: %{?scl_prefix_ruby}ruby(release)
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
@@ -73,6 +72,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Mon Sep 10 2018 Michael Moll <mmoll@mmoll.at> 6.0.0-1
+- Update secure_headers to 6.0.0
+
 * Wed Sep 05 2018 Eric D. Helms <ericdhelms@gmail.com> - 5.0.5-2
 - Rebuild for Rails 5.2 and Ruby 2.5
 

--- a/packages/foreman/rubygem-secure_headers/secure_headers-5.0.5.gem
+++ b/packages/foreman/rubygem-secure_headers/secure_headers-5.0.5.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/81/Q3/SHA256E-s58880--cf40223ae2b77e37da72772440f230e0dd4d14e4fcb1866396f38ae34baa3cde.5.gem/SHA256E-s58880--cf40223ae2b77e37da72772440f230e0dd4d14e4fcb1866396f38ae34baa3cde.5.gem

--- a/packages/foreman/rubygem-secure_headers/secure_headers-6.0.0.gem
+++ b/packages/foreman/rubygem-secure_headers/secure_headers-6.0.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/vV/61/SHA256E-s57344--85dda4a30ca2ad4ca34552b1543dd2078a5aea9ac733d0a3d68f6e2f51649d9d.0.gem/SHA256E-s57344--85dda4a30ca2ad4ca34552b1543dd2078a5aea9ac733d0a3d68f6e2f51649d9d.0.gem


### PR DESCRIPTION
this should be built into:

* [x] Nightly

after https://github.com/theforeman/foreman/pull/6055 got merged.