### PR TITLE
Adds logging-journald to nonscl

### DIFF
--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -289,6 +289,8 @@
       <packagereq type="default">rubygem-concurrent-ruby</packagereq>
       <packagereq type="default">rubygem-hashie</packagereq>
       <packagereq type="default">rubygem-highline</packagereq>
+      <packagereq type="default">rubygem-journald-logger</packagereq>
+      <packagereq type="default">rubygem-journald-native</packagereq>
       <packagereq type="default">rubygem-jwt</packagereq>
       <packagereq type="default">rubygem-kafo</packagereq>
       <packagereq type="default">rubygem-kafo_parsers</packagereq>
@@ -321,6 +323,8 @@
       <packagereq type="default">rubygem-foreman_maintain-doc</packagereq>
       <packagereq type="default">rubygem-hashie-doc</packagereq>
       <packagereq type="default">rubygem-highline-doc</packagereq>
+      <packagereq type="default">rubygem-journald-logger-doc</packagereq>
+      <packagereq type="default">rubygem-journald-native-doc</packagereq>
       <packagereq type="default">rubygem-jwt-doc</packagereq>
       <packagereq type="default">rubygem-kafo-doc</packagereq>
       <packagereq type="default">rubygem-kafo_parsers-doc</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -108,8 +108,6 @@ foreman_scl_packages:
     rubygem-hoe: {}
     rubygem-http-cookie: {}
     rubygem-ipaddress: {}
-    rubygem-journald-logger: {}
-    rubygem-journald-native: {}
     rubygem-jquery-turbolinks: {}
     rubygem-jquery-ui-rails: {}
     rubygem-launchy: {}
@@ -365,6 +363,8 @@ foreman_scl_and_nonscl_packages:
     rubygem-clamp: {}
     rubygem-hashie: {}
     rubygem-highline: {}
+    rubygem-journald-logger: {}
+    rubygem-journald-native: {}
     rubygem-jwt: {}
     rubygem-little-plugger: {}
     rubygem-logging: {}


### PR DESCRIPTION
This is my attempt to copy logging-journald to nonscl repository. There
is a patch pending review which adds new dependency for improved logging
stack and abilities:

https://github.com/theforeman/smart-proxy/pull/611

Once the two deps are merged, I will work on packaging changes of
foreman-proxy package (new bundler group).

* [x] Nightly