### PR TITLE
Update hammer-cli-katello for nightly

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -399,8 +399,11 @@ katello_packages:
     rubygem-hammer_cli_csv: {}
     rubygem-hammer_cli_foreman_virt_who_configure: {}
     rubygem-hammer_cli_katello:
+      releasers:
+        - "{{ nightly_releaser }}"
+      build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
       nightly_package_tito_releaser_args:
-        - "--arg jenkins_job=hammer-cli-katello-nightly-release"
+        - "--arg jenkins_job=hammer-cli-katello-master-release"
     rubygem-katello:
       releasers:
         - "{{ nightly_releaser }}"


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
