### PR TITLE
Update rubygem-foreman_docker to 4.1.1

### DIFF
--- a/packages/plugins/rubygem-foreman_docker/foreman_docker-4.1.0.gem
+++ b/packages/plugins/rubygem-foreman_docker/foreman_docker-4.1.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/19/9m/SHA256E-s95744--db6a1f495c4d3dc7a62da22ffc785c5a4cd8afbaaa035d42881c16d2c00a2bcd.0.gem/SHA256E-s95744--db6a1f495c4d3dc7a62da22ffc785c5a4cd8afbaaa035d42881c16d2c00a2bcd.0.gem

--- a/packages/plugins/rubygem-foreman_docker/foreman_docker-4.1.1.gem
+++ b/packages/plugins/rubygem-foreman_docker/foreman_docker-4.1.1.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/QG/x3/SHA256E-s95744--4cc50ca0525d57f8dc83922300dcbfd1d77ca0bd612d49eb56e3c6f28a03789f.1.gem/SHA256E-s95744--4cc50ca0525d57f8dc83922300dcbfd1d77ca0bd612d49eb56e3c6f28a03789f.1.gem

--- a/packages/plugins/rubygem-foreman_docker/rubygem-foreman_docker.spec
+++ b/packages/plugins/rubygem-foreman_docker/rubygem-foreman_docker.spec
@@ -8,8 +8,8 @@
 
 Summary:    Provision and manage Docker containers and images from Foreman
 Name:       %{?scl_prefix}rubygem-%{gem_name}
-Version:    4.1.0
-Release:    2%{?foremandist}%{?dist}
+Version:    4.1.1
+Release:    1%{?foremandist}%{?dist}
 Group:      Applications/Systems
 License:    GPLv3
 URL:        https://github.com/theforeman/foreman_docker
@@ -43,7 +43,7 @@ BuildRequires: %{?scl_prefix_ruby}ruby
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
-Provides: foreman-plugin-%{plugin_name}
+Provides: foreman-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 Provides: foreman-docker
 %{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
@@ -122,6 +122,9 @@ cp -pa .%{gem_dir}/* \
 exit 0
 
 %changelog
+* Wed Feb 27 2019 Sebastian Gräßl <mail@bastilian.me> 4.1.1-1
+- Update to 4.1.1
+
 * Fri Sep 07 2018 Eric D. Helms <ericdhelms@gmail.com> - 4.1.0-2
 - Rebuild for Rails 5.2 and Ruby 2.5
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
