### PR TITLE
use foreman-develop-release instead of test_develop for building foreman

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -36,7 +36,7 @@ foreman_scl_packages:
         - "{{ nightly_releaser }}"
       build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
       nightly_package_tito_releaser_args:
-        - "--arg jenkins_job=test_develop"
+        - "--arg jenkins_job=foreman-develop-release"
     rubygem-activerecord-session_store: {}
     rubygem-addressable: {}
     rubygem-algebrick: {}


### PR DESCRIPTION
test_develop was removed some time ago

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
