### PR TITLE
Update foreman-tasks-core to 0.2.6 (deb)

### DIFF
--- a/plugins/ruby-foreman-tasks/debian/gem.list
+++ b/plugins/ruby-foreman-tasks/debian/gem.list
@@ -1,6 +1,6 @@
 # list of gem urls to download via Jenkins, space separated
 GEMS="https://rubygems.org/downloads/foreman-tasks-0.14.5.gem"
-GEMS="$GEMS https://rubygems.org/downloads/foreman-tasks-core-0.2.5.gem"
+GEMS="$GEMS https://rubygems.org/downloads/foreman-tasks-core-0.2.6.gem"
 GEMS="$GEMS https://rubygems.org/downloads/parse-cron-0.1.4.gem"
 GEMS="$GEMS https://rubygems.org/downloads/sinatra-2.0.4.gem"
 GEMS="$GEMS https://rubygems.org/downloads/rack-protection-2.0.4.gem"


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [x] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---

Needed for compatibility with the concurrent-ruby.

Proxy update on it's way as well