### PR TITLE
Update the github template in deb/develop

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
 For plugin updates, please indicate which repos this should be built into:
 
 * [x] Nightly
-* [ ] 1.11
-* [ ] 1.10
-* [ ] 1.9
+* [ ] 1.20
+* [ ] 1.19
+* [ ] 1.18
 
-See Foreman's [plugin maintainer documentation](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
+See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
 
 ---


### PR DESCRIPTION
When using `hub` cli, it was pulling wrong template.


For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---