### PR TITLE
Update foreman-installer dependencies

### DIFF
--- a/debian/bionic/foreman-installer/control
+++ b/debian/bionic/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet-agent-puppet-strings | ruby-puppet-strings, ruby-kafo (>= 1.0.5)
+               puppet-agent-puppet-strings (>= 1.2.0), ruby-kafo (>= 3.0.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all
@@ -12,9 +12,9 @@ XS-Ruby-Versions: all
 Package: foreman-installer
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby,
-         ruby-kafo (>= 1.0.5),
-         puppet-agent (>= 1.9.0) | puppet (>= 4.9.0),
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
+         ruby-kafo (>= 3.0.0),
+         puppet-agent (>= 5.5.8) | puppet (>= 5.5.8),
          curl,
          lsb-release
 Description: Automated puppet-based installer for The Foreman

--- a/debian/stretch/foreman-installer/control
+++ b/debian/stretch/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet-agent-puppet-strings | ruby-puppet-strings, ruby-kafo (>= 1.0.5)
+               puppet-agent-puppet-strings (>= 1.2.0), ruby-kafo (>= 3.0.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all
@@ -12,9 +12,9 @@ XS-Ruby-Versions: all
 Package: foreman-installer
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby,
-         ruby-kafo (>= 1.0.5),
-         puppet-agent (>= 1.9.0) | puppet (>= 4.9.0),
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
+         ruby-kafo (>= 3.0.0),
+         puppet-agent (>= 5.5.8) | puppet (>= 5.5.8),
          curl,
          lsb-release
 Description: Automated puppet-based installer for The Foreman

--- a/debian/xenial/foreman-installer/control
+++ b/debian/xenial/foreman-installer/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Greg Sutcliffe <gsutclif@redhat.com>
 Build-Depends: debhelper (>= 7.0.50~), asciidoc, rake, libxml2-utils,
                xsltproc, docbook-xsl, git, ca-certificates, ruby-dev,
-               puppet-agent-puppet-strings, ruby-kafo (>= 1.0.5)
+               puppet-agent-puppet-strings (>= 1.2.0), ruby-kafo (>= 3.0.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-installer
 XS-Ruby-Versions: all
@@ -13,8 +13,8 @@ Package: foreman-installer
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-kafo (>= 1.0.5),
-         puppet-agent (>= 1.9.0) | puppet (>= 4.9.0),
+         ruby-kafo (>= 3.0.0),
+         puppet-agent (>= 5.5.8) | puppet (>= 5.5.8),
          curl,
          lsb-release
 Description: Automated puppet-based installer for The Foreman


### PR DESCRIPTION
We now depend on kafo >= 3.0.0 and Puppet 5.5.8.

https://community.theforeman.org/t/dropping-puppet-4-support-in-our-installer/13029