### PR TITLE
rubygem-angular-rails-templates-fips - enable FIPS

### DIFF
--- a/packages/plugins/rubygem-angular-rails-templates/enable-fips.patch
+++ b/packages/plugins/rubygem-angular-rails-templates/enable-fips.patch
@@ -1,0 +1,29 @@
+From 9f33843010154e77d6cba00a62b157e6ac9787c5 Mon Sep 17 00:00:00 2001
+From: Dmitri Dolguikh <dmitri@appliedlogic.ca>
+Date: Wed, 18 Apr 2018 11:15:16 -0700
+Subject: [PATCH] Use ActiveSupport::Digest when available
+
+Taken from https://github.com/pitr/angular-rails-templates/pull/158, as
+the upstream is not responsive to get this patch merged and released
+properly.
+---
+ lib/angular-rails-templates/engine.rb | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/lib/angular-rails-templates/engine.rb b/lib/angular-rails-templates/engine.rb
+index 3c509a8..20467d0 100644
+--- a/lib/angular-rails-templates/engine.rb
++++ b/lib/angular-rails-templates/engine.rb
+@@ -37,10 +37,11 @@ class Engine < ::Rails::Engine
+ 
+       # Sprockets Cache Busting
+       # If ART's version or settings change, expire and recompile all assets
++      hash_digest = defined?(ActiveSupport::Digest) ? ActiveSupport::Digest : Digest::MD5
+       app.config.assets.version = [
+         app.config.assets.version,
+         'ART',
+-        Digest::MD5.hexdigest("#{VERSION}-#{app.config.angular_templates}")
++        hash_digest.hexdigest("#{VERSION}-#{app.config.angular_templates}")
+       ].join '-'
+     end
+ 

--- a/packages/plugins/rubygem-angular-rails-templates/rubygem-angular-rails-templates.spec
+++ b/packages/plugins/rubygem-angular-rails-templates/rubygem-angular-rails-templates.spec
@@ -8,13 +8,14 @@
 
 Name:      %{?scl_prefix}rubygem-%{gem_name}
 Version:   1.0.2
-Release:   3%{?dist}
+Release:   4%{?dist}
 Epoch:     1
 Summary:   Use your angular templates with rails' asset pipeline
 Group:     Development/Languages
 License:   MIT
 URL:       https://github.com/pitr/angular-rails-templates
 Source0:   https://rubygems.org/gems/%{gem_name}-%{version}.gem
+Patch0:    enable-fips.patch
 
 BuildArch: noarch
 Provides:  %{?scl_prefix}rubygem(%{gem_name}) = %{version}
@@ -51,6 +52,10 @@ This package contains documentation for %{pkg_name}
 %gem_install -n %{SOURCE0}
 %{?scl:EOF}
 
+pushd .%{gem_instdir}
+%patch0 -p1
+popd
+
 %build
 
 %install
@@ -70,6 +75,9 @@ cp -a .%{gem_dir}/* %{buildroot}%{gem_dir}
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Oct 01 2018 Ivan Necas <inecas@gmail.com> - 1.0.2-4
+- Add patch to enable running in FIPS mode
+
 * Fri Sep 07 2018 Eric D. Helms <ericdhelms@gmail.com> - 1:1.0.2-3
 - Rebuild for Rails 5.2 and Ruby 2.5
 


### PR DESCRIPTION
Add patch to enable running in FIPS mode. The patch was sent to upstream
a while ago (https://github.com/pitr/angular-rails-templates/pull/158),
but the maintainers were not responsive to get this in and released.
Threfore, we need to provide this patch during packaging.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
