### PR TITLE
Update smart_proxy_dynflow{,_core} to 0.2.1

### DIFF
--- a/plugins/smart_proxy_dynflow/changelog
+++ b/plugins/smart_proxy_dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-dynflow (0.2.1-1) stable; urgency=high
+
+  * 0.2.1 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Thu, 20 Sep 2018 21:47:58 +0200
+
 ruby-smart-proxy-dynflow (0.2.0-1) stable; urgency=low
 
   * 0.2.0 released

--- a/plugins/smart_proxy_dynflow/dynflow.rb
+++ b/plugins/smart_proxy_dynflow/dynflow.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_dynflow', '0.2.0'
+gem 'smart_proxy_dynflow', '0.2.1'

--- a/plugins/smart_proxy_dynflow_core/changelog
+++ b/plugins/smart_proxy_dynflow_core/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-dynflow-core (0.2.1-1) stable; urgency=high
+
+  * 0.2.1 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Thu, 20 Sep 2018 21:48:29 +0200
+
 ruby-smart-proxy-dynflow-core (0.2.0-2) stable; urgency=low
 
   * Fix version in dynflow_core.rb

--- a/plugins/smart_proxy_dynflow_core/dynflow_core.rb
+++ b/plugins/smart_proxy_dynflow_core/dynflow_core.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_dynflow_core', '0.2.0'
+gem 'smart_proxy_dynflow_core', '0.2.1'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.19
* [x] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
