### PR TITLE
update foreman_datacenter to 1.20.0

### DIFF
--- a/plugins/ruby-foreman-datacenter/debian/changelog
+++ b/plugins/ruby-foreman-datacenter/debian/changelog
@@ -1,23 +1,5 @@
-ruby-foreman-datacenter (0.1.44) stable; urgency=low
+ruby-foreman-datacenter (1.20.0) stable; urgency=low
 
-  * 0.1.44 released
+  * 1.20.0 released
 
- -- Eugene Loginov <foreman@cloudevelops.com>  Sat, 16 Dec 2017 14:10:00 +0200
-
-ruby-foreman-datacenter (0.1.43) stable; urgency=low
-
-  * 0.1.43 released
-
- -- Eugene Loginov <foreman@cloudevelops.com>  Thu, 30 Nov 2017 20:45:05 +0200
-
-ruby-foreman-datacenter (0.1.42) stable; urgency=low
-
-  * 0.1.42 released
-
- -- Eugene Loginov <foreman@cloudevelops.com>  Thu, 23 Nov 2017 14:03:20 +0200
-
-ruby-foreman-datacenter (0.1.41) stable; urgency=low
-
-  * 0.1.41 released
-
- -- Eugene Loginov <foreman@cloudevelops.com>  Sun, 19 Nov 2017 18:23:01 +0200
+ -- Eugene Loginov <foreman@cloudevelops.com>  Sat, 9 Feb 2019 16:14:53 +0200

--- a/plugins/ruby-foreman-datacenter/debian/control
+++ b/plugins/ruby-foreman-datacenter/debian/control
@@ -2,12 +2,12 @@ Source: ruby-foreman-datacenter
 Section: ruby
 Priority: extra
 Maintainer: Cloudevelops <foreman@cloudevelops.com>
-Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.15.0), foreman-sqlite3 (>= 1.15.0), ruby-foreman-deface (<<2.0.0)
+Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.20.0), foreman-sqlite3 (>= 1.20.0), ruby-foreman-deface (<<2.0.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/cloudevelops/foreman_datacenter
 
 Package: ruby-foreman-datacenter
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.15.0), foreman-compute (>= 1.15.0), ruby-foreman-deface (<<2.0.0)
+Depends: ${misc:Depends}, bundler, foreman (>= 1.20.0), foreman-compute (>= 1.20.0), ruby-foreman-deface (<<2.0.0)
 Description: Foreman Datacenter for managing physical servers
  Foreman Datacenter lets you document your physical servers across multiple datacenters

--- a/plugins/ruby-foreman-datacenter/debian/gem.list
+++ b/plugins/ruby-foreman-datacenter/debian/gem.list
@@ -1,5 +1,5 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_datacenter-0.1.44.gem"
+GEMS="https://rubygems.org/downloads/foreman_datacenter-1.20.0.gem"
 GEMS="$GEMS https://rubygems.org/downloads/prawn-2.2.2.gem"
 GEMS="$GEMS https://rubygems.org/downloads/pdf-core-0.7.0.gem"
 GEMS="$GEMS https://rubygems.org/downloads/ttfunk-1.5.1.gem"

--- a/plugins/ruby-foreman-datacenter/foreman_datacenter.rb
+++ b/plugins/ruby-foreman-datacenter/foreman_datacenter.rb
@@ -1,1 +1,1 @@
-gem 'foreman_datacenter', '0.1.44'
+gem 'foreman_datacenter', '1.20.0'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.21
* [x] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
