### PR TITLE
Update rubygem-foreman_hooks to 0.3.15

### DIFF
--- a/packages/plugins/rubygem-foreman_hooks/foreman_hooks-0.3.14.gem
+++ b/packages/plugins/rubygem-foreman_hooks/foreman_hooks-0.3.14.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/FW/Fm/SHA256E-s26112--9c1bd70204ab41bb5fcc4a5ce30fcb4239c6ce2dc9bd03583994d83267d8a70e.14.gem/SHA256E-s26112--9c1bd70204ab41bb5fcc4a5ce30fcb4239c6ce2dc9bd03583994d83267d8a70e.14.gem

--- a/packages/plugins/rubygem-foreman_hooks/foreman_hooks-0.3.15.gem
+++ b/packages/plugins/rubygem-foreman_hooks/foreman_hooks-0.3.15.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/PP/fV/SHA256E-s26624--2ffbfb055653ef8c9c9da68ed8d2b0a7932f655bf14040952caf72346d207fb8.15.gem/SHA256E-s26624--2ffbfb055653ef8c9c9da68ed8d2b0a7932f655bf14040952caf72346d207fb8.15.gem

--- a/packages/plugins/rubygem-foreman_hooks/rubygem-foreman_hooks.spec
+++ b/packages/plugins/rubygem-foreman_hooks/rubygem-foreman_hooks.spec
@@ -8,8 +8,8 @@
 
 Summary:    Run custom hook scripts on Foreman events
 Name:       %{?scl_prefix}rubygem-%{gem_name}
-Version:    0.3.14
-Release:    3%{?foremandist}%{?dist}
+Version:    0.3.15
+Release:    1%{?foremandist}%{?dist}
 Group:      Applications/Systems
 License:    GPLv3
 URL:        https://github.com/theforeman/foreman_hooks
@@ -107,6 +107,9 @@ ln -s %{gem_instdir}/extra/foreman-debug.sh %{buildroot}%{foreman_dir}/script/fo
 exit 0
 
 %changelog
+* Fri Oct 26 2018 Evgeni Golov - 0.3.15-1
+- Release rubygem-foreman_hooks 0.3.15
+
 * Fri Sep 07 2018 Eric D. Helms <ericdhelms@gmail.com> - 0.3.14-3
 - Rebuild for Rails 5.2 and Ruby 2.5
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
