### PR TITLE
Release katello-client-boostrap 1.7.1

### DIFF
--- a/packages/katello/katello-client-bootstrap/katello-client-bootstrap-1.7.0.tar.gz
+++ b/packages/katello/katello-client-bootstrap/katello-client-bootstrap-1.7.0.tar.gz
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/F1/8V/SHA256E-s41176--c2c67db8e7091ff4954cea2abd5eebf130df77ef47a500f3b3babea59af420e5.tar.gz/SHA256E-s41176--c2c67db8e7091ff4954cea2abd5eebf130df77ef47a500f3b3babea59af420e5.tar.gz

--- a/packages/katello/katello-client-bootstrap/katello-client-bootstrap-1.7.1.tar.gz
+++ b/packages/katello/katello-client-bootstrap/katello-client-bootstrap-1.7.1.tar.gz
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/zz/63/SHA256E-s41851--222c781b7f8b110f85de959c0d6bb8623f959dbc4f516b917e526bded085e58e.tar.gz/SHA256E-s41851--222c781b7f8b110f85de959c0d6bb8623f959dbc4f516b917e526bded085e58e.tar.gz

--- a/packages/katello/katello-client-bootstrap/katello-client-bootstrap.spec
+++ b/packages/katello/katello-client-bootstrap/katello-client-bootstrap.spec
@@ -17,7 +17,7 @@
 #
 
 Name:           katello-client-bootstrap
-Version:        1.7.0
+Version:        1.7.1
 Release:        1%{?dist}
 Summary:        Client bootstrap utility for Foreman and Katello
 
@@ -50,6 +50,9 @@ cp bootstrap.py %{buildroot}%{_var}/www/html/pub/bootstrap.py
 %{_var}/www/html/pub/bootstrap.py
 
 %changelog
+* Tue Mar 12 2019 Evgeni Golov - 1.7.1-1
+- Release katello-client-boostrap 1.7.1
+
 * Fri Jan 25 2019 Evgeni Golov - 1.7.0-1
 - Release katello-client-bootstrap 1.7.0
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
