### PR TITLE
set foremandist for all (non client) releasers

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -2,12 +2,14 @@
 [koji-foreman]
 releaser = tito.release.KojiReleaser
 autobuild_tags = foreman-nightly-nonscl-rhel7 foreman-nightly-rhel7
+builder.rpmbuild_options = --define "foremandist .fm1_21"
 
 [koji-foreman-jenkins]
 releaser = tito.release.KojiReleaser
 autobuild_tags = foreman-nightly-nonscl-rhel7 foreman-nightly-rhel7
 builder = tito.builder.FetchBuilder
 builder.jenkins_url = https://ci.theforeman.org
+builder.rpmbuild_options = --define "foremandist .fm1_21"
 
 [koji-foreman-plugins]
 releaser = tito.release.KojiReleaser
@@ -40,3 +42,4 @@ releaser = tito.release.KojiReleaser
 autobuild_tags = katello-nightly-rhel7
 builder = tito.builder.FetchBuilder
 builder.jenkins_url = https://ci.theforeman.org
+builder.rpmbuild_options = --define "foremandist .fm1_21"


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
