### PR TITLE
Drop outdated hammer_cli_foreman gem

### DIFF
--- a/packages/foreman/rubygem-hammer_cli_foreman/hammer_cli_foreman-0.14.0.gem
+++ b/packages/foreman/rubygem-hammer_cli_foreman/hammer_cli_foreman-0.14.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/4j/1V/SHA256E-s435200--ad2a6fec57b2ee7ab251774d017c9a325732354c1cc8a67b82daaab83f62ca92.0.gem/SHA256E-s435200--ad2a6fec57b2ee7ab251774d017c9a325732354c1cc8a67b82daaab83f62ca92.0.gem


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
