### PR TITLE
Update foreman-tasks to 0.14.4

### DIFF
--- a/plugins/ruby-foreman-tasks/debian/changelog
+++ b/plugins/ruby-foreman-tasks/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-tasks (0.14.4-1) stable; urgency=low
+
+  * 0.14.4 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Tue, 11 Dec 2018 10:02:55 +0100
+
 ruby-foreman-tasks (0.14.3-1) stable; urgency=low
 
   * 0.14.3 released

--- a/plugins/ruby-foreman-tasks/debian/gem.list
+++ b/plugins/ruby-foreman-tasks/debian/gem.list
@@ -1,5 +1,5 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman-tasks-0.14.3.gem"
+GEMS="https://rubygems.org/downloads/foreman-tasks-0.14.4.gem"
 GEMS="$GEMS https://rubygems.org/downloads/foreman-tasks-core-0.2.5.gem"
 GEMS="$GEMS https://rubygems.org/downloads/parse-cron-0.1.4.gem"
 GEMS="$GEMS https://rubygems.org/downloads/sinatra-2.0.4.gem"

--- a/plugins/ruby-foreman-tasks/foreman-tasks.rb
+++ b/plugins/ruby-foreman-tasks/foreman-tasks.rb
@@ -1,1 +1,1 @@
-gem 'foreman-tasks', '0.14.3'
+gem 'foreman-tasks', '0.14.4'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
