### PR TITLE
Fix foreman-client repoclosure reference for fedora

### DIFF
--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -171,7 +171,7 @@ baseurl=http://yum.puppetlabs.com/puppet5/fedora/27/x86_64/
 
 [f27-foreman-client-nightly]
 name=Foreman Client nightly F27
-baseurl=https://yum.theforeman.org/client/nightly/f27/x86_64
+baseurl=https://yum.theforeman.org/client/nightly/fc27/x86_64
 
 [f27-katello-client-nightly]
 name=Katello nightly F27
@@ -195,7 +195,7 @@ baseurl=http://yum.puppetlabs.com/puppet5/fedora/28/x86_64/
 
 [f28-foreman-client-nightly]
 name=Foreman Client nightly F28
-baseurl=https://yum.theforeman.org/client/nightly/f28/x86_64
+baseurl=https://yum.theforeman.org/client/nightly/fc28/x86_64
 
 [f28-katello-client-nightly]
 name=Katello nightly F28

--- a/repoclosure/yum_f27.conf
+++ b/repoclosure/yum_f27.conf
@@ -29,7 +29,7 @@ baseurl=http://yum.puppetlabs.com/puppet5/fedora/27/x86_64/
 
 [f27-foreman-client-nightly]
 name=Foreman Client nightly F27
-baseurl=https://yum.theforeman.org/client/nightly/f27/x86_64
+baseurl=https://yum.theforeman.org/client/nightly/fc27/x86_64
 
 [f27-katello-client-nightly]
 name=Katello nightly F27

--- a/repoclosure/yum_f28.conf
+++ b/repoclosure/yum_f28.conf
@@ -29,7 +29,7 @@ baseurl=http://yum.puppetlabs.com/puppet5/fedora/28/x86_64/
 
 [f28-foreman-client-nightly]
 name=Foreman Client nightly F28
-baseurl=https://yum.theforeman.org/client/nightly/f28/x86_64
+baseurl=https://yum.theforeman.org/client/nightly/fc28/x86_64
 
 [f28-katello-client-nightly]
 name=Katello nightly F28


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
