### PR TITLE
don't whitelist foreman-release for foreman-client-nightly-rhel7

### DIFF
--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -435,7 +435,8 @@ whitelist = ansiblerole-insights-client
 
 [foreman-client-nightly-rhel7]
 disttag = .el7
-whitelist = foreman-release
+whitelist =
+  # don't whitelist foreman-release here, it's already in foreman-nightly-nonscl-rhel7
   katello-host-tools
   rubygem-foreman_scap_client
 


### PR DESCRIPTION
it's already in foreman-nightly-nonscl-rhel7 and building it for both
results in `GenericError: Build already in progress` as both targets
produce the same NEVR.

See https://ci.theforeman.org/job/foreman-packaging-release/224/console for an example build that failed due to this.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
