### PR TITLE
use the nightly macro in the ForemanSourceStrategy

### DIFF
--- a/rel-eng/custom/custom.py
+++ b/rel-eng/custom/custom.py
@@ -88,7 +88,7 @@ class ForemanSourceStrategy(SourceStrategy):
         rel_date = datetime.utcnow().strftime("%Y%m%d%H%M")
         self.release = rel_date + gitrev
         print("Building release: %s" % self.release)
-        run_command("sed -i '/^Release:/ s/\s\+/ 0.%s/' %s" % (self.release, self.spec_file))
+        run_command("sed -i '1i %%global nightly .%s/' %s" % (self.release, self.spec_file))
 
     """
     Downloads the source files from Jenkins, from a job that produces them as


### PR DESCRIPTION
previously tito would (via our ForemanSourceStrategy) generate versions
like foreman-1.22.0-0.201903280802git97b75e70.8.develop.el7.src.rpm
because it was prepending `0.<date>git<hash>` to the %release macro

but `obal nightly` uses a special `nightly` macro to inject
`<date>git<hash>` into %release.

because of this difference, different jobs would generate different
version structures, resulting in nightly packages that can't be upgraded
because ForemanSourceStrategy generated a newer version than `obal
nightly`.

this commit adjusts ForemanSourceStrategy to also use the same method as
`obal nightly`, resulting in
foreman-1.22.0-0.8.develop.201903280802git97b75e70.el7.src.rpm for the
above example
