### PR TITLE
Update rubygem-concurrent-ruby to 1.1.4 (rpm)

### DIFF
--- a/packages/foreman/rubygem-concurrent-ruby/concurrent-ruby-1.0.3.gem
+++ b/packages/foreman/rubygem-concurrent-ruby/concurrent-ruby-1.0.3.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/Pw/w6/SHA256E-s131584--f147ee7b088953d964f09b12c8c99cbed839426747dbbb22e48f16edf47a8dea.3.gem/SHA256E-s131584--f147ee7b088953d964f09b12c8c99cbed839426747dbbb22e48f16edf47a8dea.3.gem

--- a/packages/foreman/rubygem-concurrent-ruby/concurrent-ruby-1.1.4.gem
+++ b/packages/foreman/rubygem-concurrent-ruby/concurrent-ruby-1.1.4.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/KK/3w/SHA256E-s353792--e12e6ab140d8d99c14763a605b9671a5e182d4bf6dc951d4cb5debe86eeaacc7.4.gem/SHA256E-s353792--e12e6ab140d8d99c14763a605b9671a5e182d4bf6dc951d4cb5debe86eeaacc7.4.gem

--- a/packages/foreman/rubygem-concurrent-ruby/rubygem-concurrent-ruby.spec
+++ b/packages/foreman/rubygem-concurrent-ruby/rubygem-concurrent-ruby.spec
@@ -5,8 +5,8 @@
 
 Summary: Modern concurrency tools for Ruby
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 1.0.3
-Release: 6%{?foremandist}%{?dist}
+Version: 1.1.4
+Release: 1%{?foremandist}%{?dist}
 Epoch: 1
 Group: Development/Languages
 
@@ -63,10 +63,13 @@ cp -a .%{gem_dir}/* \
 
 %files
 %dir %{gem_instdir}
-%doc %{gem_instdir}/LICENSE.txt
+%license %{gem_instdir}/LICENSE.md
 %{gem_libdir}
 
 %exclude %{gem_cache}
+%exclude %{gem_instdir}/ext
+%exclude %{gem_instdir}/Gemfile
+%exclude %{gem_instdir}/Rakefile
 %{gem_spec}
 
 %files doc
@@ -75,6 +78,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_docdir}
 
 %changelog
+* Fri Jan 04 2019 Ivan Nečas <inecas@redhat.com> 1:1.1.4-1
+- Update to 1.1.4
+
 * Tue Jan 09 2018 Eric D. Helms <ericdhelms@gmail.com> 1.0.3-6
 - Bump releases for base foreman plugins packages (ericdhelms@gmail.com)
 - Use HTTPS URLs for github and rubygems (ewoud@kohlvanwijngaarden.nl)


### PR DESCRIPTION
Extracted from https://github.com/theforeman/foreman-packaging/pull/3328: seems we need to get this package in first so that the repoclosure check passes.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---