### PR TITLE
Build katello-host-tools for foreman-client repos

### DIFF
--- a/comps/comps-foreman-client-fedora27.xml
+++ b/comps/comps-foreman-client-fedora27.xml
@@ -12,6 +12,15 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="default">foreman-client-release</packagereq>
+      <packagereq type="default">gofer</packagereq>
+      <packagereq type="default">katello-agent</packagereq>
+      <packagereq type="default">katello-host-tools-fact-plugin</packagereq>
+      <packagereq type="default">katello-host-tools-tracer</packagereq>
+      <packagereq type="default">katello-host-tools</packagereq>
+      <packagereq type="default">python3-gofer</packagereq>
+      <packagereq type="default">python3-gofer-proton</packagereq>
+      <packagereq type="default">python2-gofer</packagereq>
+      <packagereq type="default">python2-gofer-proton</packagereq>
     </packagelist>
   </group>
 </comps>

--- a/comps/comps-foreman-client-fedora28.xml
+++ b/comps/comps-foreman-client-fedora28.xml
@@ -12,6 +12,15 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="default">foreman-client-release</packagereq>
+      <packagereq type="default">gofer</packagereq>
+      <packagereq type="default">katello-agent</packagereq>
+      <packagereq type="default">katello-host-tools-fact-plugin</packagereq>
+      <packagereq type="default">katello-host-tools-tracer</packagereq>
+      <packagereq type="default">katello-host-tools</packagereq>
+      <packagereq type="default">python3-gofer</packagereq>
+      <packagereq type="default">python3-gofer-proton</packagereq>
+      <packagereq type="default">python2-gofer</packagereq>
+      <packagereq type="default">python2-gofer-proton</packagereq>
     </packagelist>
   </group>
 </comps>

--- a/comps/comps-foreman-client-rhel5.xml
+++ b/comps/comps-foreman-client-rhel5.xml
@@ -12,6 +12,26 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="default">foreman-client-release</packagereq>
+      <packagereq type="default">gofer</packagereq>
+      <packagereq type="default">katello-agent</packagereq>
+      <packagereq type="default">katello-client-repos</packagereq>
+      <packagereq type="default">katello-host-tools-fact-plugin</packagereq>
+      <packagereq type="default">katello-host-tools</packagereq>
+      <packagereq type="default">pulp-rpm-handlers</packagereq>
+      <packagereq type="default">python-gofer-proton</packagereq>
+      <packagereq type="default">python-gofer</packagereq>
+      <packagereq type="default">python-isodate</packagereq>
+      <packagereq type="default">python-pulp-agent-lib</packagereq>
+      <packagereq type="default">python-pulp-common</packagereq>
+      <packagereq type="default">python-pulp-rpm-common</packagereq>
+      <packagereq type="default">python-qpid-common</packagereq>
+      <packagereq type="default">python-qpid-proton</packagereq>
+      <packagereq type="default">python-qpid</packagereq>
+      <packagereq type="default">python-rhsm</packagereq>
+      <packagereq type="default">python-saslwrapper</packagereq>
+      <packagereq type="default">qpid-proton-c</packagereq>
+      <packagereq type="default">saslwrapper</packagereq>
+      <packagereq type="default">subscription-manager</packagereq>
     </packagelist>
   </group>
 </comps>

--- a/comps/comps-foreman-client-rhel6.xml
+++ b/comps/comps-foreman-client-rhel6.xml
@@ -12,6 +12,15 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="default">foreman-client-release</packagereq>
+      <packagereq type="default">gofer</packagereq>
+      <packagereq type="default">katello-agent</packagereq>
+      <packagereq type="default">katello-client-repos</packagereq>
+      <packagereq type="default">katello-host-tools-fact-plugin</packagereq>
+      <packagereq type="default">katello-host-tools-tracer</packagereq>
+      <packagereq type="default">katello-host-tools</packagereq>
+      <packagereq type="default">python-gofer-proton</packagereq>
+      <packagereq type="default">python-gofer</packagereq>
+      <packagereq type="default">qpid-proton-c</packagereq>
     </packagelist>
   </group>
 </comps>

--- a/comps/comps-foreman-client-rhel7.xml
+++ b/comps/comps-foreman-client-rhel7.xml
@@ -12,6 +12,15 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="default">foreman-client-release</packagereq>
+      <packagereq type="default">gofer</packagereq>
+      <packagereq type="default">katello-agent</packagereq>
+      <packagereq type="default">katello-client-repos</packagereq>
+      <packagereq type="default">katello-host-tools-fact-plugin</packagereq>
+      <packagereq type="default">katello-host-tools-tracer</packagereq>
+      <packagereq type="default">katello-host-tools</packagereq>
+      <packagereq type="default">python-gofer-proton</packagereq>
+      <packagereq type="default">python-gofer</packagereq>
+      <packagereq type="default">qpid-proton-c</packagereq>
     </packagelist>
   </group>
 </comps>

--- a/comps/comps-foreman-client-sles11.xml
+++ b/comps/comps-foreman-client-sles11.xml
@@ -12,6 +12,18 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="default">foreman-client-release</packagereq>
+      <packagereq type="default">katello-host-tools-fact-plugin</packagereq>
+      <packagereq type="default">katello-host-tools</packagereq>
+      <packagereq type="default">python-decorator</packagereq>
+      <packagereq type="default">python-iniparse</packagereq>
+      <packagereq type="default">python-rhsm-certificates</packagereq>
+      <packagereq type="default">python-rhsm</packagereq>
+      <packagereq type="default">python-six</packagereq>
+      <packagereq type="default">subscription-manager-gui</packagereq>
+      <packagereq type="default">subscription-manager-rhsm-certificates</packagereq>
+      <packagereq type="default">subscription-manager-rhsm</packagereq>
+      <packagereq type="default">subscription-manager</packagereq>
+      <packagereq type="default">virt-what</packagereq>
     </packagelist>
   </group>
 </comps>

--- a/comps/comps-foreman-client-sles12.xml
+++ b/comps/comps-foreman-client-sles12.xml
@@ -12,6 +12,19 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="default">foreman-client-release</packagereq>
+      <packagereq type="default">katello-host-tools-fact-plugin</packagereq>
+      <packagereq type="default">katello-host-tools</packagereq>
+      <packagereq type="default">python-gpgme</packagereq>
+      <packagereq type="default">python-iniparse</packagereq>
+      <packagereq type="default">python-rhsm-certificates</packagereq>
+      <packagereq type="default">python-rhsm</packagereq>
+      <packagereq type="default">python-yum</packagereq>
+      <packagereq type="default">subscription-manager-gui</packagereq>
+      <packagereq type="default">subscription-manager-rhsm-certificates</packagereq>
+      <packagereq type="default">subscription-manager-rhsm</packagereq>
+      <packagereq type="default">subscription-manager</packagereq>
+      <packagereq type="default">virt-what</packagereq>
+      <packagereq type="default">yum</packagereq>
     </packagelist>
   </group>
 </comps>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -373,7 +373,13 @@ foreman_client_packages:
   vars:
     package_base_dir: 'packages/client/'
     releasers:
-    - koji-foreman-client
+      - koji-foreman-client
+    diff_package_tags:
+      - foreman-client-nightly-rhel7
+      - foreman-client-nightly-rhel6
+      - foreman-client-nightly-rhel5
+      - foreman-client-nightly-fedora27
+      - foreman-client-nightly-fedora28
     repoclosure_config: repoclosure/yum.conf
     repoclosure_lookaside_repos:
       - el7-base
@@ -406,7 +412,22 @@ foreman_client_packages:
       - f27-updates
       - f27-puppet-5
       - f27-foreman-client-nightly
-  hosts: {}
+  hosts:
+    katello-host-tools:
+      diff_package_tags:
+      - foreman-client-nightly-rhel7
+      - foreman-client-nightly-rhel6
+      - foreman-client-nightly-rhel5
+      - foreman-client-nightly-fedora27
+      - foreman-client-nightly-fedora28
+      - katello-nightly-rhel7
+      - katello-nightly-rhel6
+      - katello-nightly-rhel5
+      - katello-nightly-fedora27
+      - katello-nightly-fedora28
+      releasers:
+      - koji-foreman-client
+      - koji-katello-client
 
 katello_packages:
   vars:
@@ -519,7 +540,6 @@ katello_client_packages:
       - f27-puppet-5
       - f27-katello-client-nightly
   hosts:
-    katello-host-tools: {}
     katello-repos: {}
 
 plugins_packages:

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -406,22 +406,27 @@ whitelist = ansiblerole-insights-client
 [foreman-client-nightly-rhel7]
 disttag = .el7
 whitelist = foreman-release
+  katello-host-tools
 
 [foreman-client-nightly-rhel6]
 disttag = .el6
 whitelist = foreman-release
+  katello-host-tools
 
 [foreman-client-nightly-rhel5]
 disttag = .el5
 whitelist = foreman-release
+  katello-host-tools
 
 [foreman-client-nightly-fedora27]
 disttag = .fc27
 whitelist = foreman-release
+  katello-host-tools
 
 [foreman-client-nightly-fedora28]
 disttag = .fc28
 whitelist = foreman-release
+  katello-host-tools
 
 [katello-nightly-rhel7]
 disttag = .el7
@@ -429,7 +434,6 @@ scl = tfm
 whitelist = katello
   katello-certs-tools
   katello-client-bootstrap
-  katello-host-tools
   katello-installer-base
   katello-repos
   katello-selinux


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
