### PR TITLE
Update foreman_remote_execution to 1.6.7

### DIFF
--- a/plugins/ruby-foreman-remote-execution/debian/changelog
+++ b/plugins/ruby-foreman-remote-execution/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution (1.6.7-1) stable; urgency=low
+
+  * 1.6.7 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Wed, 12 Dec 2018 18:06:38 +0100
+
 ruby-foreman-remote-execution (1.6.6-1) stable; urgency=low
 
   * 1.6.6 released

--- a/plugins/ruby-foreman-remote-execution/debian/gem.list
+++ b/plugins/ruby-foreman-remote-execution/debian/gem.list
@@ -1,3 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.6.6.gem"
+GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.6.7.gem"
 GEMS="$GEMS https://rubygems.org/downloads/foreman_remote_execution_core-1.1.4.gem"

--- a/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
+++ b/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
@@ -1,1 +1,1 @@
-gem 'foreman_remote_execution', '1.6.6'
+gem 'foreman_remote_execution', '1.6.7'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

This should be the last 1.20 rex release (except security fixes)
