### PR TITLE
foreman-installer - remove special variables for nightly building

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -192,12 +192,7 @@ foreman_nonscl_packages:
       - el7-foreman-nightly
   hosts:
     foreman-bootloaders-redhat: {}
-    foreman-installer:
-      releasers:
-        - "{{ nightly_releaser }}"
-      build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
-      nightly_package_tito_releaser_args:
-        - "--arg jenkins_job=packaging_trigger_installer_develop"
+    foreman-installer: {}
     foreman-proxy:
       releasers:
         - "{{ nightly_releaser }}"


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

this is to go along with theforeman/foreman-infra#859