### PR TITLE
Update rubygem-hammer_cli_foreman_openscap to 0.1.7

### DIFF
--- a/packages/plugins/rubygem-hammer_cli_foreman_openscap/hammer_cli_foreman_openscap-0.1.6.gem
+++ b/packages/plugins/rubygem-hammer_cli_foreman_openscap/hammer_cli_foreman_openscap-0.1.6.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/8P/F1/SHA256E-s158720--e9dbb2fa3fce2a5c348cd5d770284c6b63d2a1eb0372c174dc1c68961c14bbca.6.gem/SHA256E-s158720--e9dbb2fa3fce2a5c348cd5d770284c6b63d2a1eb0372c174dc1c68961c14bbca.6.gem

--- a/packages/plugins/rubygem-hammer_cli_foreman_openscap/hammer_cli_foreman_openscap-0.1.7.gem
+++ b/packages/plugins/rubygem-hammer_cli_foreman_openscap/hammer_cli_foreman_openscap-0.1.7.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/kv/Fg/SHA256E-s158720--5fbc552bac7f5d8259d5525cc65f9f68cff29a9bf186f475d145d6efc1dd1a92.7.gem/SHA256E-s158720--5fbc552bac7f5d8259d5525cc65f9f68cff29a9bf186f475d145d6efc1dd1a92.7.gem

--- a/packages/plugins/rubygem-hammer_cli_foreman_openscap/rubygem-hammer_cli_foreman_openscap.spec
+++ b/packages/plugins/rubygem-hammer_cli_foreman_openscap/rubygem-hammer_cli_foreman_openscap.spec
@@ -8,8 +8,8 @@
 
 Summary: Foreman OpenSCAP commands for Hammer CLI
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 0.1.6
-Release: 2%{?foremandist}%{?dist}
+Version: 0.1.7
+Release: 1%{?foremandist}%{?dist}
 Group: Applications/System
 License: GPLv3
 URL: https://github.com/theforeman/hammer_cli_foreman_openscap
@@ -65,6 +65,9 @@ cp -pa .%{gem_instdir}/config/foreman_openscap.yml %{buildroot}%{_root_sysconfdi
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Tue Mar 19 2019 Marek Hulan <mhulan@redhat.com> 0.1.7-1
+- Update to 0.1.7
+
 * Fri Sep 07 2018 Eric D. Helms <ericdhelms@gmail.com> - 0.1.6-2
 - Rebuild for Rails 5.2 and Ruby 2.5
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
