### PR TITLE
Fixes #24927 - Fix sending signal after logrotate

### DIFF
--- a/debian/bionic/foreman-proxy/logrotate
+++ b/debian/bionic/foreman-proxy/logrotate
@@ -10,7 +10,7 @@
 	daily
   postrotate
     if [ -d /run/systemd/system ] ; then
-      pkill --signal SIGUSR1 --full /usr/share/foreman-proxy/bin/smart-proxy >/dev/null 2>&1 || true
+      /bin/systemctl kill --signal=SIGUSR1 --kill-who=main foreman-proxy >/dev/null 2>&1 || true
     elif [ -e /etc/init.d/foreman-proxy ] ; then
       /etc/init.d/foreman-proxy logrotate >/dev/null 2>&1 || true
     fi

--- a/debian/stretch/foreman-proxy/logrotate
+++ b/debian/stretch/foreman-proxy/logrotate
@@ -10,7 +10,7 @@
 	daily
   postrotate
     if [ -d /run/systemd/system ] ; then
-      pkill --signal SIGUSR1 --full /usr/share/foreman-proxy/bin/smart-proxy >/dev/null 2>&1 || true
+      /bin/systemctl kill --signal=SIGUSR1 --kill-who=main foreman-proxy >/dev/null 2>&1 || true
     elif [ -e /etc/init.d/foreman-proxy ] ; then
       /etc/init.d/foreman-proxy logrotate >/dev/null 2>&1 || true
     fi

--- a/debian/xenial/foreman-proxy/logrotate
+++ b/debian/xenial/foreman-proxy/logrotate
@@ -10,7 +10,7 @@
 	daily
   postrotate
     if [ -d /run/systemd/system ] ; then
-      pkill --signal SIGUSR1 --full /usr/share/foreman-proxy/bin/smart-proxy >/dev/null 2>&1 || true
+      /bin/systemctl kill --signal=SIGUSR1 --kill-who=main foreman-proxy >/dev/null 2>&1 || true
     elif [ -e /etc/init.d/foreman-proxy ] ; then
       /etc/init.d/foreman-proxy logrotate >/dev/null 2>&1 || true
     fi


### PR DESCRIPTION
The solution with using pkill was not ideal as pkill
would match the process it was meant to kill and the
shell running pkill as well. This could lead to
a situation where the shell would be killed first
and the signal would not be delivered to the intended
target process.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
