### PR TITLE
Add rubygem-typhoeus

### DIFF
--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -32,6 +32,7 @@
       <packagereq type="default">tfm-rubygem-katello</packagereq>
       <packagereq type="default">tfm-rubygem-katello-assets</packagereq>
       <packagereq type="default">tfm-rubygem-redhat_access</packagereq>
+      <packagereq type="default">tfm-rubygem-typhoeus</packagereq>
 
       <!-- katello thirdparty nodejs packages -->
       <packagereq type="default">nodejs-angular</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -523,6 +523,7 @@ katello_packages:
     rubygem-redhat_access_lib: {}
     rubygem-robotex: {}
     rubygem-runcible: {}
+    rubygem-typhoeus: {}
 
 plugins_packages:
   children:

--- a/packages/katello/rubygem-typhoeus/rubygem-typhoeus.spec
+++ b/packages/katello/rubygem-typhoeus/rubygem-typhoeus.spec
@@ -1,0 +1,97 @@
+# Generated from typhoeus-1.3.1.gem by gem2rpm -*- rpm-spec -*-
+# template: scl
+%{?scl:%scl_package rubygem-%{gem_name}}
+%{!?scl:%global pkg_name %{name}}
+
+%global gem_name typhoeus
+
+Name: %{?scl_prefix}rubygem-%{gem_name}
+Version: 1.3.1
+Release: 1%{?dist}
+Summary: Parallel HTTP library on top of libcurl multi
+Group: Development/Languages
+License: MIT
+URL: https://github.com/typhoeus/typhoeus
+Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
+
+# start specfile generated dependencies
+Requires: %{?scl_prefix_ruby}ruby(release)
+Requires: %{?scl_prefix_ruby}ruby 
+Requires: %{?scl_prefix_ruby}ruby(rubygems) >= 1.3.6
+Requires: %{?scl_prefix}rubygem(ethon) >= 0.9.0
+BuildRequires: %{?scl_prefix_ruby}ruby(release)
+BuildRequires: %{?scl_prefix_ruby}ruby 
+BuildRequires: %{?scl_prefix_ruby}rubygems-devel >= 1.3.6
+BuildArch: noarch
+Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
+# end specfile generated dependencies
+
+%description
+Like a modern code version of the mythical beast with 100 serpent heads,
+Typhoeus runs HTTP requests in parallel while cleanly encapsulating handling
+logic.
+
+
+%package doc
+Summary: Documentation for %{pkg_name}
+Group: Documentation
+Requires: %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+BuildArch: noarch
+
+%description doc
+Documentation for %{pkg_name}.
+
+%prep
+%{?scl:scl enable %{scl} - << \EOF}
+gem unpack %{SOURCE0}
+%{?scl:EOF}
+
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+%{?scl:scl enable %{scl} - << \EOF}
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
+%{?scl:EOF}
+
+%build
+# Create the gem as gem install only works on a gem file
+%{?scl:scl enable %{scl} - << \EOF}
+gem build %{gem_name}.gemspec
+%{?scl:EOF}
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%{?scl:scl enable %{scl} - << \EOF}
+%gem_install
+%{?scl:EOF}
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -pa .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+%files
+%dir %{gem_instdir}
+%exclude %{gem_instdir}/.gitignore
+%exclude %{gem_instdir}/.travis.yml
+%{gem_instdir}/Guardfile
+%license %{gem_instdir}/LICENSE
+%{gem_instdir}/UPGRADE.md
+%{gem_libdir}
+%{gem_instdir}/perf
+%exclude %{gem_cache}
+%{gem_spec}
+
+%files doc
+%doc %{gem_docdir}
+%exclude %{gem_instdir}/.rspec
+%doc %{gem_instdir}/CHANGELOG.md
+%doc %{gem_instdir}/CONTRIBUTING.md
+%{gem_instdir}/Gemfile
+%doc %{gem_instdir}/README.md
+%{gem_instdir}/Rakefile
+%{gem_instdir}/spec
+%{gem_instdir}/typhoeus.gemspec
+
+%changelog
+* Fri Mar 08 2019 Justin Sherrill <jsherril@redhat.com> 1.3.1-1
+- Initial build

--- a/packages/katello/rubygem-typhoeus/typhoeus-1.3.1.gem
+++ b/packages/katello/rubygem-typhoeus/typhoeus-1.3.1.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/7v/9Z/SHA256E-s55808--257e7163d50bed15e52c3c25bde890ea3ad854f3bd2e3fd16ce0b216c342d132.1.gem/SHA256E-s55808--257e7163d50bed15e52c3c25bde890ea3ad854f3bd2e3fd16ce0b216c342d132.1.gem

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -517,3 +517,4 @@ whitelist = katello
   rubygem-redhat_access_lib
   rubygem-robotex
   rubygem-runcible
+  rubygem-typhoeus


### PR DESCRIPTION
a dependency for zest, an autogenerated pulp3 api gem

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
