### PR TITLE
Refs #26097 - Ignore cross-env in NPM requirements

### DIFF
--- a/update-requirements
+++ b/update-requirements
@@ -13,6 +13,7 @@ NPM_BLACKLIST = [
     'babel-jest',
     'babel-plugin-dynamic-import-node',
     'coveralls',
+    'cross-env',
     'highlight.js',
     'jest',
     'prettier',


### PR DESCRIPTION
This is only used for storybook building which we don't do in our packaged builds.