### PR TITLE
Fixes #24919 - Remove the use of the _license macro and just hard cod…

### DIFF
--- a/packages/foreman/rubygem-hashie/rubygem-hashie.spec
+++ b/packages/foreman/rubygem-hashie/rubygem-hashie.spec
@@ -8,16 +8,15 @@
 %define _version 2.0.5
 %define _summary Your friendly neighborhood hash toolkit.
 %define _url https://github.com/intridea/hashie
-%define _license MIT
 
 %define desc Hashie is a small collection of tools that make hashes more powerful. Currently includes Mash (Mocking Hash) and Dash (Discrete Hash)
 
 Name:      %{?scl_prefix}rubygem-%{gem_name}
 Version:   %{_version}
-Release:   6%{?dist}
+Release:   7%{?dist}
 Summary:   %{_summary}
 Group:     Development/Languages
-License:   %{_license}
+License:   MIT
 URL:       %{_url}
 Source0:   https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
@@ -97,6 +96,9 @@ cp -a .%{gem_dir}/* %{buildroot}%{gem_dir}
 %doc %{gem_docdir}/ri
 
 %changelog
+* Wed Sep 12 2018 Bryan Kearney <bryan.kearney@gmail.com> - 2.0.5-7
+- Remove the use of the _license macro and just hard code it in the License line
+
 * Wed Sep 05 2018 Eric D. Helms <ericdhelms@gmail.com> - 2.0.5-6
 - Rebuild for Rails 5.2 and Ruby 2.5
 

--- a/packages/foreman/rubygem-powerbar/rubygem-powerbar.spec
+++ b/packages/foreman/rubygem-powerbar/rubygem-powerbar.spec
@@ -8,16 +8,15 @@
 %define _version 1.0.17
 %define _summary The last progressbar-library you'll ever need
 %define _url https://github.com/busyloop/powerbar
-%define _license MIT
 
 %define desc The last progressbar-library you'll ever need
 
 Name:      %{?scl_prefix}rubygem-%{gem_name}
 Version:   %{_version}
-Release:   3%{?dist}
+Release:   4%{?dist}
 Summary:   %{_summary}
 Group:     Development/Languages
-License:   %{_license}
+License:   MIT
 URL:       %{_url}
 Source0:   https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
@@ -97,6 +96,9 @@ cp -pa .%{_bindir}/* %{buildroot}%{_bindir}/
 %doc %{gem_docdir}/ri
 
 %changelog
+* Wed Sep 12 2018 Bryan Kearney <bryan.kearney@gmail.com> - 1.0.17-4
+- Remove the use of the _license macro and just hard code it in the License line
+
 * Wed Sep 05 2018 Eric D. Helms <ericdhelms@gmail.com> - 1.0.17-3
 - Rebuild for Rails 5.2 and Ruby 2.5
 

--- a/packages/plugins/rubygem-wicked/rubygem-wicked.spec
+++ b/packages/plugins/rubygem-wicked/rubygem-wicked.spec
@@ -6,16 +6,15 @@
 %define _version 1.3.2
 %define _summary Wicked is a Rails engine for producing easy wizard controllers
 %define _url https://github.com/schneems/wicked
-%define _license MIT
 
 %define desc Wicked is a Rails engine for producing easy wizard controllers
 
 Name:      %{?scl_prefix}rubygem-%{gem_name}
 Version:   %{_version}
-Release:   2%{?dist}
+Release:   3%{?dist}
 Summary:   %{_summary}
 Group:     Development/Languages
-License:   %{_license}
+License:   MIT
 URL:       %{_url}
 Source0:   https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
@@ -89,6 +88,9 @@ cp -a .%{gem_dir}/* %{buildroot}%{gem_dir}
 %doc %{gem_instdir}/CHANGELOG.md
 
 %changelog
+* Wed Sep 12 2018 Bryan Kearney <bryan.kearney@gmail.com> - 1.3.2-3
+- Remove the use of the _license macro and just hard code it in the License line
+
 * Fri Sep 07 2018 Eric D. Helms <ericdhelms@gmail.com> - 1.3.2-2
 - Rebuild for Rails 5.2 and Ruby 2.5
 


### PR DESCRIPTION
…e it in the License line

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
