### PR TITLE
Update rubygem-foreman-tasks-core to 0.2.6

### DIFF
--- a/packages/plugins/rubygem-foreman-tasks-core/foreman-tasks-core-0.2.5.gem
+++ b/packages/plugins/rubygem-foreman-tasks-core/foreman-tasks-core-0.2.5.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/F4/1w/SHA256E-s21504--e98e2cf74c70e25776866af80c3d632e59cc5cf36a7f18cb684cec9701b1af3a.5.gem/SHA256E-s21504--e98e2cf74c70e25776866af80c3d632e59cc5cf36a7f18cb684cec9701b1af3a.5.gem

--- a/packages/plugins/rubygem-foreman-tasks-core/foreman-tasks-core-0.2.6.gem
+++ b/packages/plugins/rubygem-foreman-tasks-core/foreman-tasks-core-0.2.6.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/x1/70/SHA256E-s21504--27d8b63fcd7c7bf4387bf588ea927ae3c015367acdaec4babffb060df7affef0.6.gem/SHA256E-s21504--27d8b63fcd7c7bf4387bf588ea927ae3c015367acdaec4babffb060df7affef0.6.gem

--- a/packages/plugins/rubygem-foreman-tasks-core/rubygem-foreman-tasks-core.spec
+++ b/packages/plugins/rubygem-foreman-tasks-core/rubygem-foreman-tasks-core.spec
@@ -5,8 +5,8 @@
 
 Summary: Code used both at Forman and Foreman proxy regarding tasks
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 0.2.5
-Release: 2%{?foremandist}%{?dist}
+Version: 0.2.6
+Release: 1%{?foremandist}%{?dist}
 Group: Development/Languages
 License: GPLv3
 URL: https://github.com/theforeman/foreman-tasks
@@ -60,6 +60,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/LICENSE
 
 %changelog
+* Fri Mar 15 2019 Ivan Nečas <inecas@redhat.com> 0.2.6-1
+- Update to 0.2.6
+
 * Mon Sep 10 2018 Eric D. Helms <ericdhelms@gmail.com> - 0.2.5-2
 - Rebuild for Rails 5.2 and Ruby 2.5
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [x] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

It seems I've missed releasing foreman-tasks-core version for 1.21, that would be compatible with concurrent-ruby updates we did in 1.21. This is supposed to fix the mess.