### PR TITLE
Fix releasers for client Fedora 29

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -24,11 +24,11 @@ builder.rpmbuild_options = --define "foremandist .fm1_22"
 
 [koji-foreman-client]
 releaser = tito.release.KojiReleaser
-autobuild_tags = foreman-client-nightly-rhel5 foreman-client-nightly-rhel6 foreman-client-nightly-rhel7 foreman-client-nightly-fedora27 foreman-client-nightly-fedora28
+autobuild_tags = foreman-client-nightly-rhel5 foreman-client-nightly-rhel6 foreman-client-nightly-rhel7 foreman-client-nightly-fedora29 foreman-client-nightly-fedora28
 
 [koji-foreman-client-jenkins]
 releaser = tito.release.KojiReleaser
-autobuild_tags = foreman-client-nightly-rhel5 foreman-client-nightly-rhel6 foreman-client-nightly-rhel7 foreman-client-nightly-fedora27 foreman-client-nightly-fedora28
+autobuild_tags = foreman-client-nightly-rhel5 foreman-client-nightly-rhel6 foreman-client-nightly-rhel7 foreman-client-nightly-fedora29 foreman-client-nightly-fedora28
 builder = tito.builder.FetchBuilder
 
 # Katello Releasers

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -479,8 +479,8 @@ disttag = .el5
 whitelist = foreman-release
   katello-host-tools
 
-[foreman-client-nightly-fedora27]
-disttag = .fc27
+[foreman-client-nightly-fedora29]
+disttag = .fc29
 whitelist = foreman-release
   katello-host-tools
   rubygem-foreman_scap_client


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
