### PR TITLE
Fixes #24928 - add generators for requires and provides of webpack content

### DIFF
--- a/packages/foreman/foreman/foreman.attr
+++ b/packages/foreman/foreman/foreman.attr
@@ -1,0 +1,3 @@
+%__foreman_provides  %{_rpmconfigdir}/foreman.prov
+%__foreman_requires  %{_rpmconfigdir}/foreman.req
+%__foreman_path ^(/var/lib/foreman/public/webpack|/opt/theforeman/tfm/root/usr/share/gems/gems/[^/]+/public/webpack/[^/]+)/manifest\\.json$

--- a/packages/foreman/foreman/foreman.provreq
+++ b/packages/foreman/foreman/foreman.provreq
@@ -37,13 +37,15 @@ def parse_manifest(manifest_path):
     with open(manifest_path) as fh:
         manifest = json.load(fh)
 
-    for name, content in manifest['assetsByChunkName'].items():
-        if name != 'vendor':
-            continue
+    try:
+        name = 'vendor'
+        content = manifest['assetsByChunkName'][name]
         if isinstance(content, basestring):
             content = [content]
         for chunk in content:
             webpack_chunks.add(foreman_webpack(name, chunk))
+    except KeyError:
+        pass
 
     return webpack_chunks
 

--- a/packages/foreman/foreman/foreman.provreq
+++ b/packages/foreman/foreman/foreman.provreq
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+"""
+Automatic Provides and Requires generator for Foreman's webpack bundles.
+
+Foreman ships webpack bundles in its RPMs to be consumed by plugins. To ensure
+proper dependency relationships between the plugins and the main Foreman RPM,
+this script generates Provides for the Foreman RPM that contain the hash of
+the webpack bundles shipped and matching Requires for the plugins packages.
+Each time the Foreman bundles change hashes, the plugins become uninstallable
+and indicate that a rebuild is required.
+"""
+from __future__ import print_function
+
+import json
+import os
+import sys
+
+try:
+    basestring
+except NameError:
+    basestring = str
+
+FOREMAN_MANIFEST = '/var/lib/foreman/public/webpack/manifest.json'
+
+
+def foreman_webpack(name, chunk):
+    filename, fileext = os.path.splitext(chunk)
+    fileext = fileext.lstrip('.')
+    filehash = filename.rsplit('-', 1)[1]
+    return 'foreman-webpack-{}-{}({})'.format(name, fileext, filehash)
+
+
+def parse_manifest(manifest_path):
+    webpack_chunks = set()
+
+    with open(manifest_path) as fh:
+        manifest = json.load(fh)
+
+    for name, content in manifest['assetsByChunkName'].items():
+        if name != 'vendor':
+            continue
+        if isinstance(content, basestring):
+            content = [content]
+        for chunk in content:
+            webpack_chunks.add(foreman_webpack(name, chunk))
+
+    return webpack_chunks
+
+
+paths = [path.rstrip() for path in sys.stdin.readlines()]
+
+mode = os.path.splitext(sys.argv[0])[1].lstrip('.')
+
+result = set()
+
+for path in paths:
+    if path.endswith('/webpack/manifest.json') and mode == 'prov':
+        result.update(parse_manifest(path))
+    elif path.endswith('/manifest.json') and mode == 'req':
+        result.update(parse_manifest(FOREMAN_MANIFEST))
+
+print("\n".join(result))

--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -8,7 +8,7 @@
 %global scl_ruby_bin /usr/bin/%{?scl:%{scl_prefix}}ruby
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 10
+%global release 11
 %global prerelease develop
 
 Name:    foreman
@@ -25,6 +25,8 @@ Source2: %{name}.sysconfig
 Source3: %{name}.logrotate
 Source4: %{name}.cron.d
 Source5: %{name}.tmpfiles
+Source6: %{name}.attr
+Source7: %{name}.provreq
 Source10: %{executor_service_name}.sysconfig
 Source11: %{executor_service_name}.service
 BuildArch:  noarch
@@ -854,6 +856,8 @@ Meta package with support for building RPMs in the Foreman release cycle.
 
 %files build
 %{_sysconfdir}/rpm/macros.%{name}-dist
+%{_fileattrsdir}/%{name}.attr
+%{_rpmconfigdir}/%{name}.*
 
 %package console
 Summary: Foreman console support
@@ -1161,6 +1165,11 @@ rm -rf ./usr \\
 %%{?-s:[ -e %%{buildroot}%%{%{name}_webpack_plugin} ] && ln -s %%{%{name}_webpack_plugin} %%{buildroot}%%{%{name}_webpack_foreman}}
 EOF
 
+#copy rpm config
+install -Dpm0644 %{SOURCE6} %{buildroot}%{_fileattrsdir}/%{name}.attr
+install -pm0755 %{SOURCE7} %{buildroot}%{_rpmconfigdir}/%{name}.prov
+install -pm0755 %{SOURCE7} %{buildroot}%{_rpmconfigdir}/%{name}.req
+
 %clean
 rm -rf %{buildroot}
 
@@ -1276,6 +1285,11 @@ exit 0
 %systemd_postun_with_restart %{name}.service
 
 %changelog
+* Fri Oct 12 2018 Evgeni Golov - 1.20.0-0.11.develop
+- Add automatic Provides and Requires for Foreman's webpack bundles.
+  This should ensure that plugins can depend on a specific bundle version and
+  get rebuilt when Foreman's bundle changes.
+
 * Mon Oct 08 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.20.0-0.10.develop
 - Update Gem and NPM dependencies
 


### PR DESCRIPTION
This adds automatic Provides and Requires for Foreman's webpack bundles.
    
Foreman ships webpack bundles in its RPMs to be consumed by plugins. To ensure
proper dependency relationships between the plugins and the main Foreman RPM,
this script generates Provides for the Foreman RPM that contain the hash of
the webpack bundles shipped and matching Requires for the plugins packages.
Each time the Foreman bundles change hashes, the plugins become uninstallable
and indicate that a rebuild is required.
