### PR TITLE
Update foreman_remote_execution_core to 1.1.5 (DEB proxy)

### DIFF
--- a/dependencies/bionic/foreman_remote_execution_core/changelog
+++ b/dependencies/bionic/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.1.5-1) stable; urgency=low
+
+  * 1.1.5 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Tue, 15 Jan 2019 00:06:41 +0100
+
 ruby-foreman-remote-execution-core (1.1.3-1) stable; urgency=low
 
   * Initial release for Ubuntu/bionic

--- a/dependencies/stretch/foreman_remote_execution_core/changelog
+++ b/dependencies/stretch/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.1.5-1) stable; urgency=low
+
+  * 1.1.5 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Tue, 15 Jan 2019 00:06:02 +0100
+
 ruby-foreman-remote-execution-core (1.1.3-1) stable; urgency=low
 
   * 1.1.3 released

--- a/dependencies/xenial/foreman_remote_execution_core/changelog
+++ b/dependencies/xenial/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.1.5-1) stable; urgency=low
+
+  * 1.1.5 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Tue, 15 Jan 2019 00:06:19 +0100
+
 ruby-foreman-remote-execution-core (1.1.3-1) stable; urgency=low
 
   * 1.1.3 released


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.20
* [ ] 1.19
* [ ] 1.18

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---