### PR TITLE
Update foreman-tasks-core to 0.2.6

### DIFF
--- a/dependencies/bionic/foreman-tasks-core/changelog
+++ b/dependencies/bionic/foreman-tasks-core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-tasks-core (0.2.6-1) stable; urgency=low
+
+  * 0.2.6 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Fri, 15 Mar 2019 11:59:03 +0100
+
 ruby-foreman-tasks-core (0.2.5-1) stable; urgency=low
 
   * Initial release for Ubuntu/bionic

--- a/dependencies/stretch/foreman-tasks-core/changelog
+++ b/dependencies/stretch/foreman-tasks-core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-tasks-core (0.2.6-1) stable; urgency=low
+
+  * 0.2.6 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Fri, 15 Mar 2019 11:59:03 +0100
+
 ruby-foreman-tasks-core (0.2.5-1) stable; urgency=low
 
   * 0.2.5 released

--- a/dependencies/xenial/foreman-tasks-core/changelog
+++ b/dependencies/xenial/foreman-tasks-core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-tasks-core (0.2.6-1) stable; urgency=low
+
+  * 0.2.6 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Fri, 15 Mar 2019 11:59:03 +0100
+
 ruby-foreman-tasks-core (0.2.5-1) stable; urgency=low
 
   * 0.2.5 released


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [ ] Nightly
* [x] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
