### PR TITLE
Update rubygem-foreman_scap_client to 0.4.2

### DIFF
--- a/packages/client/rubygem-foreman_scap_client/foreman_scap_client-0.4.1.gem
+++ b/packages/client/rubygem-foreman_scap_client/foreman_scap_client-0.4.1.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/9V/P9/SHA256E-s19456--2235fe8e0c357f86f2a7eec32db2ffadc6233515d2aec0e2bb8e0852784b4fd0.1.gem/SHA256E-s19456--2235fe8e0c357f86f2a7eec32db2ffadc6233515d2aec0e2bb8e0852784b4fd0.1.gem

--- a/packages/client/rubygem-foreman_scap_client/foreman_scap_client-0.4.2.gem
+++ b/packages/client/rubygem-foreman_scap_client/foreman_scap_client-0.4.2.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/zf/21/SHA256E-s19968--fd4d7217891d11abc827f02f6527fed69fed805691dbc659a8008e5aebf4b46e.2.gem/SHA256E-s19968--fd4d7217891d11abc827f02f6527fed69fed805691dbc659a8008e5aebf4b46e.2.gem

--- a/packages/client/rubygem-foreman_scap_client/rubygem-foreman_scap_client.spec
+++ b/packages/client/rubygem-foreman_scap_client/rubygem-foreman_scap_client.spec
@@ -4,7 +4,7 @@
 %define rubyabi 1.8
 
 Name: rubygem-%{gem_name}
-Version: 0.4.1
+Version: 0.4.2
 Release: 1%{?dist}
 Summary: Client script that runs OpenSCAP scan and uploads the result to foreman proxy
 Group: Development/Languages
@@ -96,6 +96,9 @@ mkdir -p %{buildroot}%{config_dir}
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Tue Feb 12 2019 Marek Hulan <mhulan@redhat.com> 0.4.2-1
+- Update to 0.4.2
+
 * Tue Jan 29 2019 Marek Hulan <mhulan@redhat.com> 0.4.1-1
 - Update to 0.4.1
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
