### PR TITLE
Bump Katello to 3.11

### DIFF
--- a/packages/katello/katello-installer-base/katello-installer-base.spec
+++ b/packages/katello/katello-installer-base/katello-installer-base.spec
@@ -3,10 +3,10 @@
 %global scl_ruby /usr/bin/ruby
 
 %global prerelease master
-%global release 4
+%global release 1
 
 Name:    katello-installer-base
-Version: 3.10.0
+Version: 3.11.0
 Release: %{?prerelease:0.}%{release}%{?prerelease:.}%{?prerelease}%{?nightly}%{?dist}
 Summary: Puppet-based installer for the Katello and Foreman proxies with content
 Group:   Applications/System
@@ -110,6 +110,9 @@ ln -sf %{_datadir}/foreman-installer-katello/bin/katello-certs-check %{buildroot
 %doc README.*
 
 %changelog
+* Fri Nov 30 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.11.0-0.1.master
+- Bump version to 3.11
+
 * Fri Nov 02 2018 Evgeni Golov - 3.10.0-0.4.master
 - Don't obsolete/migrate old Capsule setups anymore
 

--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -6,10 +6,10 @@
 %define repo_dist %{dist}
 
 %global prerelease .nightly
-%global release 4
+%global release 1
 
 Name:           katello-repos
-Version:        3.10.0
+Version:        3.11.0
 Release:        %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:        Definition of yum repositories for Katello
 
@@ -77,6 +77,9 @@ rm -rf %{buildroot}
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-katello
 
 %changelog
+* Fri Nov 30 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.11.0-0.1.nightly
+- Bump version to 3.11
+
 * Mon Nov 26 2018 John Mitsch <parthaa@redhat.com> - 3.10.0-0.4.nightly
 - Switch to Pulp 2-18 beta
 

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -3,11 +3,11 @@
 
 %global homedir %{_datarootdir}/%{name}
 %global confdir common
-# %%global prerelease .rc1
-%global release 6
+%global prerelease .master
+%global release 1
 
 Name:       katello
-Version:    3.10.0
+Version:    3.11.0
 Release:    %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:    A package for managing application life-cycle for Linux systems
 BuildArch:  noarch
@@ -196,6 +196,9 @@ Useful utilities for managing Katello services
 %{_sysconfdir}/bash_completion.d/katello-service
 
 %changelog
+* Fri Nov 30 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.11.0-1
+- Bump version to 3.11
+
 * Mon Nov 19 2018 Evgeni Golov - 3.10.0-6
 - Move rubygem-katello and rubygem-hammer* requires to katello
 
@@ -207,7 +210,7 @@ Useful utilities for managing Katello services
   This allows foreman-proxy-content to depend on k-common.
 
 * Tue Oct 23 2018 sokeeffe <sokeeffe@redhat.com> - 3.10.0-3
-- Split out Katello and Smart Proxy Cron 
+- Split out Katello and Smart Proxy Cron
 
 * Mon Oct 22 2018 Chris Roberts <chrobert@redhat.com> - 3.10.0-2
 - Change katello-remove to support wildcards and cleanup

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -5,8 +5,8 @@
 %global plugin_name katello
 %global gem_name katello
 %global prerelease .pre.master
-%global mainver 3.10.0
-%global release 4
+%global mainver 3.11.0
+%global release 1
 
 Name:    %{?scl_prefix}rubygem-%{gem_name}
 Summary: Content and Subscription Management plugin for Foreman
@@ -358,6 +358,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/webpack
 
 %changelog
+* Fri Nov 30 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.11.0-0.1.pre.master
+- Bump version to 3.11
+
 * Wed Oct 31 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.10.0-0.4.pre.master
 - Stop removing JS source maps
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
