### PR TITLE
Update rubygem-foreman_remote_execution to 1.5.6

### DIFF
--- a/packages/plugins/rubygem-foreman_remote_execution/foreman_remote_execution-1.5.5.gem
+++ b/packages/plugins/rubygem-foreman_remote_execution/foreman_remote_execution-1.5.5.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/JM/Jw/SHA256E-s249856--52d87cfc4b4afa69309c6123aaef30b3af163c314d02d98b88d00f3c1e189a31.5.gem/SHA256E-s249856--52d87cfc4b4afa69309c6123aaef30b3af163c314d02d98b88d00f3c1e189a31.5.gem

--- a/packages/plugins/rubygem-foreman_remote_execution/foreman_remote_execution-1.5.6.gem
+++ b/packages/plugins/rubygem-foreman_remote_execution/foreman_remote_execution-1.5.6.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/kp/wZ/SHA256E-s250368--1313baa3423fb92a4a71e9df1aedf596a0f32c2b6d16d4ef6c571fab11ca88a0.6.gem/SHA256E-s250368--1313baa3423fb92a4a71e9df1aedf596a0f32c2b6d16d4ef6c571fab11ca88a0.6.gem

--- a/packages/plugins/rubygem-foreman_remote_execution/rubygem-foreman_remote_execution.spec
+++ b/packages/plugins/rubygem-foreman_remote_execution/rubygem-foreman_remote_execution.spec
@@ -13,7 +13,7 @@
 
 Summary:    Plugin that brings remote execution capabilities to Foreman
 Name:       %{?scl_prefix}rubygem-%{gem_name}
-Version:    1.5.5
+Version:    1.5.6
 Release:    1%{?foremandist}%{?dist}
 Group:      Applications/System
 License:    GPLv3
@@ -115,6 +115,9 @@ exit 0
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Thu Sep 13 2018 Adam Ruzicka <aruzicka@redhat.com> 1.5.6-1
+- Update to 1.5.6
+
 * Tue Aug 14 2018 Adam Ruzicka <aruzicka@redhat.com> 1.5.5-1
 - Update to 1.5.5
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [x] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
