### PR TITLE
Remove foreman-compute dependencies from plugins

### DIFF
--- a/plugins/ruby-foreman-datacenter/debian/control
+++ b/plugins/ruby-foreman-datacenter/debian/control
@@ -8,6 +8,6 @@ Homepage: https://github.com/cloudevelops/foreman_datacenter
 
 Package: ruby-foreman-datacenter
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.20.0), foreman-compute (>= 1.20.0), ruby-foreman-deface (<<2.0.0)
+Depends: ${misc:Depends}, bundler, foreman (>= 1.20.0), ruby-foreman-deface (<<2.0.0)
 Description: Foreman Datacenter for managing physical servers
  Foreman Datacenter lets you document your physical servers across multiple datacenters

--- a/plugins/ruby-foreman-digitalocean/debian/control
+++ b/plugins/ruby-foreman-digitalocean/debian/control
@@ -8,5 +8,5 @@ Homepage: https://github.com/theforeman/foreman-digitalocean
 
 Package: ruby-foreman-digitalocean
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman-compute (>= 1.13.0),
+Depends: ${misc:Depends}, bundler
 Description: Foreman DigitalOcean compute resource

--- a/plugins/ruby-foreman-docker/debian/control
+++ b/plugins/ruby-foreman-docker/debian/control
@@ -2,13 +2,13 @@ Source: ruby-foreman-docker
 Section: ruby
 Priority: extra
 Maintainer: Pujan Shah <pujan14@gmail.com>
-Build-Depends: debhelper, foreman-compute (>= 1.15.0~rc1), foreman-assets (>= 1.15.0~rc1), foreman-sqlite3 (>= 1.15.0~rc1), ruby-foreman-deface (<<2.0.0)
+Build-Depends: debhelper, foreman-assets (>= 1.15.0~rc1), foreman-sqlite3 (>= 1.15.0~rc1), ruby-foreman-deface (<<2.0.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-docker
 
 Package: ruby-foreman-docker
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman-compute (>= 1.15.0~rc1), ruby-foreman-deface (<<2.0.0)
+Depends: ${misc:Depends}, bundler, ruby-foreman-deface (<<2.0.0)
 Description: Foreman Docker compute resource
  Docker compute resource plugin for Foreman
  This version does not provide any functionality and only makes plugin removal easier.


### PR DESCRIPTION
the package was dropped in 8b3ab60bee6a28b1d29156ffe51f82d4c38838ab but
some plugins still require it

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
