### PR TITLE
Update ovirt_provision_plugin to 2.0.1

### DIFF
--- a/packages/plugins/rubygem-ovirt_provision_plugin/ovirt_provision_plugin-1.0.2.gem
+++ b/packages/plugins/rubygem-ovirt_provision_plugin/ovirt_provision_plugin-1.0.2.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/z9/7P/SHA256E-s19456--fe8457f80d7ba204729a571157abca30b14c01f1b7d1ce67a57e1c8daf62dd80.2.gem/SHA256E-s19456--fe8457f80d7ba204729a571157abca30b14c01f1b7d1ce67a57e1c8daf62dd80.2.gem

--- a/packages/plugins/rubygem-ovirt_provision_plugin/ovirt_provision_plugin-2.0.2.gem
+++ b/packages/plugins/rubygem-ovirt_provision_plugin/ovirt_provision_plugin-2.0.2.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/jj/X1/SHA256E-s19456--2b439bda87fd9e91435998aabccb128f1c3ad91893b57f8a5d05b1eaddc59b22.2.gem/SHA256E-s19456--2b439bda87fd9e91435998aabccb128f1c3ad91893b57f8a5d05b1eaddc59b22.2.gem

--- a/packages/plugins/rubygem-ovirt_provision_plugin/rubygem-ovirt_provision_plugin.spec
+++ b/packages/plugins/rubygem-ovirt_provision_plugin/rubygem-ovirt_provision_plugin.spec
@@ -17,8 +17,8 @@
 
 Summary:    Foreman plugin to provision new hosts and integrate to oVirt Engine
 Name:       %{?scl_prefix}rubygem-%{gem_name}
-Version:    1.0.2
-Release:    2%{?foremandist}%{?dist}
+Version:    2.0.2
+Release:    1%{?foremandist}%{?dist}
 Group:      Applications/System
 License:    GPLv3
 URL:        https://github.com/theforeman/ovirt_provision_plugin
@@ -93,6 +93,9 @@ GEMFILE
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Dec 12 2018 Moti Asayag <masayag@redhat.com> 2.0.2-1
+- Update to 2.0.2
+
 * Tue Jan 09 2018 Eric D. Helms <ericdhelms@gmail.com> 1.0.2-2
 - Bump releases for base foreman plugins packages (ericdhelms@gmail.com)
 - Use HTTPS URLs for github and rubygems (ewoud@kohlvanwijngaarden.nl)


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
