### PR TITLE
Bump katello versions to 3.10

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -471,6 +471,7 @@ katello_packages:
       build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
       nightly_package_tito_releaser_args:
         - "--arg jenkins_job=katello-installer-nightly-release"
+    katello-repos: {}
     katello-selinux: {}
     nodejs-bootstrap-select: {}
     nodejs-downshift: {}
@@ -515,8 +516,6 @@ katello_client_packages:
       - katello-nightly-rhel5
       - katello-nightly-fedora27
       - katello-nightly-fedora28
-    releasers:
-      - koji-katello-client
     repoclosure_config: repoclosure/yum.conf
     repoclosure_lookaside_repos:
       - el7-base

--- a/packages/katello/katello-installer-base/katello-installer-base.spec
+++ b/packages/katello/katello-installer-base/katello-installer-base.spec
@@ -3,10 +3,10 @@
 %global scl_ruby /usr/bin/ruby
 
 # %%global prerelease .rc1
-%global release 2
+%global release 1
 
 Name:    katello-installer-base
-Version: 3.9.0
+Version: 3.10.0
 Release: %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary: Puppet-based installer for the Katello and Katello Capsule
 Group:   Applications/System
@@ -118,6 +118,9 @@ ln -sf %{_datadir}/foreman-installer-katello/bin/katello-certs-check %{buildroot
 %doc README.*
 
 %changelog
+* Thu Oct 18 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.10.0-1
+- Bump version to 3.10
+
 * Tue Jul 24 2018 Eric D. Helms <ericdhelms@gmail.com> 3.9.0-2
 - Add prerelease macro support
 

--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -17,10 +17,10 @@
 %endif
 
 %global prerelease .nightly
-%global release 4
+%global release 1
 
 Name:           katello-repos
-Version:        3.9.0
+Version:        3.10.0
 Release:        %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:        Definition of yum repositories for Katello
 
@@ -112,6 +112,9 @@ rm -rf %{buildroot}
 %endif
 
 %changelog
+* Thu Oct 18 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.10.0-0.1.nightly
+- Bump version to 3.10
+
 * Fri Aug 17 2018 Partha Aji <paji@redhat.com> - 3.9.0-0.4.nightly
 - Switch to Pulp 2.17 beta
 

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -4,10 +4,10 @@
 %global homedir %{_datarootdir}/%{name}
 %global confdir common
 # %%global prerelease .rc1
-%global release 11
+%global release 1
 
 Name:       katello
-Version:    3.9.0
+Version:    3.10.0
 Release:    %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:    A package for managing application life-cycle for Linux systems
 BuildArch:  noarch
@@ -199,6 +199,9 @@ Useful utilities for managing Katello services
 %{_sysconfdir}/bash_completion.d/katello-service
 
 %changelog
+* Thu Oct 18 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.10.0-1
+- Bump version to 3.10
+
 * Wed Oct 10 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.9.0-11
 - Cleanup spec requires
 

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -5,8 +5,8 @@
 %global plugin_name katello
 %global gem_name katello
 # %%global prerelease .rc1
-%global mainver 3.9.0
-%global release 6
+%global mainver 3.10.0
+%global release 1
 
 Name:    %{?scl_prefix}rubygem-%{gem_name}
 Summary: Content and Subscription Management plugin for Foreman
@@ -359,6 +359,9 @@ rm -f %{buildroot}%{foreman_webpack_plugin}/*.js.map
 %{gem_instdir}/webpack
 
 %changelog
+* Thu Oct 18 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.10.0-1
+- Bump version to 3.10
+
 * Thu Oct 11 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.9.0-6
 - Update NPM dependencies
 - Exclude Javascript source maps


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
