### PR TITLE
Fix foreman-release whitelist for new client subpackage

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -209,6 +209,13 @@ foreman_nonscl_packages:
       nightly_package_tito_releaser_args:
         - "--arg jenkins_job=test_proxy_develop"
     foreman-release:
+      diff_package_tags:
+        - foreman-nightly-nonscl-rhel7
+        - foreman-client-nightly-rhel7
+        - foreman-client-nightly-rhel6
+        - foreman-client-nightly-rhel5
+        - foreman-client-nightly-fedora27
+        - foreman-client-nightly-fedora28
       releasers:
       - koji-foreman
       - koji-foreman-client

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -404,23 +404,23 @@ whitelist = ansiblerole-insights-client
 
 [foreman-client-nightly-rhel7]
 disttag = .el7
-whitelist = foreman-client-release
+whitelist = foreman-release
 
 [foreman-client-nightly-rhel6]
 disttag = .el6
-whitelist = foreman-client-release
+whitelist = foreman-release
 
 [foreman-client-nightly-rhel5]
 disttag = .el5
-whitelist = foreman-client-release
+whitelist = foreman-release
 
 [foreman-client-nightly-fedora27]
 disttag = .fc27
-whitelist = foreman-client-release
+whitelist = foreman-release
 
 [foreman-client-nightly-fedora28]
 disttag = .fc28
-whitelist = foreman-client-release
+whitelist = foreman-release
 
 [katello-nightly-rhel7]
 disttag = .el7


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
