### PR TITLE
Fixes #26401 - Remove GPG key from f-release-client

### DIFF
--- a/packages/foreman/foreman-release/foreman-client.repo
+++ b/packages/foreman/foreman-release/foreman-client.repo
@@ -3,11 +3,11 @@ name=Foreman client nightly
 baseurl=https://yum.theforeman.org/client/nightly/$DIST/$basearch
 enabled=1
 gpgcheck=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman-client
 
 [foreman-client-source]
 name=Foreman client nightly - source
 baseurl=https://yum.theforeman.org/client/nightly/$DIST/source
 enabled=0
 gpgcheck=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman-client

--- a/packages/foreman/foreman-release/foreman-release.spec
+++ b/packages/foreman/foreman-release/foreman-release.spec
@@ -13,7 +13,7 @@
 %define repo_dist %{dist}
 %endif
 
-%global release 1
+%global release 2
 %global prerelease develop
 
 Name:     foreman-release
@@ -55,7 +55,6 @@ Defines yum repositories for Foreman clients.
 
 %files -n foreman-client-release
 %config %{repo_dir}/foreman-client.repo
-%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman
 
 %if 0%{?rhel} == 6
 %config %{repo_dir}/pulp.repo
@@ -110,6 +109,9 @@ install -Dpm0644 %{SOURCE4} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-f
 %{_sysconfdir}/pki/rpm-gpg/*
 
 %changelog
+* Tue Mar 19 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.22.0-0.2.develop
+- Remove GPG key from -client package
+
 * Wed Jan 16 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.22.0-0.1.develop
 - Bump to 1.22
 


### PR DESCRIPTION
This file belongs to foreman-release and can create conflicts on upgrade.