### PR TITLE
katello-host-tools 3.3.2-3

### DIFF
--- a/packages/katello/katello-host-tools/katello-host-tools.spec
+++ b/packages/katello/katello-host-tools/katello-host-tools.spec
@@ -15,7 +15,7 @@
 
 Name: katello-host-tools
 Version: 3.3.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A set of commands and yum plugins that support a Katello host
 Group:   Development/Languages
 License: LGPLv2
@@ -86,7 +86,7 @@ Requires: python-gofer-proton >= 2.5
 %endif
 
 Requires: subscription-manager
-Requires: katello-host-tools
+Requires: katello-host-tools = %{version}-%{release}
 
 %if 0%{?rhel} == 6
 Requires: yum-plugin-security
@@ -356,6 +356,9 @@ exit 0
 %endif #build_tracer
 
 %changelog
+* Tue Nov 13 2018 Jonathon Turel <jturel@gmail.com> - 3.3.2-2
+- Fix katello-agent upgrades from old versions
+
 * Fri Jul 13 2018 Jonathon Turel <jturel@gmail.com> - 3.3.2-1
 - Fixes #24214 - fill in vars on repo URLs (cduryee@redhat.com)
 

--- a/packages/katello/katello-host-tools/katello-host-tools.spec
+++ b/packages/katello/katello-host-tools/katello-host-tools.spec
@@ -15,7 +15,7 @@
 
 Name: katello-host-tools
 Version: 3.3.2
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: A set of commands and yum plugins that support a Katello host
 Group:   Development/Languages
 License: LGPLv2
@@ -77,6 +77,8 @@ Requires: python-pulp-agent-lib >= 2.6
 Requires: pulp-rpm-handlers >= 2.6
 %else
 Requires: gofer >= 2.12.1
+Obsoletes: python-pulp-agent-lib < 3.0
+Obsoletes: pulp-rpm-handlers < 3.0
 %endif
 
 %if %{dnf_install}
@@ -356,8 +358,11 @@ exit 0
 %endif #build_tracer
 
 %changelog
-* Tue Nov 13 2018 Jonathon Turel <jturel@gmail.com> - 3.3.2-2
+* Tue Nov 13 2018 Jonathon Turel <jturel@gmail.com> - 3.3.2-3
 - Fix katello-agent upgrades from old versions
+
+* Tue Jul 17 2018 Jonathon Turel <jturel@gmail.com> - 3.3.2-2
+- Fix obsoletes
 
 * Fri Jul 13 2018 Jonathon Turel <jturel@gmail.com> - 3.3.2-1
 - Fixes #24214 - fill in vars on repo URLs (cduryee@redhat.com)


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [ ] 1.20
* [ ] 1.19
* [x] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
