### PR TITLE
Update smart_proxy_dynflow{,_core} to 0.2.2 (DEB)

### DIFF
--- a/plugins/smart_proxy_dynflow/changelog
+++ b/plugins/smart_proxy_dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-dynflow (0.2.2-1) stable; urgency=low
+
+  * 0.2.2 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Mon, 14 Jan 2019 23:05:58 +0100
+
 ruby-smart-proxy-dynflow (0.2.1-1) stable; urgency=high
 
   * 0.2.1 released

--- a/plugins/smart_proxy_dynflow/dynflow.rb
+++ b/plugins/smart_proxy_dynflow/dynflow.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_dynflow', '0.2.1'
+gem 'smart_proxy_dynflow', '0.2.2'

--- a/plugins/smart_proxy_dynflow_core/changelog
+++ b/plugins/smart_proxy_dynflow_core/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-dynflow-core (0.2.2-1) stable; urgency=low
+
+  * 0.2.2 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Mon, 14 Jan 2019 23:06:11 +0100
+
 ruby-smart-proxy-dynflow-core (0.2.1-1) stable; urgency=high
 
   * 0.2.1 released

--- a/plugins/smart_proxy_dynflow_core/control
+++ b/plugins/smart_proxy_dynflow_core/control
@@ -10,7 +10,7 @@ XS-Ruby-Versions: all
 Package: ruby-smart-proxy-dynflow-core
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, ruby-dynflow (>= 1.0.0),
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, ruby-dynflow (>= 1.1.0),
   ruby-dynflow (<< 2.0.0), ruby-foreman-tasks-core (>= 0.1.7),
   ruby-rest-client, ruby-sequel, ruby-sqlite3
 Description: Dynflow runtime for Foreman smart proxy

--- a/plugins/smart_proxy_dynflow_core/dynflow_core.rb
+++ b/plugins/smart_proxy_dynflow_core/dynflow_core.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_dynflow_core', '0.2.1'
+gem 'smart_proxy_dynflow_core', '0.2.2'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---