### PR TITLE
drop foreman-compute require from foreman-one

### DIFF
--- a/packages/plugins/rubygem-foreman_one/rubygem-foreman_one.spec
+++ b/packages/plugins/rubygem-foreman_one/rubygem-foreman_one.spec
@@ -9,7 +9,7 @@
 Summary:    Provision and manage OpenNebula VMs from Foreman
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    0.4
-Release:    3%{?foremandist}%{?dist}
+Release:    4%{?foremandist}%{?dist}
 Group:      Applications/Systems
 License:    GPLv3
 URL:        https://github.com/theforeman/foreman-one
@@ -17,7 +17,6 @@ Source0:    https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
 # start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
-Requires: foreman-compute >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
@@ -100,6 +99,9 @@ cp -pa .%{gem_dir}/* \
 exit 0
 
 %changelog
+* Thu Mar 28 2019 Evgeni Golov - 0.4-4
+- Drop foreman-compute requirement
+
 * Fri Sep 07 2018 Eric D. Helms <ericdhelms@gmail.com> - 0.4-3
 - Rebuild for Rails 5.2 and Ruby 2.5
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
