### PR TITLE
Correct source map behavior

### DIFF
--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -6,7 +6,7 @@
 %global gem_name katello
 %global prerelease .pre.master
 %global mainver 3.10.0
-%global release 3
+%global release 4
 
 Name:    %{?scl_prefix}rubygem-%{gem_name}
 Summary: Content and Subscription Management plugin for Foreman
@@ -327,7 +327,6 @@ cp -pa .%{gem_dir}/* \
 
 %foreman_bundlerd_file
 %foreman_precompile_plugin -a -s
-rm -f %{buildroot}%{foreman_webpack_plugin}/*.js.map
 
 %files
 %dir %{gem_instdir}
@@ -359,6 +358,9 @@ rm -f %{buildroot}%{foreman_webpack_plugin}/*.js.map
 %{gem_instdir}/webpack
 
 %changelog
+* Wed Oct 31 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.10.0-0.4.pre.master
+- Stop removing JS source maps
+
 * Thu Oct 25 2018 Adam Price <komidore64@gmail.com> - 3.10.0-0.3.pre.master
 - add nightly macro
 

--- a/packages/plugins/rubygem-foreman_ansible/rubygem-foreman_ansible.spec
+++ b/packages/plugins/rubygem-foreman_ansible/rubygem-foreman_ansible.spec
@@ -7,7 +7,7 @@
 Summary: Ansible integration with Foreman (theforeman.org)
 Name:    %{?scl_prefix}rubygem-%{gem_name}
 Version: 2.2.9
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Group:   Applications/System
 License: GPLv3
 URL:     https://github.com/theforeman/foreman_ansible
@@ -111,6 +111,9 @@ exit 0
 
 
 %changelog
+* Wed Oct 31 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 2.2.9-3
+- Revbump to correct source map handling
+
 * Wed Oct 31 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 2.2.9-2
 - Use the license macro
 - Remove rpmlint warnings

--- a/packages/plugins/rubygem-foreman_remote_execution/rubygem-foreman_remote_execution.spec
+++ b/packages/plugins/rubygem-foreman_remote_execution/rubygem-foreman_remote_execution.spec
@@ -14,7 +14,7 @@
 Summary:    Plugin that brings remote execution capabilities to Foreman
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    1.6.4
-Release:    1%{?foremandist}%{?dist}
+Release:    2%{?foremandist}%{?dist}
 Group:      Applications/System
 License:    GPLv3
 URL:        https://github.com/theforeman/foreman_remote_execution
@@ -77,7 +77,6 @@ rm %{buildroot}%{gem_instdir}/.babelrc
 
 %{foreman_bundlerd_file}
 %foreman_precompile_plugin -a -s
-rm -f %{buildroot}%{foreman_webpack_plugin}/*.js.map
 
 %posttrans
 %{foreman_db_migrate}
@@ -116,6 +115,9 @@ exit 0
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Oct 31 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.6.4-2
+- Stop removing JS source maps
+
 * Tue Oct 09 2018 Ivan Nečas <inecas@redhat.com> 1.6.4-1
 - Update to 1.6.4
 


### PR DESCRIPTION
This is now handled in the foreman_precompile_plugin macro so individual plugins no longer need to care about this.