### PR TITLE
Fix sed command for nightly macro

### DIFF
--- a/rel-eng/custom/custom.py
+++ b/rel-eng/custom/custom.py
@@ -88,7 +88,7 @@ class ForemanSourceStrategy(SourceStrategy):
         rel_date = datetime.utcnow().strftime("%Y%m%d%H%M")
         self.release = rel_date + gitrev
         print("Building release: %s" % self.release)
-        run_command("sed -i '1i %%global nightly .%s/' %s" % (self.release, self.spec_file))
+        run_command("sed -i '1i %%global nightly .%s' %s" % (self.release, self.spec_file))
 
     """
     Downloads the source files from Jenkins, from a job that produces them as


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
The causes errors: https://ci.theforeman.org/blue/organizations/jenkins/foreman-packaging-rpm-pr-test/detail/foreman-packaging-rpm-pr-test/174/pipeline/

I expect https://github.com/theforeman/foreman-packaging/pull/3627 to pass with this change, but we probably want to add it separately.
