### PR TITLE
Remove sinatra from the ruby SCL prefix

### DIFF
--- a/scl_prefixes.json
+++ b/scl_prefixes.json
@@ -46,7 +46,6 @@
 	"sass": "_ror",
 	"sass-rails": "_ror",
 	"sinatra": "_ror",
-	"sinatra": "_ruby",
 	"sprockets": "_ror",
 	"sprockets-rails": "_ror",
 	"sqlite3": "_ror",


### PR DESCRIPTION
This package is only shipped in our RoR SCL so it generates broken output.