### PR TITLE
Rebuild foreman_templates

### DIFF
--- a/plugins/ruby-foreman-templates/debian/changelog
+++ b/plugins/ruby-foreman-templates/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-templates (6.0.3-2) stable; urgency=low
+
+  * Rebuild 6.0.3 with newer git version
+
+ -- Marek Hulan <mhulan@redhat.com>  Fri, 11 Jan 2019 09:47:48 +0200
+
 ruby-foreman-templates (6.0.3-1) stable; urgency=low
 
   * Update foreman_templates to 6.0.3

--- a/plugins/ruby-foreman-templates/debian/gem.list
+++ b/plugins/ruby-foreman-templates/debian/gem.list
@@ -1,4 +1,4 @@
 # list of gem urls to download via Jenkins, space separated
 GEMS="https://rubygems.org/downloads/foreman_templates-6.0.3.gem"
 GEMS="$GEMS https://rubygems.org/downloads/diffy-3.2.0.gem"
-GEMS="$GEMS https://rubygems.org/downloads/git-1.3.0.gem"
+GEMS="$GEMS https://rubygems.org/downloads/git-1.5.0.gem"


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

we need newer git dependency, we now bundle 1.3.0, more details at https://github.com/theforeman/foreman_templates/issues/107