### PR TITLE
Add missing f27 and f28 updates to foreman client repoclosures

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -791,12 +791,14 @@ repoclosures:
       repoclosure_target_repo: f28-foreman-client-nightly
       repoclosure_lookaside_repos:
         - f28-base
+        - f28-updates
         - f28-puppet-5
     foreman-client-repoclosure-f27:
       repoclosure_config: repoclosure/yum_f27.conf
       repoclosure_target_repo: f27-foreman-client-nightly
       repoclosure_lookaside_repos:
         - f27-base
+        - f27-updates
         - f27-puppet-5
     katello-client-repoclosure-el7:
       repoclosure_target_repo: el7-katello-client-nightly


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.19
* [ ] 1.18
* [ ] 1.17

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
