### PR TITLE
Update foreman_remote_execution to 1.7.1

### DIFF
--- a/dependencies/bionic/foreman_remote_execution_core/changelog
+++ b/dependencies/bionic/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.1.6-1) stable; urgency=low
+
+  * 1.1.6 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Thu, 11 Apr 2019 09:19:31 +0200
+
 ruby-foreman-remote-execution-core (1.1.5-1) stable; urgency=low
 
   * 1.1.5 released

--- a/dependencies/stretch/foreman_remote_execution_core/changelog
+++ b/dependencies/stretch/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.1.6-1) stable; urgency=low
+
+  * 1.1.6 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Thu, 11 Apr 2019 09:19:31 +0200
+
 ruby-foreman-remote-execution-core (1.1.5-1) stable; urgency=low
 
   * 1.1.5 released

--- a/dependencies/xenial/foreman_remote_execution_core/changelog
+++ b/dependencies/xenial/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.1.6-1) stable; urgency=low
+
+  * 1.1.6 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Thu, 11 Apr 2019 09:19:31 +0200
+
 ruby-foreman-remote-execution-core (1.1.5-1) stable; urgency=low
 
   * 1.1.5 released

--- a/plugins/ruby-foreman-remote-execution/debian/changelog
+++ b/plugins/ruby-foreman-remote-execution/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution (1.7.1-1) stable; urgency=low
+
+  * 1.7.1 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Thu, 11 Apr 2019 09:17:32 +0200
+
 ruby-foreman-remote-execution (1.7.0-1) stable; urgency=low
 
   * 1.7.0 released

--- a/plugins/ruby-foreman-remote-execution/debian/control
+++ b/plugins/ruby-foreman-remote-execution/debian/control
@@ -3,13 +3,13 @@ Section: ruby
 Priority: extra
 Maintainer: Stephen Benjamin <stephen@redhat.com>
 Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.20.0~rc1), foreman (>= 1.20.0~rc1),
-  foreman-sqlite3 (>= 1.20.0~rc1), ruby-foreman-tasks (>= 0.12.0), ruby-foreman-deface
+  foreman-sqlite3 (>= 1.20.0~rc1), ruby-foreman-tasks (>= 0.15.1), ruby-foreman-deface
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_remote_execution
 
 Package: ruby-foreman-remote-execution
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.20.0~rc1), ruby-foreman-tasks (>= 0.12.0),
+Depends: ${misc:Depends}, bundler, foreman (>= 1.20.0~rc1), ruby-foreman-tasks (>= 0.15.1),
   ruby-foreman-deface
 Description: Foreman Remote Execution Plugin
   A plugin bringing remote execution to the Foreman, completing the config management functionality with remote management functionality

--- a/plugins/ruby-foreman-remote-execution/debian/gem.list
+++ b/plugins/ruby-foreman-remote-execution/debian/gem.list
@@ -1,3 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.7.0.gem"
-GEMS="$GEMS https://rubygems.org/downloads/foreman_remote_execution_core-1.1.5.gem"
+GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.7.1.gem"
+GEMS="$GEMS https://rubygems.org/downloads/foreman_remote_execution_core-1.1.6.gem"

--- a/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
+++ b/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
@@ -1,1 +1,1 @@
-gem 'foreman_remote_execution', '1.7.0'
+gem 'foreman_remote_execution', '1.7.1'


### PR DESCRIPTION
And core to 1.1.6

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
