### PR TITLE
Avoid unversioned Provides in gem2rpm templates

### DIFF
--- a/gem2rpm/foreman_plugin.spec.erb
+++ b/gem2rpm/foreman_plugin.spec.erb
@@ -82,9 +82,9 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel <%= req %>
 BuildArch: noarch
 <% end -%>
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
-Provides: foreman-plugin-%{plugin_name}
+Provides: foreman-plugin-%{plugin_name} = %{version}
 <% if has_compute -%>
-Provides: foreman-%{plugin_name}
+Provides: foreman-%{plugin_name} = %{version}
 <% end -%>
 # end generated dependencies
 

--- a/gem2rpm/smart_proxy_plugin.spec.erb
+++ b/gem2rpm/smart_proxy_plugin.spec.erb
@@ -48,7 +48,7 @@ BuildRequires: rubygems-devel <%= req %>
 BuildArch: noarch
 <% end -%>
 Provides: rubygem(%{gem_name}) = %{version}
-Provides: foreman-proxy-plugin-%{plugin_name}
+Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end generated dependencies
 
 %description


### PR DESCRIPTION
This prevents the unversioned-explicit-provides warning from rpmlint in newly generated specs.