### PR TITLE
Add more env vars to the foreman service

### DIFF
--- a/packages/foreman/foreman/foreman.service
+++ b/packages/foreman/foreman/foreman.service
@@ -5,11 +5,11 @@ After=network.target remote-fs.target nss-lookup.target
 
 [Service]
 Type=simple
-User=foreman
+User=$FOREMAN_USER
 TimeoutSec=300
 WorkingDirectory=/usr/share/foreman
-ExecStart=/usr/bin/scl enable tfm "rails server -e $FOREMAN_ENV -p $FOREMAN_PORT"
-Environment=FOREMAN_ENV=production FOREMAN_PORT=3000
+ExecStart=/usr/bin/scl enable tfm "rails server -e $FOREMAN_ENV -p $FOREMAN_PORT -b $FOREMAN_IFACE"
+Environment=FOREMAN_ENV=production FOREMAN_PORT=3000 FOREMAN_IFACE=0.0.0.0 FOREMAN_USER=foreman
 EnvironmentFile=-/etc/sysconfig/foreman
 
 [Install]

--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -8,7 +8,7 @@
 %global scl_ruby_bin /usr/bin/%{?scl:%{scl_prefix}}ruby
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 6
+%global release 7
 %global prerelease develop
 
 Name:    foreman
@@ -1288,6 +1288,9 @@ exit 0
 %systemd_postun_with_restart %{name}.service
 
 %changelog
+* Mon Dec 17 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.21.0-0.7.develop
+- Add more env vars to the foreman service
+
 * Wed Dec 05 2018 Evgeni Golov - 1.21.0-0.6.develop
 - Make the Requires script more robust if the manifest.json cannot be found
 


### PR DESCRIPTION
These are the same ones as used in the old sysvinit script and the installer can be made generic.