### PR TITLE
Fix foreman-client repoclosure for Fedoras

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -834,10 +834,12 @@ repoclosures:
       repoclosure_target_repo: f28-katello-client-nightly
       repoclosure_lookaside_repos:
         - f28-base
+        - f28-updates
         - f28-puppet-5
     katello-client-repoclosure-f27:
       repoclosure_config: repoclosure/yum_f27.conf
       repoclosure_target_repo: f27-katello-client-nightly
       repoclosure_lookaside_repos:
         - f27-base
+        - f27-updates
         - f27-puppet-5


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
