### PR TITLE
Update smart_proxy_dynflow{,_core} to 0.1.11 (foreman <= 1.17)

### DIFF
--- a/plugins/smart_proxy_dynflow/changelog
+++ b/plugins/smart_proxy_dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-dynflow (0.1.11-1) stable; urgency=high
+
+  * 0.1.11 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Thu, 20 Sep 2018 22:05:32 +0200
+
 ruby-smart-proxy-dynflow (0.1.10-1) stable; urgency=low
 
   * 0.1.10 released

--- a/plugins/smart_proxy_dynflow/dynflow.rb
+++ b/plugins/smart_proxy_dynflow/dynflow.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_dynflow', '0.1.10'
+gem 'smart_proxy_dynflow', '0.1.11'

--- a/plugins/smart_proxy_dynflow_core/changelog
+++ b/plugins/smart_proxy_dynflow_core/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-dynflow-core (0.1.11-1) stable; urgency=high
+
+  * 0.1.11 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Thu, 20 Sep 2018 22:05:45 +0200
+
 ruby-smart-proxy-dynflow-core (0.1.10-1) stable; urgency=low
 
   * 0.1.10 released

--- a/plugins/smart_proxy_dynflow_core/dynflow_core.rb
+++ b/plugins/smart_proxy_dynflow_core/dynflow_core.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_dynflow_core', '0.1.10'
+gem 'smart_proxy_dynflow_core', '0.1.11'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [ ] 1.19
* [ ] 1.18
* [x] 1.17
* [x] 1.16
* [x] 1.15

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
