### PR TITLE
Match start/end tags for specfile updating

### DIFF
--- a/gem2rpm/foreman_plugin.spec.erb
+++ b/gem2rpm/foreman_plugin.spec.erb
@@ -46,7 +46,7 @@ URL: <%= spec.homepage %>
 <% end -%>
 Source0: <%= download_path %>%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>
@@ -86,7 +86,7 @@ Provides: foreman-plugin-%{plugin_name} = %{version}
 <% if has_compute -%>
 Provides: foreman-%{plugin_name} = %{version}
 <% end -%>
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 <%= spec.description %>

--- a/gem2rpm/hammer_plugin.spec.erb
+++ b/gem2rpm/hammer_plugin.spec.erb
@@ -25,7 +25,7 @@ URL: <%= spec.homepage %>
 <% end -%>
 Source0: <%= download_path %>%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>
 Requires: %{?scl_prefix_ruby}ruby <%= req %>
@@ -49,7 +49,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel <%= req %>
 BuildArch: noarch
 <% end -%>
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 <%= spec.description %>

--- a/gem2rpm/nonscl.spec.erb
+++ b/gem2rpm/nonscl.spec.erb
@@ -13,7 +13,7 @@ URL: <%= spec.homepage %>
 <% end -%>
 Source0: <%= download_path %>%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: ruby(release)
 <% for req in spec.required_ruby_version -%>
 Requires: ruby <%= req %>
@@ -37,7 +37,7 @@ BuildRequires: rubygems-devel <%= req %>
 BuildArch: noarch
 <% end -%>
 Provides: rubygem(%{gem_name}) = %{version}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 <%= spec.description %>

--- a/gem2rpm/scl.spec.erb
+++ b/gem2rpm/scl.spec.erb
@@ -20,7 +20,7 @@ URL: <%= spec.homepage %>
 <% end -%>
 Source0: <%= download_path %>%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>
 Requires: %{?scl_prefix_ruby}ruby <%= req %>
@@ -44,7 +44,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel <%= req %>
 BuildArch: noarch
 <% end -%>
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 <%= spec.description %>

--- a/gem2rpm/smart_proxy_plugin.spec.erb
+++ b/gem2rpm/smart_proxy_plugin.spec.erb
@@ -23,7 +23,7 @@ URL: <%= spec.homepage %>
 <% end -%>
 Source0: <%= download_path %>%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: ruby(release)
 <% for req in spec.required_ruby_version -%>
@@ -49,7 +49,7 @@ BuildArch: noarch
 <% end -%>
 Provides: rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 <%= spec.description %>

--- a/packages/foreman/rubygem-fog-xenserver/rubygem-fog-xenserver.spec
+++ b/packages/foreman/rubygem-fog-xenserver/rubygem-fog-xenserver.spec
@@ -14,7 +14,7 @@ License: MIT
 URL: https://github.com/fog/fog-xenserver
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby >= 2.0
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
@@ -26,7 +26,7 @@ BuildRequires: %{?scl_prefix_ruby}ruby >= 2.0
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 Module for the 'fog' gem to support XENSERVER.

--- a/packages/foreman/rubygem-hashie/rubygem-hashie.spec
+++ b/packages/foreman/rubygem-hashie/rubygem-hashie.spec
@@ -14,7 +14,7 @@ License: MIT
 URL: https://github.com/intridea/hashie
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
@@ -23,7 +23,7 @@ BuildRequires: %{?scl_prefix_ruby}ruby
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 Hashie is a collection of classes and mixins that make hashes more powerful.

--- a/packages/foreman/rubygem-kafo_parsers/rubygem-kafo_parsers.spec
+++ b/packages/foreman/rubygem-kafo_parsers/rubygem-kafo_parsers.spec
@@ -14,7 +14,7 @@ License: GPLv3+
 URL: https://github.com/theforeman/kafo_parsers
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
@@ -25,7 +25,7 @@ BuildRequires: %{?scl_prefix_ruby}ruby
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 This gem can parse values, validations, documentation, types, groups and

--- a/packages/foreman/rubygem-powerbar/rubygem-powerbar.spec
+++ b/packages/foreman/rubygem-powerbar/rubygem-powerbar.spec
@@ -14,7 +14,7 @@ License: MIT
 URL: https://github.com/busyloop/powerbar
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby > 1.9.3
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
@@ -24,7 +24,7 @@ BuildRequires: %{?scl_prefix_ruby}ruby > 1.9.3
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 The last progressbar-library you'll ever need.

--- a/packages/foreman/rubygem-puma/rubygem-puma.spec
+++ b/packages/foreman/rubygem-puma/rubygem-puma.spec
@@ -14,7 +14,7 @@ License: BSD-3-Clause
 URL: http://puma.io
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby >= 1.9.3
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
@@ -23,7 +23,7 @@ BuildRequires: %{?scl_prefix_ruby}ruby
 BuildRequires: %{?scl_prefix_ruby}ruby-devel >= 1.9.3
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 Puma is a simple, fast, threaded, and highly concurrent HTTP 1.1 server for

--- a/packages/foreman/rubygem-xmlrpc/rubygem-xmlrpc.spec
+++ b/packages/foreman/rubygem-xmlrpc/rubygem-xmlrpc.spec
@@ -14,7 +14,7 @@ License: Ruby
 URL: https://github.com/ruby/xmlrpc
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby >= 2.3
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
@@ -23,7 +23,7 @@ BuildRequires: %{?scl_prefix_ruby}ruby >= 2.3
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 XMLRPC is a lightweight protocol that enables remote procedure calls over

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -20,7 +20,7 @@ Source0: https://rubygems.org/downloads/%{gem_name}-%{version}%{?prerelease}.gem
 
 Requires: katello-selinux
 Requires: foreman-postgresql
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -69,7 +69,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 Obsoletes: %{?scl_prefix}rubygem-%{gem_name}_ostree
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 

--- a/packages/plugins/rubygem-bastion/rubygem-bastion.spec
+++ b/packages/plugins/rubygem-bastion/rubygem-bastion.spec
@@ -16,7 +16,7 @@ URL:        https://github.com/Katello/bastion
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -33,7 +33,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 Bastion serves as a plugin to Foreman that provides common

--- a/packages/plugins/rubygem-fog-proxmox/rubygem-fog-proxmox.spec
+++ b/packages/plugins/rubygem-fog-proxmox/rubygem-fog-proxmox.spec
@@ -14,7 +14,7 @@ License: GPLv3
 URL: https://github.com/fog/fog-proxmox
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby >= 2.3
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
@@ -29,7 +29,7 @@ BuildRequires: %{?scl_prefix_ruby}ruby >= 2.3
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 This library can be used as a module for `fog`.

--- a/packages/plugins/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
+++ b/packages/plugins/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
@@ -19,7 +19,7 @@ Requires:   ipxe-bootimgs
 Requires:   /usr/bin/isohybrid
 Requires:   /usr/bin/genisoimage
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -32,7 +32,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-foreman_chef/rubygem-foreman_chef.spec
+++ b/packages/plugins/rubygem-foreman_chef/rubygem-foreman_chef.spec
@@ -15,7 +15,7 @@ License:    GPLv3
 URL:        https://github.com/theforeman/foreman_chef
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -32,7 +32,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-foreman_cockpit/rubygem-foreman_cockpit.spec
+++ b/packages/plugins/rubygem-foreman_cockpit/rubygem-foreman_cockpit.spec
@@ -15,7 +15,7 @@ License:    GPLv3
 URL:        https://github.com/theforeman/foreman_cockpit
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -30,7 +30,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-foreman_column_view/rubygem-foreman_column_view.spec
+++ b/packages/plugins/rubygem-foreman_column_view/rubygem-foreman_column_view.spec
@@ -15,7 +15,7 @@ License:    GPLv3
 URL:        https://github.com/theforeman/foreman_column_view
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -28,7 +28,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-foreman_default_hostgroup/rubygem-foreman_default_hostgroup.spec
+++ b/packages/plugins/rubygem-foreman_default_hostgroup/rubygem-foreman_default_hostgroup.spec
@@ -15,7 +15,7 @@ License:    GPLv3
 URL:        https://github.com/theforeman/foreman_default_hostgroup
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -27,7 +27,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-foreman_dhcp_browser/rubygem-foreman_dhcp_browser.spec
+++ b/packages/plugins/rubygem-foreman_dhcp_browser/rubygem-foreman_dhcp_browser.spec
@@ -15,7 +15,7 @@ License:    GPLv3
 URL:        https://github.com/theforeman/foreman_dhcp_browser
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -28,7 +28,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 Provides: foreman-plugin-dhcp-browser
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 

--- a/packages/plugins/rubygem-foreman_digitalocean/rubygem-foreman_digitalocean.spec
+++ b/packages/plugins/rubygem-foreman_digitalocean/rubygem-foreman_digitalocean.spec
@@ -15,7 +15,7 @@ License:    GPLv3
 URL:        https://github.com/theforeman/foreman-digitalocean
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -30,7 +30,7 @@ BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
 Provides: foreman-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-foreman_discovery/rubygem-foreman_discovery.spec
+++ b/packages/plugins/rubygem-foreman_discovery/rubygem-foreman_discovery.spec
@@ -24,7 +24,7 @@ License:    GPLv3
 URL:        https://github.com/theforeman/foreman_discovery
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}%{?prever}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -36,7 +36,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-foreman_dlm/rubygem-foreman_dlm.spec
+++ b/packages/plugins/rubygem-foreman_dlm/rubygem-foreman_dlm.spec
@@ -16,7 +16,7 @@ License: GPLv3+
 URL: https://github.com/timogoebel/foreman_dlm
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -28,7 +28,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 Adds a Distributed Lock Manager to Foreman. This enables painless system

--- a/packages/plugins/rubygem-foreman_docker/rubygem-foreman_docker.spec
+++ b/packages/plugins/rubygem-foreman_docker/rubygem-foreman_docker.spec
@@ -17,7 +17,7 @@ Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
 Requires: foreman-compute >= %{foreman_min_version}
 BuildRequires: foreman-compute >= %{foreman_min_version}
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -44,7 +44,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 Provides: foreman-docker
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 

--- a/packages/plugins/rubygem-foreman_expire_hosts/rubygem-foreman_expire_hosts.spec
+++ b/packages/plugins/rubygem-foreman_expire_hosts/rubygem-foreman_expire_hosts.spec
@@ -17,7 +17,7 @@ Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 Source1:    %{gem_name}.cron.d
 
 Requires:   %{?scl:%_root_sysconfdir}%{!?scl:%_sysconfdir}/cron.d
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -34,7 +34,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 A Foreman plugin that allows hosts to expire at a configurable date.

--- a/packages/plugins/rubygem-foreman_fog_proxmox/rubygem-foreman_fog_proxmox.spec
+++ b/packages/plugins/rubygem-foreman_fog_proxmox/rubygem-foreman_fog_proxmox.spec
@@ -16,7 +16,7 @@ License: GPLv3
 URL: https://github.com/tristanrobert/foreman_fog_proxmox
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -36,7 +36,7 @@ BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name} = %{version}
 Provides: foreman-%{plugin_name} = %{version}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 Foreman plugin adds Proxmox VE compute resource using fog-proxmox. It is

--- a/packages/plugins/rubygem-foreman_graphite/rubygem-foreman_graphite.spec
+++ b/packages/plugins/rubygem-foreman_graphite/rubygem-foreman_graphite.spec
@@ -15,7 +15,7 @@ License:    GPLv3
 URL:        https://github.com/theforeman/foreman_graphite
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -28,7 +28,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-foreman_hooks/rubygem-foreman_hooks.spec
+++ b/packages/plugins/rubygem-foreman_hooks/rubygem-foreman_hooks.spec
@@ -15,7 +15,7 @@ License:    GPLv3
 URL:        https://github.com/theforeman/foreman_hooks
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -27,7 +27,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-foreman_host_extra_validator/rubygem-foreman_host_extra_validator.spec
+++ b/packages/plugins/rubygem-foreman_host_extra_validator/rubygem-foreman_host_extra_validator.spec
@@ -15,7 +15,7 @@ License:    GPLv3
 URL:        https://github.com/theforeman/foreman_host_extra_validator
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -27,7 +27,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 This plugin adds extra validations to a host.

--- a/packages/plugins/rubygem-foreman_m2/rubygem-foreman_m2.spec
+++ b/packages/plugins/rubygem-foreman_m2/rubygem-foreman_m2.spec
@@ -14,7 +14,7 @@ License: GPLv3
 URL: https://github.com/ianballou/foreman_m2
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby 
@@ -27,7 +27,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 M2 bare metal provisioning plugin for Foreman.

--- a/packages/plugins/rubygem-foreman_memcache/rubygem-foreman_memcache.spec
+++ b/packages/plugins/rubygem-foreman_memcache/rubygem-foreman_memcache.spec
@@ -15,7 +15,7 @@ License:    GPLv3
 URL:        https://github.com/theforeman/foreman_memcache
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -28,7 +28,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-foreman_monitoring/rubygem-foreman_monitoring.spec
+++ b/packages/plugins/rubygem-foreman_monitoring/rubygem-foreman_monitoring.spec
@@ -15,7 +15,7 @@ License: GPLv3
 URL: https://github.com/theforeman/foreman_monitoring
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -29,7 +29,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 Foreman plugin for monitoring system integration.

--- a/packages/plugins/rubygem-foreman_noenv/rubygem-foreman_noenv.spec
+++ b/packages/plugins/rubygem-foreman_noenv/rubygem-foreman_noenv.spec
@@ -15,7 +15,7 @@ License:    GPLv3
 URL:        https://github.com/joshuabaird/foreman_noenv
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -28,7 +28,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-foreman_omaha/rubygem-foreman_omaha.spec
+++ b/packages/plugins/rubygem-foreman_omaha/rubygem-foreman_omaha.spec
@@ -15,7 +15,7 @@ License: GPLv3
 URL: https://github.com/theforeman/foreman_omaha
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -30,7 +30,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-foreman_one/rubygem-foreman_one.spec
+++ b/packages/plugins/rubygem-foreman_one/rubygem-foreman_one.spec
@@ -15,7 +15,7 @@ License:    GPLv3
 URL:        https://github.com/theforeman/foreman-one
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: foreman-compute >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
@@ -29,7 +29,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 Provides: foreman-plugin-opennebula
 Provides: foreman-one
 Provides: foreman-opennebula

--- a/packages/plugins/rubygem-foreman_openscap/rubygem-foreman_openscap.spec
+++ b/packages/plugins/rubygem-foreman_openscap/rubygem-foreman_openscap.spec
@@ -16,7 +16,7 @@ URL: https://github.com/theforeman/foreman_openscap
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
 Requires: scap-security-guide
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -31,7 +31,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 Obsoletes: %{?scl_prefix}rubygem(scaptimony) < 0.3.2-3
 

--- a/packages/plugins/rubygem-foreman_remote_execution_core/rubygem-foreman_remote_execution_core.spec
+++ b/packages/plugins/rubygem-foreman_remote_execution_core/rubygem-foreman_remote_execution_core.spec
@@ -13,7 +13,7 @@ License: GPLv3
 URL: https://github.com/theforeman/foreman_remote_execution
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
@@ -24,7 +24,7 @@ BuildRequires: %{?scl_prefix_ruby}ruby
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 Ssh remote execution provider code sharable between Foreman and

--- a/packages/plugins/rubygem-foreman_rescue/rubygem-foreman_rescue.spec
+++ b/packages/plugins/rubygem-foreman_rescue/rubygem-foreman_rescue.spec
@@ -14,7 +14,7 @@ License: GPLv3+
 URL: https://github.com/dm-drogeriemarkt/foreman_rescue
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -26,7 +26,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 Foreman Plugin to provide the ability to boot a host into a rescue system.

--- a/packages/plugins/rubygem-foreman_salt/rubygem-foreman_salt.spec
+++ b/packages/plugins/rubygem-foreman_salt/rubygem-foreman_salt.spec
@@ -15,7 +15,7 @@ License:    GPLv3
 URL:        https://github.com/theforeman/foreman_salt
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -34,7 +34,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-foreman_setup/rubygem-foreman_setup.spec
+++ b/packages/plugins/rubygem-foreman_setup/rubygem-foreman_setup.spec
@@ -15,7 +15,7 @@ License:    GPLv3
 URL:        https://github.com/theforeman/foreman_setup
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -27,7 +27,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-foreman_snapshot_management/rubygem-foreman_snapshot_management.spec
+++ b/packages/plugins/rubygem-foreman_snapshot_management/rubygem-foreman_snapshot_management.spec
@@ -15,7 +15,7 @@ License: GPLv3
 URL: https://www.orcharhino.com
 Source0: https://rubygems.org/downloads/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -29,7 +29,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 Foreman-plugin to manage snapshots in a vSphere environment.

--- a/packages/plugins/rubygem-foreman_spacewalk/rubygem-foreman_spacewalk.spec
+++ b/packages/plugins/rubygem-foreman_spacewalk/rubygem-foreman_spacewalk.spec
@@ -14,7 +14,7 @@ License: GPLv3+
 URL: https://github.com/dm-drogeriemarkt/foreman_spacewalk
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -26,7 +26,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 Spacewalk integration for Foreman.

--- a/packages/plugins/rubygem-foreman_templates/rubygem-foreman_templates.spec
+++ b/packages/plugins/rubygem-foreman_templates/rubygem-foreman_templates.spec
@@ -17,7 +17,7 @@ Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
 Requires: git
 BuildRequires: git
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -33,7 +33,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-foreman_userdata/rubygem-foreman_userdata.spec
+++ b/packages/plugins/rubygem-foreman_userdata/rubygem-foreman_userdata.spec
@@ -15,7 +15,7 @@ License: GPLv3
 URL: https://github.com/theforeman/foreman_userdata
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -27,7 +27,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 This plug-in adds support for serving user-data for cloud-init to The Foreman.

--- a/packages/plugins/rubygem-foreman_vmwareannotations/rubygem-foreman_vmwareannotations.spec
+++ b/packages/plugins/rubygem-foreman_vmwareannotations/rubygem-foreman_vmwareannotations.spec
@@ -15,7 +15,7 @@ License: GPLv3
 URL: https://github.com/theforeman/foreman_vmwareannotations
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -28,7 +28,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 This plug-in copies the host comment to VMWare annotations in The Foreman.

--- a/packages/plugins/rubygem-foreman_wreckingball/rubygem-foreman_wreckingball.spec
+++ b/packages/plugins/rubygem-foreman_wreckingball/rubygem-foreman_wreckingball.spec
@@ -16,7 +16,7 @@ License: GPLv3+
 URL: https://github.com/dm-drogeriemarkt/foreman_wreckingball
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -29,7 +29,7 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 Adds status checks of the VMWare VMs to Foreman.

--- a/packages/plugins/rubygem-foreman_xen/rubygem-foreman_xen.spec
+++ b/packages/plugins/rubygem-foreman_xen/rubygem-foreman_xen.spec
@@ -15,7 +15,7 @@ License:    GPLv3
 URL:        https://github.com/theforeman/foreman-xen
 Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
@@ -33,7 +33,7 @@ BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name}
 Provides: foreman-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
 
 %description

--- a/packages/plugins/rubygem-smart_proxy_m2/rubygem-smart_proxy_m2.spec
+++ b/packages/plugins/rubygem-smart_proxy_m2/rubygem-smart_proxy_m2.spec
@@ -15,7 +15,7 @@ License: GPLv3
 URL: https://github.com/ianballou/smart_proxy_m2
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: ruby(release)
 Requires: ruby
@@ -26,7 +26,7 @@ BuildRequires: rubygems-devel
 BuildArch: noarch
 Provides: rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 M2 smart proxy plugin for Foreman.

--- a/packages/plugins/rubygem-smart_proxy_spacewalk/rubygem-smart_proxy_spacewalk.spec
+++ b/packages/plugins/rubygem-smart_proxy_spacewalk/rubygem-smart_proxy_spacewalk.spec
@@ -15,7 +15,7 @@ License: GPLv3
 URL: https://github.com/dm-drogeriemarkt/smart_proxy_spacewalk
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: ruby(release)
 Requires: ruby
@@ -27,7 +27,7 @@ BuildRequires: rubygems-devel
 BuildArch: noarch
 Provides: rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 This plug-in adds support for managing hosts registered at a spacewalk server

--- a/packages/plugins/rubygem-wicked/rubygem-wicked.spec
+++ b/packages/plugins/rubygem-wicked/rubygem-wicked.spec
@@ -14,7 +14,7 @@ License: MIT
 URL: https://github.com/schneems/wicked
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# start generated dependencies
+# start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
@@ -24,7 +24,7 @@ BuildRequires: %{?scl_prefix_ruby}ruby
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
-# end generated dependencies
+# end specfile generated dependencies
 
 %description
 Wicked is a Rails engine for producing easy wizard controllers.


### PR DESCRIPTION
The update-requirements script looks for start specfile when calling bump_rpm.sh. Because we did't use this in our gem2rpm templates and actual specs it never actually replaced the dependencies.