### PR TITLE
Reformat the manifest

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -20,7 +20,7 @@ foreman_scl_packages:
     diff_package_tags:
       - foreman-nightly-rhel7
     releasers:
-    - koji-foreman
+      - koji-foreman
     nightly_releaser: koji-foreman-jenkins
     repoclosure_config: repoclosure/yum_el7.conf
     repoclosure_lookaside_repos:
@@ -182,7 +182,7 @@ foreman_nonscl_packages:
     diff_package_tags:
       - foreman-nightly-nonscl-rhel7
     releasers:
-    - koji-foreman
+      - koji-foreman
     nightly_releaser: koji-foreman-jenkins
     repoclosure_config: repoclosure/yum_el7.conf
     repoclosure_lookaside_repos:
@@ -215,8 +215,8 @@ foreman_nonscl_packages:
         - foreman-client-nightly-fedora27
         - foreman-client-nightly-fedora28
       releasers:
-      - koji-foreman
-      - koji-foreman-client
+        - koji-foreman
+        - koji-foreman-client
     foreman-release-scl: {}
     foreman-selinux:
       releasers:
@@ -348,7 +348,7 @@ foreman_scl_and_nonscl_packages:
       - foreman-nightly-rhel7
       - foreman-nightly-nonscl-rhel7
     releasers:
-    - koji-foreman
+      - koji-foreman
     nightly_releaser: koji-foreman-jenkins
     repoclosure_config: repoclosure/yum_el7.conf
     repoclosure_lookaside_repos:
@@ -427,7 +427,7 @@ katello_packages:
     diff_package_tags:
       - katello-nightly-rhel7
     releasers:
-    - koji-katello
+      - koji-katello
     nightly_releaser: koji-katello-jenkins
     repoclosure_config: repoclosure/yum_el7.conf
     repoclosure_lookaside_repos:
@@ -498,7 +498,7 @@ katello_client_packages:
       - katello-nightly-fedora27
       - katello-nightly-fedora28
     releasers:
-    - koji-katello-client
+      - koji-katello-client
     repoclosure_config: repoclosure/yum.conf
     repoclosure_lookaside_repos:
       - el7-base
@@ -547,7 +547,7 @@ plugin_scl_packages:
     diff_package_tags:
       - foreman-plugins-nightly-rhel7
     releasers:
-    - koji-foreman-plugins
+      - koji-foreman-plugins
     nightly_releaser: koji-foreman-plugins-jenkins
     repoclosure_config: repoclosure/yum_el7.conf
     repoclosure_lookaside_repos:
@@ -650,9 +650,9 @@ plugin_nonscl_packages:
     package_base_dir: 'packages/plugins/'
     diff_package_skip: false
     diff_package_tags:
-    - foreman-plugins-nightly-nonscl-rhel7
+      - foreman-plugins-nightly-nonscl-rhel7
     releasers:
-    - koji-foreman-plugins
+      - koji-foreman-plugins
     nightly_releaser: koji-foreman-plugins-jenkins
     repoclosure_config: repoclosure/yum_el7.conf
     repoclosure_lookaside_repos:


### PR DESCRIPTION
This is based on ruemal-yaml which maintains as much style as possible but is strict about indenting levels and quotes. It prefers unquoted when possible and falls back to single quotes.

https://github.com/theforeman/obal/pull/59 was used to format this. I haven't found a way to prefer double quotes over single quotes.