### PR TITLE
Make the Requires script more robust if manifest.json cannot be found

### DIFF
--- a/packages/foreman/foreman/foreman.provreq
+++ b/packages/foreman/foreman/foreman.provreq
@@ -34,6 +34,9 @@ def foreman_webpack(name, chunk):
 def parse_manifest(manifest_path):
     webpack_chunks = set()
 
+    if not os.path.exists(manifest_path):
+        return webpack_chunks
+
     with open(manifest_path) as fh:
         manifest = json.load(fh)
 

--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -8,7 +8,7 @@
 %global scl_ruby_bin /usr/bin/%{?scl:%{scl_prefix}}ruby
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 5
+%global release 6
 %global prerelease develop
 
 Name:    foreman
@@ -1288,6 +1288,9 @@ exit 0
 %systemd_postun_with_restart %{name}.service
 
 %changelog
+* Wed Dec 05 2018 Evgeni Golov - 1.21.0-0.6.develop
+- Make the Requires script more robust if the manifest.json cannot be found
+
 * Thu Nov 29 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.21.0-0.5.develop
 - Update Gem and NPM dependencies
 


### PR DESCRIPTION
When building foreman itself, we call both, the requires and the
provides script, but as foreman is not installed when building foreman,
the requires script can't find the installed foreman's manifest.json and
errors:

    BUILDSTDERR: Traceback (most recent call last):
    BUILDSTDERR:   File "/usr/lib/rpm/foreman.req", line 64, in <module>
    BUILDSTDERR:     result.update(parse_manifest(FOREMAN_MANIFEST))
    BUILDSTDERR:   File "/usr/lib/rpm/foreman.req", line 37, in parse_manifest
    BUILDSTDERR:     with open(manifest_path) as fh:
    BUILDSTDERR: IOError: [Errno 2] No such file or directory: '/var/lib/foreman/public/webpack/manifest.json'

While not a real problem (rpm handles the error gracefuly), the output
is missleading and might cause confusion when debugging build errors.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
