### PR TITLE
Fixes #20302 - Update rubygem-fog-vsphere to 2.4.0

### DIFF
--- a/packages/foreman/rubygem-fog-vsphere/fog-vsphere-2.3.0.gem
+++ b/packages/foreman/rubygem-fog-vsphere/fog-vsphere-2.3.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/g9/vj/SHA256E-s71680--dc129a8cc067358e5f752a9174c72ecd3e149b773868bda9fffc7d7b5bb3055d.0.gem/SHA256E-s71680--dc129a8cc067358e5f752a9174c72ecd3e149b773868bda9fffc7d7b5bb3055d.0.gem

--- a/packages/foreman/rubygem-fog-vsphere/fog-vsphere-2.4.0.gem
+++ b/packages/foreman/rubygem-fog-vsphere/fog-vsphere-2.4.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/Ww/Vz/SHA256E-s72704--bcbe099ecb256682e0e18d32bdf3d83c1c48a37d6446ef97dd24cb2d9987689c.0.gem/SHA256E-s72704--bcbe099ecb256682e0e18d32bdf3d83c1c48a37d6446ef97dd24cb2d9987689c.0.gem

--- a/packages/foreman/rubygem-fog-vsphere/rubygem-fog-vsphere.spec
+++ b/packages/foreman/rubygem-fog-vsphere/rubygem-fog-vsphere.spec
@@ -4,8 +4,8 @@
 %global gem_name fog-vsphere
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 2.3.0
-Release: 2%{?dist}
+Version: 2.4.0
+Release: 1%{?dist}
 Summary: Module for the 'fog' gem to support VMware vSphere
 Group: Development/Languages
 License: MIT
@@ -88,6 +88,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/tests
 
 %changelog
+* Tue Oct 23 2018 Daniel Lobato Garcia <me@daniellobato.me> 2.4.0-1
+- Update to 2.4.0
+
 * Wed Sep 05 2018 Eric D. Helms <ericdhelms@gmail.com> - 2.3.0-2
 - Rebuild for Rails 5.2 and Ruby 2.5
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.20
* [x] 1.19
* [x] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

I think according to the [Gemfile](https://github.com/theforeman/foreman/blob/develop/bundler.d/vmware.rb#L2 ) and the [foreman spec](https://github.com/theforeman/foreman-packaging/blob/rpm/develop/packages/foreman/foreman/foreman.spec#L580) just by releasing a new gem, this would be used right away.

cc @timogoebel @chris1984  as the reason I submitted this mostly https://github.com/fog/fog-vsphere/pull/157 as you can see in the redmine issue,
