### PR TITLE
Move rubygem-katello and rubygem-hammer* requires to katello

### DIFF
--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -4,7 +4,7 @@
 %global homedir %{_datarootdir}/%{name}
 %global confdir common
 # %%global prerelease .rc1
-%global release 5
+%global release 6
 
 Name:       katello
 Version:    3.10.0
@@ -36,6 +36,11 @@ BuildRequires: util-linux
 Requires: %{name}-common = %{version}-%{release}
 
 Requires: foreman-installer-%{name}
+
+Requires: %{?scl_prefix}rubygem-katello
+Requires: %{?scl_prefix}rubygem-hammer_cli
+Requires: %{?scl_prefix}rubygem-hammer_cli_foreman
+Requires: %{?scl_prefix}rubygem-hammer_cli_katello
 
 #Pulp Requirements
 Requires: pulp-katello
@@ -122,10 +127,6 @@ install -m 644 ./manpages/katello-change-hostname.8.gz %{buildroot}/%{_mandir}/m
 BuildArch:  noarch
 Summary:    Common runtime components of %{name}
 
-Requires:       %{?scl_prefix}rubygem-katello
-Requires:       %{?scl_prefix}rubygem-hammer_cli
-Requires:       %{?scl_prefix}rubygem-hammer_cli_foreman
-Requires:       %{?scl_prefix}rubygem-hammer_cli_katello
 Requires:       rubygem-highline
 Requires:       %{name}-debug
 Requires:       %{name}-service
@@ -195,6 +196,9 @@ Useful utilities for managing Katello services
 %{_sysconfdir}/bash_completion.d/katello-service
 
 %changelog
+* Mon Nov 19 2018 Evgeni Golov - 3.10.0-6
+- Move rubygem-katello and rubygem-hammer* requires to katello
+
 * Tue Nov 13 2018 Evgeni Golov - 3.10.0-5
 - Drop rubygem-highline from foreman-proxy-content requires
 


### PR DESCRIPTION
These are not *common* as they are not required on the content proxy.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
