### PR TITLE
Obsolete python-pulp-rpm-common for katello-host-tools

### DIFF
--- a/packages/katello/katello-host-tools/katello-host-tools.spec
+++ b/packages/katello/katello-host-tools/katello-host-tools.spec
@@ -15,7 +15,7 @@
 
 Name: katello-host-tools
 Version: 3.3.5
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A set of commands and yum plugins that support a Katello host
 Group:   Development/Languages
 License: LGPLv2
@@ -79,6 +79,7 @@ Requires: pulp-rpm-handlers >= 2.6
 Requires: gofer >= 2.12.1
 Obsoletes: python-pulp-agent-lib < 3.0
 Obsoletes: pulp-rpm-handlers < 3.0
+Obsoletes: python-pulp-rpm-common < 3.0
 %endif
 
 %if %{dnf_install}
@@ -358,6 +359,9 @@ exit 0
 %endif #build_tracer
 
 %changelog
+* Tue Sep 18 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.3.5-2
+- Obsolete python-pulp-rpm-common on EL7
+
 * Wed Aug 29 2018 Jonathon Turel <jturel@gmail.com> - 3.3.5-1
 - Fixes #24500 - prevent exceptions through registerCommand
 - Remove old makefile syntax from readme


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
