### PR TITLE
Update smart_proxy_ansible to 2.1.0

### DIFF
--- a/plugins/smart_proxy_ansible/ansible.rb
+++ b/plugins/smart_proxy_ansible/ansible.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_ansible', '2.0.3'
+gem 'smart_proxy_ansible', '2.1.0'

--- a/plugins/smart_proxy_ansible/changelog
+++ b/plugins/smart_proxy_ansible/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-ansible (2.1.0-1) stable; urgency=low
+
+  * 2.1.0 released
+
+ -- Michael Moll <mmoll@mmoll.at>  Sun, 23 Dec 2018 14:20:00 +0100
+
 ruby-smart-proxy-ansible (2.0.3-2) stable; urgency=low
 
   * Fix smart-proxy-dynflow dependency


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
