### PR TITLE
Add rubygem-ethon

### DIFF
--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -25,6 +25,7 @@
       <packagereq type="default">python-gofer-qpid</packagereq>
       <packagereq type="default">pulp-katello</packagereq>
       <packagereq type="default">tfm-rubygem-activerecord-import</packagereq>
+      <packagereq type="default">tfm-rubygem-ethon</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_virt_who_configure</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_virt_who_configure</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_import</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -502,6 +502,7 @@ katello_packages:
     pulp-katello: {}
     rubygem-activerecord-import: {}
     rubygem-anemone: {}
+    rubygem-ethon: {}
     rubygem-foreman_scc_manager: {}
     rubygem-foreman_virt_who_configure: {}
     rubygem-hammer_cli_csv: {}

--- a/packages/katello/rubygem-ethon/ethon-0.12.0.gem
+++ b/packages/katello/rubygem-ethon/ethon-0.12.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/k6/FV/SHA256E-s56832--e99d3095e89f82c5a7e63d9261ddf4a21f28ae5d12a9d3abaa6920cce6cbef3d.0.gem/SHA256E-s56832--e99d3095e89f82c5a7e63d9261ddf4a21f28ae5d12a9d3abaa6920cce6cbef3d.0.gem

--- a/packages/katello/rubygem-ethon/rubygem-ethon.spec
+++ b/packages/katello/rubygem-ethon/rubygem-ethon.spec
@@ -1,0 +1,94 @@
+# Generated from ethon-0.12.0.gem by gem2rpm -*- rpm-spec -*-
+# template: scl
+%{?scl:%scl_package rubygem-%{gem_name}}
+%{!?scl:%global pkg_name %{name}}
+
+%global gem_name ethon
+
+Name: %{?scl_prefix}rubygem-%{gem_name}
+Version: 0.12.0
+Release: 1%{?dist}
+Summary: Libcurl wrapper
+Group: Development/Languages
+License: MIT
+URL: https://github.com/typhoeus/ethon
+Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
+
+# start specfile generated dependencies
+Requires: %{?scl_prefix_ruby}ruby(release)
+Requires: %{?scl_prefix_ruby}ruby 
+Requires: %{?scl_prefix_ruby}ruby(rubygems) >= 1.3.6
+Requires: %{?scl_prefix}rubygem(ffi) >= 1.3.0
+BuildRequires: %{?scl_prefix_ruby}ruby(release)
+BuildRequires: %{?scl_prefix_ruby}ruby 
+BuildRequires: %{?scl_prefix_ruby}rubygems-devel >= 1.3.6
+BuildArch: noarch
+Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
+# end specfile generated dependencies
+
+%description
+Very lightweight libcurl wrapper.
+
+
+%package doc
+Summary: Documentation for %{pkg_name}
+Group: Documentation
+Requires: %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+BuildArch: noarch
+
+%description doc
+Documentation for %{pkg_name}.
+
+%prep
+%{?scl:scl enable %{scl} - << \EOF}
+gem unpack %{SOURCE0}
+%{?scl:EOF}
+
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+%{?scl:scl enable %{scl} - << \EOF}
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
+%{?scl:EOF}
+
+%build
+# Create the gem as gem install only works on a gem file
+%{?scl:scl enable %{scl} - << \EOF}
+gem build %{gem_name}.gemspec
+%{?scl:EOF}
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%{?scl:scl enable %{scl} - << \EOF}
+%gem_install
+%{?scl:EOF}
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -pa .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+%files
+%dir %{gem_instdir}
+%exclude %{gem_instdir}/.gitignore
+%exclude %{gem_instdir}/.travis.yml
+%{gem_instdir}/Guardfile
+%license %{gem_instdir}/LICENSE
+%{gem_libdir}
+%{gem_instdir}/profile
+%exclude %{gem_cache}
+%{gem_spec}
+
+%files doc
+%doc %{gem_docdir}
+%exclude %{gem_instdir}/.rspec
+%doc %{gem_instdir}/CHANGELOG.md
+%{gem_instdir}/Gemfile
+%doc %{gem_instdir}/README.md
+%{gem_instdir}/Rakefile
+%{gem_instdir}/ethon.gemspec
+%{gem_instdir}/spec
+
+%changelog
+* Fri Mar 08 2019 Justin Sherrill <jsherril@redhat.com> 0.12.0-1
+- Initial build
+

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -506,6 +506,7 @@ whitelist = katello
   pulp-katello
   rubygem-activerecord-import
   rubygem-anemone
+  rubygem-ethon
   rubygem-foreman_scc_manager
   rubygem-foreman_virt_who_configure
   rubygem-hammer_cli_csv


### PR DESCRIPTION
a dependency for zest, an autogenerated pupl3 api gem

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
