### PR TITLE
Add dependent client repos to foreman-client-release

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -396,8 +396,8 @@ foreman_client_packages:
       - el6-epel
       - el6-extras
       - el6-puppet-5
-      - el6-subscription-manager
       - el6-qpid
+      - el6-pulp
       - el6-foreman-client-nightly
       - el5-base
       - el5-updates
@@ -525,7 +525,6 @@ katello_client_packages:
       - el6-epel
       - el6-extras
       - el6-puppet-5
-      - el6-subscription-manager
       - el6-qpid
       - el6-katello-client-nightly
       - el5-base
@@ -769,7 +768,6 @@ repoclosures:
         - el6-epel
         - el6-extras
         - el6-puppet-5
-        - el6-subscription-manager
         - el6-qpid
     foreman-client-repoclosure-el5:
       repoclosure_config: repoclosure/yum_el5.conf
@@ -811,7 +809,6 @@ repoclosures:
         - el6-epel
         - el6-extras
         - el6-puppet-5
-        - el6-subscription-manager
         - el6-qpid
     katello-client-repoclosure-el5:
       repoclosure_config: repoclosure/yum_el5.conf

--- a/packages/foreman/foreman-release/foreman-release.spec
+++ b/packages/foreman/foreman-release/foreman-release.spec
@@ -13,7 +13,7 @@
 %define repo_dist %{dist}
 %endif
 
-%global release 5
+%global release 6
 %global prerelease develop
 
 Name:     foreman-release
@@ -30,6 +30,9 @@ Source2:  foreman.gpg
 Source3:  foreman-rails.repo
 Source4:  foreman-rails.gpg
 Source5:  foreman-client.repo
+Source6:  qpid-copr.repo
+Source7:  subscription-manager.repo
+Source8:  pulp.repo
 
 # Required by RHEL5
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
@@ -53,6 +56,15 @@ Defines yum repositories for Foreman clients.
 %config %{repo_dir}/foreman-client.repo
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman
 
+%if 0%{?rhel} == 6
+%config %{repo_dir}/pulp.repo
+%config %{repo_dir}/qpid-copr.repo
+%endif
+
+%if 0%{?rhel} == 5
+%config %{repo_dir}/subscription-manager.repo
+%endif
+
 %if 0%{?suse_version}
 %dir /etc/pki
 %dir /etc/pki/rpm-gpg
@@ -65,6 +77,15 @@ install -Dpm0644 %{SOURCE0} %{buildroot}%{repo_dir}/foreman.repo
 install -Dpm0644 %{SOURCE1} %{buildroot}%{repo_dir}/foreman-plugins.repo
 install -Dpm0644 %{SOURCE3} %{buildroot}%{repo_dir}/foreman-rails.repo
 install -Dpm0644 %{SOURCE5} %{buildroot}%{repo_dir}/foreman-client.repo
+
+%if 0%{?rhel} == 6
+install -m 644 %{SOURCE8} %{buildroot}%{repo_dir}/pulp.repo
+install -m 644 %{SOURCE6} %{buildroot}%{repo_dir}/qpid-copr.repo
+%endif
+
+%if 0%{?rhel} == 5
+install -m 644 %{SOURCE7} %{buildroot}%{repo_dir}/subscription-manager.repo
+%endif
 
 trimmed_dist=`echo %{repo_dist} | sed 's/^\.//'`
 sed "s/\$DIST/${trimmed_dist}/g" -i %{buildroot}%{repo_dir}/*.repo
@@ -86,6 +107,9 @@ install -Dpm0644 %{SOURCE4} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-f
 %{_sysconfdir}/pki/rpm-gpg/*
 
 %changelog
+* Thu Sep 27 2018 Eric D. Helms <ericdhelms@gmail.com> - 1.20.0-0.6.develop
+- Add required repos to deploy in foreman-client-release
+
 * Fri Sep 14 2018 Eric D. Helms <ericdhelms@gmail.com> - 1.20.0-0.5.develop
 - Rename client subpackge to foreman-client-release
 

--- a/packages/foreman/foreman-release/pulp.repo
+++ b/packages/foreman/foreman-release/pulp.repo
@@ -1,0 +1,6 @@
+[pulp]
+name=Pulp Community Release
+baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/stable/latest/$releasever/$basearch
+gpgkey=https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2
+enabled=1
+gpgcheck=1

--- a/packages/foreman/foreman-release/qpid-copr.repo
+++ b/packages/foreman/foreman-release/qpid-copr.repo
@@ -1,0 +1,8 @@
+[group_qpid-qpid]
+name=Copr repo for qpid owned by @qpid
+baseurl=https://copr-be.cloud.fedoraproject.org/results/@qpid/qpid/epel-6-$basearch/
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/@qpid/qpid/pubkey.gpg
+enabled=1
+enabled_metadata=1

--- a/packages/foreman/foreman-release/subscription-manager.repo
+++ b/packages/foreman/foreman-release/subscription-manager.repo
@@ -1,0 +1,5 @@
+[subscription-manager]
+name=Subscription manager repository from Candlepin
+baseurl=https://repos.fedorapeople.org/candlepin/subscription-manager/epel-5/x86_64/
+gpgcheck=0
+enabled=1

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -108,13 +108,13 @@ baseurl=http://yum.puppetlabs.com/el/6/PC1/x86_64/
 name=el6-puppet-5
 baseurl=https://yum.puppetlabs.com/puppet5/el/6/x86_64/
 
-[el6-subscription-manager]
-name=el6-subscription-manager
-baseurl=https://copr-be.cloud.fedoraproject.org/results/dgoodwin/subscription-manager/epel-6-x86_64/
-
 [el6-qpid]
 name=el6-qpid
 baseurl=https://copr-be.cloud.fedoraproject.org/results/ndp/qpid/epel-6-x86_64/
+
+[el6-pulp]
+name=Pulp Community Release
+baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/stable/latest/el6/x86_64
 
 [el6-foreman-client-nightly]
 name=Foreman Client nightly EL6

--- a/repoclosure/yum_el6.conf
+++ b/repoclosure/yum_el6.conf
@@ -40,10 +40,6 @@ baseurl=http://yum.puppetlabs.com/el/6/PC1/x86_64/
 name=el6-puppet-5
 baseurl=https://yum.puppetlabs.com/puppet5/el/6/x86_64/
 
-[el6-subscription-manager]
-name=el6-subscription-manager
-baseurl=https://copr-be.cloud.fedoraproject.org/results/dgoodwin/subscription-manager/epel-6-x86_64/
-
 [el6-qpid]
 name=el6-qpid
 baseurl=https://copr-be.cloud.fedoraproject.org/results/ndp/qpid/epel-6-x86_64/
@@ -55,3 +51,7 @@ baseurl=http://koji.katello.org/releases/yum/foreman-client-nightly/el6/x86_64/
 [el6-katello-client-nightly]
 name=Katello nightly EL6
 baseurl=http://koji.katello.org/releases/yum/katello-nightly/client/el6/x86_64/
+
+[el6-pulp]
+name=Pulp Community Release
+baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/stable/latest/el6/x86_64


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
