### PR TITLE
Release constraings on smart_proxy_dynflow_core version

### DIFF
--- a/rubygem-smart_proxy_dynflow/rubygem-smart_proxy_dynflow.spec
+++ b/rubygem-smart_proxy_dynflow/rubygem-smart_proxy_dynflow.spec
@@ -18,9 +18,11 @@ Requires: ruby(rubygems)
 Requires: foreman-proxy >= 1.11.0
 
 %if 0%{?fedora}
-Requires: rubygem(smart_proxy_dynflow_core) = %{version}
+Requires: rubygem(smart_proxy_dynflow_core) >= 0.1.7
+Requires: rubygem(smart_proxy_dynflow_core) < 0.2.0
 %else
-Requires: tfm-rubygem(smart_proxy_dynflow_core) = %{version}
+Requires: tfm-rubygem(smart_proxy_dynflow_core) >= 0.1.7
+Requires: tfm-rubygem(smart_proxy_dynflow_core) < 0.2.0
 %endif
 
 BuildRequires: ruby(release)


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [ ] 1.19
* [ ] 1.18
* [x] 1.17
* [x] 1.16
* [x] 1.15

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

This makes it unnecessary to release smart_proxy_dynflow_core for this update, as it's causing various issues during the update (different scl ruby version in different releases + config file replacement)

This also means untagging http://koji.katello.org/koji/buildinfo?buildID=33262 and http://koji.katello.org/koji/buildinfo?buildID=33261 from the release so that it doesn't get into the yum repos.
