### PR TITLE
Add epoch to changelog

### DIFF
--- a/bump_rpm.sh
+++ b/bump_rpm.sh
@@ -54,7 +54,8 @@ if [[ $CURRENT_VERSION != $NEW_VERSION ]] ; then
 		sed -i "s/^\(Release:\s\+\)${RELEASE}/\11/" $SPEC_FILE
 	fi
 
-	$ROOT/add_changelog.sh $SPEC_FILE ${NEW_VERSION}-1 <<-EOF
+	EVR=$(rpmspec --srpm -q --queryformat='%{evr}' --undefine=dist $SPEC_FILE)
+	$ROOT/add_changelog.sh $SPEC_FILE $EVR <<-EOF
 	- Update to $NEW_VERSION
 	EOF
 


### PR DESCRIPTION
Otherwise the obal lint complains on version comparison.

I've hit issues when updating concurrent-ruby, that is using epoch number (https://github.com/theforeman/foreman-packaging/pull/3328)


For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---