### PR TITLE
Refs #25489 - Update fog-vsphere gem to 2.5.0

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -8,7 +8,7 @@
 %global scl_ruby_bin /usr/bin/%{?scl:%{scl_prefix}}ruby
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 3
+%global release 4
 %global prerelease develop
 
 Name:    foreman
@@ -577,7 +577,7 @@ Meta package to install requirements for Rackspace compute resource support.
 Summary: Foreman VMware support
 Group:  Applications/System
 # start specfile vmware Requires
-Requires: %{?scl_prefix}rubygem(fog-vsphere) >= 2.3.0
+Requires: %{?scl_prefix}rubygem(fog-vsphere) >= 2.5.0
 Requires: %{?scl_prefix}rubygem(rbvmomi) >= 1.9.0
 # end specfile vmware Requires
 Requires: %{name} = %{version}-%{release}
@@ -1286,6 +1286,9 @@ exit 0
 %systemd_postun_with_restart %{name}.service
 
 %changelog
+* Fri Nov 16 2018 Chris Roberts <chrobert@redhat.com - 1.21.0-0.4.develop
+- Update fog-vsphere to v2.5.0
+
 * Wed Oct 31 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.21.0-0.3.develop
 - Remove *.js.map file after asset precompile
 

--- a/packages/foreman/rubygem-fog-vsphere/fog-vsphere-2.4.0.gem
+++ b/packages/foreman/rubygem-fog-vsphere/fog-vsphere-2.4.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/Ww/Vz/SHA256E-s72704--bcbe099ecb256682e0e18d32bdf3d83c1c48a37d6446ef97dd24cb2d9987689c.0.gem/SHA256E-s72704--bcbe099ecb256682e0e18d32bdf3d83c1c48a37d6446ef97dd24cb2d9987689c.0.gem

--- a/packages/foreman/rubygem-fog-vsphere/fog-vsphere-2.5.0.gem
+++ b/packages/foreman/rubygem-fog-vsphere/fog-vsphere-2.5.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/4w/jQ/SHA256E-s73728--08c0ee398f3d1b2343be3a48a1c8398fa9a991f326bf3aee4a74c7f68d1a60cb.0.gem/SHA256E-s73728--08c0ee398f3d1b2343be3a48a1c8398fa9a991f326bf3aee4a74c7f68d1a60cb.0.gem

--- a/packages/foreman/rubygem-fog-vsphere/rubygem-fog-vsphere.spec
+++ b/packages/foreman/rubygem-fog-vsphere/rubygem-fog-vsphere.spec
@@ -4,7 +4,7 @@
 %global gem_name fog-vsphere
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 2.4.0
+Version: 2.5.0
 Release: 1%{?dist}
 Summary: Module for the 'fog' gem to support VMware vSphere
 Group: Development/Languages
@@ -88,6 +88,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/tests
 
 %changelog
+* Tue Nov 16 2018 Chris Roberts <chrobert@redhat.com> - 2.5.0-1
+- Update fog-vsphere to 2.5.0
+
 * Tue Oct 16 2018 Timo Goebel <mail@timogoebel.name> - 2.4.0-1
 - Update fog-vsphere to 2.4.0
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
