### PR TITLE
drop foremandist from the release of core gems

### DIFF
--- a/packages/foreman/rubygem-concurrent-ruby-edge/rubygem-concurrent-ruby-edge.spec
+++ b/packages/foreman/rubygem-concurrent-ruby-edge/rubygem-concurrent-ruby-edge.spec
@@ -6,7 +6,7 @@
 Summary: Edge concepts for the modern concurrency tools for Ruby
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.2.4
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?dist}
 Epoch: 1
 Group: Development/Languages
 
@@ -75,6 +75,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_docdir}
 
 %changelog
+* Thu Nov 15 2018 Evgeni Golov - 1:0.2.4-3
+- Drop foremandist from the release
+
 * Wed Sep 05 2018 Eric D. Helms <ericdhelms@gmail.com> - 1:0.2.4-2
 - Rebuild for Rails 5.2 and Ruby 2.5
 

--- a/packages/foreman/rubygem-concurrent-ruby/rubygem-concurrent-ruby.spec
+++ b/packages/foreman/rubygem-concurrent-ruby/rubygem-concurrent-ruby.spec
@@ -6,7 +6,7 @@
 Summary: Modern concurrency tools for Ruby
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.3
-Release: 6%{?foremandist}%{?dist}
+Release: 7%{?dist}
 Epoch: 1
 Group: Development/Languages
 
@@ -75,6 +75,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_docdir}
 
 %changelog
+* Thu Nov 15 2018 Evgeni Golov - 1:1.0.3-7
+- Drop foremandist from the release
+
 * Tue Jan 09 2018 Eric D. Helms <ericdhelms@gmail.com> 1.0.3-6
 - Bump releases for base foreman plugins packages (ericdhelms@gmail.com)
 - Use HTTPS URLs for github and rubygems (ewoud@kohlvanwijngaarden.nl)

--- a/packages/foreman/rubygem-dynflow/rubygem-dynflow.spec
+++ b/packages/foreman/rubygem-dynflow/rubygem-dynflow.spec
@@ -6,7 +6,7 @@
 Summary: DYNamic workFLOW engine
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.1.2
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?dist}
 Group: Development/Languages
 License: MIT
 URL: https://github.com/Dynflow/dynflow
@@ -88,6 +88,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/examples
 
 %changelog
+* Thu Nov 15 2018 Evgeni Golov - 1.1.2-2
+- Drop foremandist from the release
+
 * Thu Nov 15 2018 Evgeni Golov - 1.1.2-1
 - Release rubygem-dynflow 1.1.2
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
