### PR TITLE
Fixes #25289 - Split out Katello and Smart Proxy Cron

### DIFF
--- a/packages/katello/katello/foreman-proxy-content.cron
+++ b/packages/katello/katello/foreman-proxy-content.cron
@@ -1,0 +1,5 @@
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+# cronjob to clean puppet envs for puppet
+15 22 * * 0	root	[ -d /etc/puppetlabs/code/environments ] &&  find /etc/puppetlabs/code/environments/KT* -maxdepth 0 -type d -empty -delete > /dev/null 2>&1

--- a/packages/katello/katello/katello.cron
+++ b/packages/katello/katello/katello.cron
@@ -4,11 +4,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 # Script for initiating removal of orphaned content
 00 22 * * 0	root	foreman-rake katello:delete_orphaned_content RAILS_ENV=production >/dev/null 2>&1
 
-# cronjob to clean puppet envs for puppet 4
-15 22 * * 0	root	[ -d /etc/puppetlabs/code/environments ] &&  find /etc/puppetlabs/code/environments/KT* -maxdepth 0 -type d -empty -delete > /dev/null 2>&1
-
-# cronjob to clean puppet envs for puppet 3
-20 22 * * 0	root	[ -d /etc/puppet/environments ] && find /etc/puppet/environments/KT* -maxdepth 0 -type d -empty -delete > /dev/null 2>&1
-
 # Script for publishing unpublished repositories
 00 23 * * *     root    foreman-rake katello:publish_unpublished_repositories RAILS_ENV=production >/dev/null 2>&1

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -4,7 +4,7 @@
 %global homedir %{_datarootdir}/%{name}
 %global confdir common
 # %%global prerelease .rc1
-%global release 2
+%global release 3
 
 Name:       katello
 Version:    3.10.0
@@ -28,6 +28,7 @@ Source13:   katello-change-hostname.8.asciidoc
 Source16:   hostname-change.rb
 Source17:   helper.rb
 Source18:   katello.cron
+Source19:   foreman-proxy-content.cron
 
 BuildRequires: asciidoc
 BuildRequires: util-linux
@@ -82,6 +83,7 @@ mkdir -p %{buildroot}/%{_mandir}/man8
 #copy cron scripts to be scheduled
 install -d -m0755 %{buildroot}%{_sysconfdir}/cron.d
 install -m 644 %{SOURCE18} %{buildroot}%{_sysconfdir}/cron.d/katello
+install -m 644 %{SOURCE19} %{buildroot}%{_sysconfdir}/cron.d/foreman-proxy-content
 
 # symlink script libraries
 mkdir -p %{buildroot}%{_datarootdir}/katello
@@ -176,7 +178,7 @@ Obsoletes: katello-capsule
 Provides a federation of katello services
 
 %files -n foreman-proxy-content
-%config(missingok) %{_sysconfdir}/cron.d/katello
+%config(missingok) %{_sysconfdir}/cron.d/foreman-proxy-content
 %{_sbindir}/katello-backup
 %{_sbindir}/katello-restore
 %{_sbindir}/katello-change-hostname
@@ -199,6 +201,9 @@ Useful utilities for managing Katello services
 %{_sysconfdir}/bash_completion.d/katello-service
 
 %changelog
+* Tue Oct 23 2018 sokeeffe <sokeeffe@redhat.com> - 3.10.0-3
+- Split out Katello and Smart Proxy Cron 
+
 * Mon Oct 22 2018 Chris Roberts <chrobert@redhat.com> - 3.10.0-2
 - Change katello-remove to support wildcards and cleanup
 


### PR DESCRIPTION
Puppet 3 support was removed a while ago...
This also stops foreman-proxy-content listing this cron file its in %files, as it shouldn't

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
