### PR TITLE
bump foreman_datacenter to 0.1.55

### DIFF
--- a/plugins/ruby-foreman-datacenter/debian/changelog
+++ b/plugins/ruby-foreman-datacenter/debian/changelog
@@ -1,3 +1,69 @@
+ruby-foreman-datacenter (0.1.55) stable; urgency=low
+
+  * 0.1.55 released
+
+ -- Eugene Loginov <foreman@cloudevelops.com>  Fri, 30 Nov 2018 12:00:00 +0200
+
+ruby-foreman-datacenter (0.1.54) stable; urgency=low
+
+  * 0.1.54 released
+
+ -- Eugene Loginov <foreman@cloudevelops.com>  Tue, 14 Aug 2018 12:00:00 +0200
+
+ruby-foreman-datacenter (0.1.53) stable; urgency=low
+
+  * 0.1.53 released
+
+ -- Eugene Loginov <foreman@cloudevelops.com>  Mon, 23 Jul 2018 12:00:00 +0200
+
+ruby-foreman-datacenter (0.1.52) stable; urgency=low
+
+  * 0.1.52 released
+
+ -- Eugene Loginov <foreman@cloudevelops.com>  Sun, 24 Jun 2018 12:00:00 +0200
+
+ruby-foreman-datacenter (0.1.51) stable; urgency=low
+
+  * 0.1.51 released
+
+ -- Eugene Loginov <foreman@cloudevelops.com>  Thu, 14 Jun 2018 12:00:00 +0200
+
+ruby-foreman-datacenter (0.1.50) stable; urgency=low
+
+  * 0.1.50 released
+
+ -- Eugene Loginov <foreman@cloudevelops.com>  Fri, 11 May 2018 12:00:00 +0200
+
+ruby-foreman-datacenter (0.1.49) stable; urgency=low
+
+  * 0.1.49 released
+
+ -- Eugene Loginov <foreman@cloudevelops.com>  Tue, 13 Mar 2018 12:00:00 +0200
+
+ruby-foreman-datacenter (0.1.48) stable; urgency=low
+
+  * 0.1.48 released
+
+ -- Eugene Loginov <foreman@cloudevelops.com>  Fri, 23 Feb 2018 12:10:00 +0200
+
+ruby-foreman-datacenter (0.1.47) stable; urgency=low
+
+  * 0.1.47 released
+
+ -- Eugene Loginov <foreman@cloudevelops.com>  Fri, 23 Feb 2018 12:00:00 +0200
+
+ruby-foreman-datacenter (0.1.46) stable; urgency=low
+
+  * 0.1.46 released
+
+ -- Eugene Loginov <foreman@cloudevelops.com>  Mon, 19 Feb 2018 12:00:00 +0200
+
+ruby-foreman-datacenter (0.1.45) stable; urgency=low
+
+  * 0.1.45 released
+
+ -- Eugene Loginov <foreman@cloudevelops.com>  Tue, 23 Jan 2018 12:00:00 +0200
+
 ruby-foreman-datacenter (0.1.44) stable; urgency=low
 
   * 0.1.44 released

--- a/plugins/ruby-foreman-datacenter/debian/control
+++ b/plugins/ruby-foreman-datacenter/debian/control
@@ -2,12 +2,12 @@ Source: ruby-foreman-datacenter
 Section: ruby
 Priority: extra
 Maintainer: Cloudevelops <foreman@cloudevelops.com>
-Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.15.0), foreman-sqlite3 (>= 1.15.0), ruby-foreman-deface (<<2.0.0)
+Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.18.0), foreman-sqlite3 (>= 1.18.0), ruby-foreman-deface (<<2.0.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/cloudevelops/foreman_datacenter
 
 Package: ruby-foreman-datacenter
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.15.0), foreman-compute (>= 1.15.0), ruby-foreman-deface (<<2.0.0)
+Depends: ${misc:Depends}, bundler, foreman (>= 1.18.0), foreman-compute (>= 1.18.0), ruby-foreman-deface (<<2.0.0)
 Description: Foreman Datacenter for managing physical servers
  Foreman Datacenter lets you document your physical servers across multiple datacenters

--- a/plugins/ruby-foreman-datacenter/debian/gem.list
+++ b/plugins/ruby-foreman-datacenter/debian/gem.list
@@ -1,5 +1,5 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_datacenter-0.1.44.gem"
+GEMS="https://rubygems.org/downloads/foreman_datacenter-0.1.55.gem"
 GEMS="$GEMS https://rubygems.org/downloads/prawn-2.2.2.gem"
 GEMS="$GEMS https://rubygems.org/downloads/pdf-core-0.7.0.gem"
 GEMS="$GEMS https://rubygems.org/downloads/ttfunk-1.5.1.gem"

--- a/plugins/ruby-foreman-datacenter/foreman_datacenter.rb
+++ b/plugins/ruby-foreman-datacenter/foreman_datacenter.rb
@@ -1,1 +1,1 @@
-gem 'foreman_datacenter', '0.1.44'
+gem 'foreman_datacenter', '0.1.55'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.20
* [x] 1.19
* [x] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
