### PR TITLE
Update rubygem-dynflow to 1.2.1

### DIFF
--- a/packages/foreman/rubygem-dynflow/dynflow-1.2.0.gem
+++ b/packages/foreman/rubygem-dynflow/dynflow-1.2.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/xw/08/SHA256E-s967680--cb026299be81b0dd8ce25e29d2ae04a34fae135cf988ec1624133a17b4a13df3.0.gem/SHA256E-s967680--cb026299be81b0dd8ce25e29d2ae04a34fae135cf988ec1624133a17b4a13df3.0.gem

--- a/packages/foreman/rubygem-dynflow/dynflow-1.2.1.gem
+++ b/packages/foreman/rubygem-dynflow/dynflow-1.2.1.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/Xk/3m/SHA256E-s967680--ed5f90c6a413bdb1627323a51e32b424b2bbfeb0e320b6672eb564d6553debe2.1.gem/SHA256E-s967680--ed5f90c6a413bdb1627323a51e32b424b2bbfeb0e320b6672eb564d6553debe2.1.gem

--- a/packages/foreman/rubygem-dynflow/rubygem-dynflow.spec
+++ b/packages/foreman/rubygem-dynflow/rubygem-dynflow.spec
@@ -5,7 +5,7 @@
 
 Summary: DYNamic workFLOW engine
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 1.2.0
+Version: 1.2.1
 Release: 1%{?foremandist}%{?dist}
 Group: Development/Languages
 License: MIT
@@ -88,6 +88,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/examples
 
 %changelog
+* Thu Jan 24 2019 Ivan Nečas <inecas@redhat.com> 1.2.1-1
+- Update to 1.2.1
+
 * Fri Jan 04 2019 Ivan Nečas <inecas@redhat.com> 1.2.0-1
 - Update to 1.2.0
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---