### PR TITLE
Release foreman-installer 1.20.0-RC1.1

### DIFF
--- a/debian/bionic/foreman-installer/changelog
+++ b/debian/bionic/foreman-installer/changelog
@@ -1,3 +1,9 @@
+foreman-installer (1.20.0~rc1.1-1) stable; urgency=low
+
+  * 1.20.0-RC1.1 released
+
+ -- Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl>  Thu, 25 Oct 2018 15:38:13 +0200
+
 foreman-installer (1.20.0~rc1-1) stable; urgency=low
 
   * 1.20.0-RC1 released

--- a/debian/stretch/foreman-installer/changelog
+++ b/debian/stretch/foreman-installer/changelog
@@ -1,3 +1,9 @@
+foreman-installer (1.20.0~rc1.1-1) stable; urgency=low
+
+  * 1.20.0-RC1.1 released
+
+ -- Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl>  Thu, 25 Oct 2018 15:38:13 +0200
+
 foreman-installer (1.20.0~rc1-1) stable; urgency=low
 
   * 1.20.0-RC1 released

--- a/debian/xenial/foreman-installer/changelog
+++ b/debian/xenial/foreman-installer/changelog
@@ -1,3 +1,9 @@
+foreman-installer (1.20.0~rc1.1-1) stable; urgency=low
+
+  * 1.20.0-RC1.1 released
+
+ -- Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl>  Thu, 25 Oct 2018 15:38:13 +0200
+
 foreman-installer (1.20.0~rc1-1) stable; urgency=low
 
   * 1.20.0-RC1 released


### PR DESCRIPTION
There was a breaking regression in RC1 on Debian based distros with the
kafo modules directory handling.