### PR TITLE
Update rubygem-fog-libvirt to 0.6.0

### DIFF
--- a/packages/foreman/rubygem-fog-libvirt/fog-libvirt-0.4.1.gem
+++ b/packages/foreman/rubygem-fog-libvirt/fog-libvirt-0.4.1.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/3P/gg/SHA256E-s29184--d79d33f57dcb11a723318d5e1ece2e8acb5db4e6d5209a8ece715b9414fe84d7.1.gem/SHA256E-s29184--d79d33f57dcb11a723318d5e1ece2e8acb5db4e6d5209a8ece715b9414fe84d7.1.gem

--- a/packages/foreman/rubygem-fog-libvirt/fog-libvirt-0.6.0.gem
+++ b/packages/foreman/rubygem-fog-libvirt/fog-libvirt-0.6.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/MG/71/SHA256E-s31232--7186e7dad0187dcf131b7fb307c33f6f4db8fb0c8ea4933cfcb13e7428cb41ec.0.gem/SHA256E-s31232--7186e7dad0187dcf131b7fb307c33f6f4db8fb0c8ea4933cfcb13e7428cb41ec.0.gem

--- a/packages/foreman/rubygem-fog-libvirt/rubygem-fog-libvirt.spec
+++ b/packages/foreman/rubygem-fog-libvirt/rubygem-fog-libvirt.spec
@@ -6,15 +6,14 @@
 Summary: Module for the 'fog' gem to support libvirt
 Name: %{?scl_prefix}rubygem-%{gem_name}
 
-Version: 0.4.1
-Release: 3%{?dist}
+Version: 0.6.0
+Release: 1%{?dist}
 Group: Development/Ruby
 License: MIT
 URL: https://github.com/fog/fog-libvirt
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: %{?scl_prefix_ruby}rubygems
 Requires: %{?scl_prefix}rubygem(fog-core) >= 1.27.4
-Requires: %{?scl_prefix}rubygem(fog-core) < 2
 Requires: %{?scl_prefix}rubygem(fog-json)
 Requires: %{?scl_prefix}rubygem(fog-xml) >= 0.1.1
 Requires: %{?scl_prefix}rubygem(fog-xml) < 0.2
@@ -71,6 +70,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/%{gem_name}.gemspec
 
 %changelog
+* Mon Feb 04 2019 Ivan Nečas <inecas@redhat.com> 0.6.0-1
+- Update to 0.6.0
+
 * Wed Sep 05 2018 Eric D. Helms <ericdhelms@gmail.com> - 0.4.1-3
 - Rebuild for Rails 5.2 and Ruby 2.5
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---