### PR TITLE
Correct manifest

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -61,6 +61,9 @@ foreman_scl_packages:
     rubygem-extlib: {}
     rubygem-facter: {}
     rubygem-faraday: {}
+      releasers:
+        - koji-foreman
+        - koji-foreman-plugins
     rubygem-fast_gettext:
       releasers:
         - koji-foreman

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -285,7 +285,6 @@ whitelist = rubygem-angular-rails-templates
   rubygem-bootstrap-datepicker-rails
   rubygem-chunky_png
   rubygem-commonjs
-  rubygem-concurrent-ruby
   rubygem-dalli
   rubygem-deface
   rubygem-diffy


### PR DESCRIPTION
rubygem-concurrent-ruby is used in both scl and nonscl.
rubygem-faraday is used in core scl and plugins nonscl.