### PR TITLE
Update rubygem-foreman_scap_client to 0.4.5

### DIFF
--- a/packages/client/rubygem-foreman_scap_client/foreman_scap_client-0.4.3.gem
+++ b/packages/client/rubygem-foreman_scap_client/foreman_scap_client-0.4.3.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/Km/90/SHA256E-s19456--4eb081dfdeadafbe793b72104b63cf2c3ab151e75b881420b7802d2319abed5d.3.gem/SHA256E-s19456--4eb081dfdeadafbe793b72104b63cf2c3ab151e75b881420b7802d2319abed5d.3.gem

--- a/packages/client/rubygem-foreman_scap_client/foreman_scap_client-0.4.5.gem
+++ b/packages/client/rubygem-foreman_scap_client/foreman_scap_client-0.4.5.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/W8/X8/SHA256E-s19968--71e61d8e57be1ba22a31ce13e6e8401dc1b80052efebe00303c377ff8c23fb2c.5.gem/SHA256E-s19968--71e61d8e57be1ba22a31ce13e6e8401dc1b80052efebe00303c377ff8c23fb2c.5.gem

--- a/packages/client/rubygem-foreman_scap_client/rubygem-foreman_scap_client.spec
+++ b/packages/client/rubygem-foreman_scap_client/rubygem-foreman_scap_client.spec
@@ -4,7 +4,7 @@
 %define rubyabi 1.8
 
 Name: rubygem-%{gem_name}
-Version: 0.4.3
+Version: 0.4.5
 Release: 1%{?dist}
 Summary: Client script that runs OpenSCAP scan and uploads the result to foreman proxy
 Group: Development/Languages
@@ -96,6 +96,9 @@ mkdir -p %{buildroot}%{config_dir}
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Tue Apr 09 2019 Marek Hulan <mhulan@redhat.com> 0.4.5-1
+- Update to 0.4.5
+
 * Thu Mar 07 2019 Marek Hulan <mhulan@redhat.com> 0.4.3-1
 - Update to 0.4.3
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
