### PR TITLE
Updated hammer-cli and hammer-cli-foreman to 0.15.1

### DIFF
--- a/dependencies/bionic/hammer_cli/changelog
+++ b/dependencies/bionic/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (0.15.1-1) stable; urgency=low
+
+  * 0.15.1 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Wed, 07 Nov 2018 01:09:45 +0100
+
 ruby-hammer-cli (0.15.0-1) stable; urgency=low
 
   * 0.15.0 released

--- a/dependencies/bionic/hammer_cli_foreman/changelog
+++ b/dependencies/bionic/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.15.1-1) stable; urgency=low
+
+  * 0.15.1 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Wed, 07 Nov 2018 01:11:54 +0100
+
 ruby-hammer-cli-foreman (0.15.0-1) stable; urgency=low
 
   * 0.15.0 released

--- a/dependencies/bionic/hammer_cli_foreman/control
+++ b/dependencies/bionic/hammer_cli_foreman/control
@@ -12,7 +12,7 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 0.15.0),
+         ruby-hammer-cli (>= 0.15.1),
          ruby-apipie-bindings (>= 0.2.2),
          ruby-rest-client (>= 1.8.0),
          ruby-rest-client (<< 3.0.0)

--- a/dependencies/stretch/hammer_cli/changelog
+++ b/dependencies/stretch/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (0.15.1-1) stable; urgency=low
+
+  * 0.15.1 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Wed, 07 Nov 2018 01:09:45 +0100
+
 ruby-hammer-cli (0.15.0-1) stable; urgency=low
 
   * 0.15.0 released

--- a/dependencies/stretch/hammer_cli_foreman/changelog
+++ b/dependencies/stretch/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.15.1-1) stable; urgency=low
+
+  * 0.15.1 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Wed, 07 Nov 2018 01:11:54 +0100
+
 ruby-hammer-cli-foreman (0.15.0-1) stable; urgency=low
 
   * 0.15.0 released

--- a/dependencies/stretch/hammer_cli_foreman/control
+++ b/dependencies/stretch/hammer_cli_foreman/control
@@ -12,7 +12,7 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 0.15.0),
+         ruby-hammer-cli (>= 0.15.1),
          ruby-apipie-bindings (>= 0.2.2),
          ruby-rest-client (>= 1.8.0),
          ruby-rest-client (<< 3.0.0)

--- a/dependencies/xenial/hammer_cli/changelog
+++ b/dependencies/xenial/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (0.15.1-1) stable; urgency=low
+
+  * 0.15.1 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Wed, 07 Nov 2018 01:09:45 +0100
+
 ruby-hammer-cli (0.15.0-1) stable; urgency=low
 
   * 0.15.0 released

--- a/dependencies/xenial/hammer_cli_foreman/changelog
+++ b/dependencies/xenial/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.15.1-1) stable; urgency=low
+
+  * 0.15.1 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Wed, 07 Nov 2018 01:11:54 +0100
+
 ruby-hammer-cli-foreman (0.15.0-1) stable; urgency=low
 
   * 0.15.0 released

--- a/dependencies/xenial/hammer_cli_foreman/control
+++ b/dependencies/xenial/hammer_cli_foreman/control
@@ -12,7 +12,7 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 0.15.0),
+         ruby-hammer-cli (>= 0.15.1),
          ruby-apipie-bindings (>= 0.2.2),
          ruby-rest-client (>= 1.8.0),
          ruby-rest-client (<< 3.0.0)


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [x] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
