### PR TITLE
Bump release on rubygem-katello-3.10 to rebuild for webpack

### DIFF
--- a/packages/katello-3.10/rubygem-katello-3.10/rubygem-katello.spec
+++ b/packages/katello-3.10/rubygem-katello-3.10/rubygem-katello.spec
@@ -6,7 +6,7 @@
 %global gem_name katello
 %global mainver 3.10.0
 %global prerelease .rc1.1
-%global release 1
+%global release 2
 
 Name:    %{?scl_prefix}rubygem-%{gem_name}
 Summary: Content and Subscription Management plugin for Foreman
@@ -359,6 +359,9 @@ rm -f %{buildroot}%{foreman_webpack_plugin}/*.js.map
 %{gem_instdir}/webpack
 
 %changelog
+* Fri Dec 07 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.10.0-0.2.rc1.1
+- Bump release to rebuild for webpack
+
 * Wed Dec 05 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.10.0-0.1.rc1.1
 - Release 3.10.0.rc1.1
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
