### PR TITLE
Update Hammer stack to 0.16.0

### DIFF
--- a/dependencies/bionic/apipie-bindings/changelog
+++ b/dependencies/bionic/apipie-bindings/changelog
@@ -1,3 +1,9 @@
+ruby-apipie-bindings (0.2.3-1) stable; urgency=low
+
+  * 0.2.3 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Thu, 17 Jan 2019 00:59:17 +0100
+
 ruby-apipie-bindings (0.2.2-1) stable; urgency=low
 
   * Initial release for Ubuntu/bionic

--- a/dependencies/bionic/hammer_cli/changelog
+++ b/dependencies/bionic/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (0.16.0-1) stable; urgency=low
+
+  * 0.16.0 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Thu, 17 Jan 2019 01:02:50 +0100
+
 ruby-hammer-cli (0.15.1-1) stable; urgency=low
 
   * 0.15.1 released

--- a/dependencies/bionic/hammer_cli_foreman/changelog
+++ b/dependencies/bionic/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.16.0-1) stable; urgency=low
+
+  * 0.16.0 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Thu, 17 Jan 2019 01:04:56 +0100
+
 ruby-hammer-cli-foreman (0.15.1-1) stable; urgency=low
 
   * 0.15.1 released

--- a/dependencies/bionic/hammer_cli_foreman/control
+++ b/dependencies/bionic/hammer_cli_foreman/control
@@ -12,7 +12,7 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 0.15.1),
+         ruby-hammer-cli (>= 0.16.0),
          ruby-apipie-bindings (>= 0.2.2),
          ruby-rest-client (>= 1.8.0),
          ruby-rest-client (<< 3.0.0)

--- a/dependencies/stretch/apipie-bindings/changelog
+++ b/dependencies/stretch/apipie-bindings/changelog
@@ -1,3 +1,9 @@
+ruby-apipie-bindings (0.2.3-1) stable; urgency=low
+
+  * 0.2.3 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Thu, 17 Jan 2019 00:59:17 +0100
+
 ruby-apipie-bindings (0.2.2-1) stable; urgency=low
 
   * 0.2.2 released

--- a/dependencies/stretch/hammer_cli/changelog
+++ b/dependencies/stretch/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (0.16.0-1) stable; urgency=low
+
+  * 0.16.0 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Thu, 17 Jan 2019 01:02:50 +0100
+
 ruby-hammer-cli (0.15.1-1) stable; urgency=low
 
   * 0.15.1 released

--- a/dependencies/stretch/hammer_cli_foreman/changelog
+++ b/dependencies/stretch/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.16.0-1) stable; urgency=low
+
+  * 0.16.0 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Thu, 17 Jan 2019 01:04:56 +0100
+
 ruby-hammer-cli-foreman (0.15.1-1) stable; urgency=low
 
   * 0.15.1 released

--- a/dependencies/stretch/hammer_cli_foreman/control
+++ b/dependencies/stretch/hammer_cli_foreman/control
@@ -12,7 +12,7 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 0.15.1),
+         ruby-hammer-cli (>= 0.16.0),
          ruby-apipie-bindings (>= 0.2.2),
          ruby-rest-client (>= 1.8.0),
          ruby-rest-client (<< 3.0.0)

--- a/dependencies/xenial/apipie-bindings/changelog
+++ b/dependencies/xenial/apipie-bindings/changelog
@@ -1,3 +1,9 @@
+ruby-apipie-bindings (0.2.3-1) stable; urgency=low
+
+  * 0.2.3 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Thu, 17 Jan 2019 00:59:17 +0100
+
 ruby-apipie-bindings (0.2.2-1) stable; urgency=low
 
   * 0.2.2 released

--- a/dependencies/xenial/hammer_cli/changelog
+++ b/dependencies/xenial/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (0.16.0-1) stable; urgency=low
+
+  * 0.16.0 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Thu, 17 Jan 2019 01:02:50 +0100
+
 ruby-hammer-cli (0.15.1-1) stable; urgency=low
 
   * 0.15.1 released

--- a/dependencies/xenial/hammer_cli_foreman/changelog
+++ b/dependencies/xenial/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (0.16.0-1) stable; urgency=low
+
+  * 0.16.0 released
+
+ -- Martin Bačovský <martin.bacovsky@gmail.com>  Thu, 17 Jan 2019 01:04:56 +0100
+
 ruby-hammer-cli-foreman (0.15.1-1) stable; urgency=low
 
   * 0.15.1 released

--- a/dependencies/xenial/hammer_cli_foreman/control
+++ b/dependencies/xenial/hammer_cli_foreman/control
@@ -12,7 +12,7 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 0.15.1),
+         ruby-hammer-cli (>= 0.16.0),
          ruby-apipie-bindings (>= 0.2.2),
          ruby-rest-client (>= 1.8.0),
          ruby-rest-client (<< 3.0.0)


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [x] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
