### PR TITLE
Fixes #24936 - Use LGPLv2 for both 2 and 2.1 versions.

### DIFF
--- a/packages/foreman/rubygem-journald-native/rubygem-journald-native.spec
+++ b/packages/foreman/rubygem-journald-native/rubygem-journald-native.spec
@@ -5,10 +5,10 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.10
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: systemd-journal logging native lib wrapper
 Group: Development/Languages
-License: LGPL-2.1+
+License: LGPLv2
 URL: https://github.com/sandfoxme/journald-native
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: %{?scl_prefix_ruby}ruby(release)
@@ -88,6 +88,9 @@ rm -rf %{buildroot}%{gem_instdir}/ext/
 %{gem_instdir}/spec
 
 %changelog
+* Thu Sep 13 2018 Bryan Kearney <bryan.kearney@gmail.com> - 1.0.10-3
+- Use LGPLv2 for versions 2 and 2.1 of the license
+
 * Wed Sep 05 2018 Eric D. Helms <ericdhelms@gmail.com> - 1.0.10-2
 - Rebuild for Rails 5.2 and Ruby 2.5
 

--- a/packages/foreman/rubygem-rubyipmi/rubygem-rubyipmi.spec
+++ b/packages/foreman/rubygem-rubyipmi/rubygem-rubyipmi.spec
@@ -6,9 +6,9 @@
 Summary: A ruby wrapper for ipmi command line tools
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.10.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Group: Development/Languages
-License: LGPLv2.1
+License: LGPLv2
 URL: https://github.com/logicminds/rubyipmi
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 %if 0%{?fedora} > 18 || 0%{?rhel} >= 7
@@ -75,6 +75,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/Gemfile*
 
 %changelog
+* Thu Sep 13 2018 Bryan Kearney <bryan.kearney@gmail.com> - 0.10.0-3
+- Use LGPLv2 for versions 2 and 2.1 of the license
+
 * Wed May 04 2016 Dominic Cleal <dominic@cleal.org> 0.10.0-2
 - Use gem_install macro (dominic@cleal.org)
 - Converted spec files (dcleal@redhat.com)


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
