### PR TITLE
katello-host-tools 3.4.1

### DIFF
--- a/packages/client/katello-host-tools/katello-host-tools-3.4.0.tar.gz
+++ b/packages/client/katello-host-tools/katello-host-tools-3.4.0.tar.gz
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/J5/GP/SHA256E-s34238--307a73fe7d8df08fcfc5ac6299de8ab479f3befb508fa13c9802cbbb05ac7f35.tar.gz/SHA256E-s34238--307a73fe7d8df08fcfc5ac6299de8ab479f3befb508fa13c9802cbbb05ac7f35.tar.gz

--- a/packages/client/katello-host-tools/katello-host-tools-3.4.1.tar.gz
+++ b/packages/client/katello-host-tools/katello-host-tools-3.4.1.tar.gz
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/5g/Kv/SHA256E-s35693--df2c23bc1622ebfbb0e901de4418809512f68ba113152aeedc5c382371beee32.tar.gz/SHA256E-s35693--df2c23bc1622ebfbb0e901de4418809512f68ba113152aeedc5c382371beee32.tar.gz


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
