### PR TITLE
Update dynflow to 1.1.6

### DIFF
--- a/dependencies/bionic/dynflow/changelog
+++ b/dependencies/bionic/dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-dynflow (1.1.6-1) stable; urgency=low
+
+  * 1.1.6 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Thu, 13 Dec 2018 11:26:18 +0100
+
 ruby-dynflow (1.1.2-1) stable; urgency=low
 
   * 1.1.2 released

--- a/dependencies/stretch/dynflow/changelog
+++ b/dependencies/stretch/dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-dynflow (1.1.6-1) stable; urgency=low
+
+  * 1.1.6 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Thu, 13 Dec 2018 11:26:18 +0100
+
 ruby-dynflow (1.1.2-1) stable; urgency=low
 
   * 1.1.2 released

--- a/dependencies/xenial/dynflow/changelog
+++ b/dependencies/xenial/dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-dynflow (1.1.6-1) stable; urgency=low
+
+  * 1.1.6 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Thu, 13 Dec 2018 11:26:18 +0100
+
 ruby-dynflow (1.1.2-1) stable; urgency=low
 
   * 1.1.2 released


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

Last planned update of dynlfow for 1.20