### PR TITLE
Add smart_proxy_rex_core dep to smart_proxy_ansible

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
+++ b/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
@@ -9,13 +9,14 @@
 Summary: Ansible support for Foreman smart proxy
 Name: rubygem-%{gem_name}
 Version: 2.0.3
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Group: Applications/System
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_ansible
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
 Requires: %{?rhel:tfm-}rubygem(smart_proxy_dynflow_core) >= 0.1.5
+Requires: %{?rhel:tfm-}rubygem(smart_proxy_remote_execution_ssh) >= 0.2.0
 Requires: %{?rhel:tfm-}rubygem(foreman_ansible_core)
 Requires: foreman-proxy >= 1.11.0
 Requires: rubygem(smart_proxy_dynflow) >= 0.1


### PR DESCRIPTION
In order to run Ansible jobs you would need this dependency. At the
moment users may choose to only install smart_proxy_ansible and jobs
will fail to run, as you can see in
https://community.theforeman.org/t/run-ansible-role-error/11501/2

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.20
* [x] 1.19
* [x] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
