### PR TITLE
Update rubygem-hammer_cli to 0.15.0

### DIFF
--- a/packages/foreman/rubygem-hammer_cli/hammer_cli-0.14.0.gem
+++ b/packages/foreman/rubygem-hammer_cli/hammer_cli-0.14.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/fK/XW/SHA256E-s176640--d663d71af8666d4ba9ff59c5add541e92987f2ef0f2d63fc22d56a4fbda42be3.0.gem/SHA256E-s176640--d663d71af8666d4ba9ff59c5add541e92987f2ef0f2d63fc22d56a4fbda42be3.0.gem

--- a/packages/foreman/rubygem-hammer_cli/hammer_cli-0.15.0.gem
+++ b/packages/foreman/rubygem-hammer_cli/hammer_cli-0.15.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/PK/GF/SHA256E-s180736--09dcf39dc09bf6f140d9dc9fc1445adfa354b1c513021ef2fc6597acf9687d02.0.gem/SHA256E-s180736--09dcf39dc09bf6f140d9dc9fc1445adfa354b1c513021ef2fc6597acf9687d02.0.gem

--- a/packages/foreman/rubygem-hammer_cli/rubygem-hammer_cli.spec
+++ b/packages/foreman/rubygem-hammer_cli/rubygem-hammer_cli.spec
@@ -4,8 +4,7 @@
 %global gem_name hammer_cli
 %global confdir hammer
 
-%global release 2
-%global prerelease .pre.develop
+%global release 1
 
 %{!?_root_bindir:%global _root_bindir %{_bindir}}
 %{!?_root_mandir:%global _root_mandir %{_mandir}}
@@ -13,7 +12,7 @@
 
 Summary: Universal command-line interface for Foreman
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 0.15
+Version: 0.15.0
 Release: %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Group: Development/Languages
 License: GPLv3
@@ -127,6 +126,9 @@ install -m 755 .%{gem_instdir}/config/cli_config.template.yml \
 %{gem_instdir}/test
 
 %changelog
+* Wed Oct 24 2018 Martin Bacovsky <mbacovsk@redhat.com> 0.15.0-1
+- Update to 0.15.0
+
 * Wed Sep 12 2018 Eric D. Helms <ericdhelms@gmail.com> - 0.15-0.2.pre.develop
 - Add prerelease support
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [x] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
