### PR TITLE
Use pulp nightly

### DIFF
--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -1,11 +1,12 @@
 %global pulp_release stable
 %global pulp_version 2.17
+%global use_pulp_nightly true
 
 %define repo_dir %{_sysconfdir}/yum.repos.d
 %define repo_dist %{dist}
 
 %global prerelease .nightly
-%global release 2
+%global release 3
 
 Name:           katello-repos
 Version:        3.10.0
@@ -56,6 +57,15 @@ for repofile in %{buildroot}%{repo_dir}/*.repo; do
     sed -i "s/@REPO_NAME@/${REPO_NAME}/" $repofile
     sed -i "s/@PULP_RELEASE@/%pulp_release/" $repofile
     sed -i "s/@PULP_VERSION@/%pulp_version/" $repofile
+    if [ "%{use_pulp_nightly}" = true ] ; then
+        PULP_URL_MIDDLE="testing\/automation\/2-master\/stage"
+        PULP_GPG_CHECK=0
+    else
+        PULP_URL_MIDDLE="%{pulp_release}\/%{pulp_version}"
+        PULP_GPG_CHECK=1
+    fi
+    sed -i "s/@PULP_URL_MIDDLE@/${PULP_URL_MIDDLE}/" $repofile
+    sed -i "s/@PULP_GPG_CHECK@/${PULP_GPG_CHECK}/" $repofile
 done
 
 %clean
@@ -67,6 +77,9 @@ rm -rf %{buildroot}
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-katello
 
 %changelog
+* Wed Oct 24 2018 John Mitsch <jomitsch@redhat.com> - 3.10.0-0.3.nightly
+- Switch to Pulp nightly
+
 * Mon Oct 22 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.10.0-0.2.nightly
 - Drop client repos
 

--- a/packages/katello/katello-repos/katello.repo
+++ b/packages/katello/katello-repos/katello.repo
@@ -9,10 +9,10 @@ gpgcheck=0
 
 [pulp]
 name=Pulp Community Release
-baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/@PULP_RELEASE@/@PULP_VERSION@/$releasever/$basearch
+baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/@PULP_URL_MIDDLE@/$releasever/$basearch
 gpgkey=https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2
 enabled=1
-gpgcheck=1
+gpgcheck=@PULP_GPG_CHECK@
 
 # Candlepin RPMs as supported by Katello - This is a coordinated
 # copy of Candlepin's packages in order to ensure compatibility
@@ -35,10 +35,10 @@ gpgcheck=0
 
 [pulp-source]
 name=Pulp Community Release Source
-baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/@PULP_RELEASE@/@PULP_VERSION@/$releasever/src/
+baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/@PULP_URL_MIDDLE@/$releasever/src/
 gpgkey=https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2
 enabled=0
-gpgcheck=1
+gpgcheck=@PULP_GPG_CHECK@
 
 [katello-candlepin-source]
 name=Katello Candlepin source


### PR DESCRIPTION
For Katello 2.10 development, we are using pulp's nightly builds
until the beta is released.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
