### PR TITLE
New ansible plugin releases (foreman_ansible, foreman_ansible_core, smart_proxy_ansible) for nightly/1.22

### DIFF
--- a/dependencies/bionic/foreman_ansible_core/changelog
+++ b/dependencies/bionic/foreman_ansible_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-ansible-core (3.0.0-1) stable; urgency=low
+
+  * Update foreman_ansible_core to 3.0.0
+
+ -- Marek Hulan <mhulan@redhat.com>  Thu, 18 Apr 2019 20:34:29 +0200
+
 ruby-foreman-ansible-core (2.2.1-1) stable; urgency=low
 
   * Update foreman_ansible_core to 2.2.1

--- a/dependencies/stretch/foreman_ansible_core/changelog
+++ b/dependencies/stretch/foreman_ansible_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-ansible-core (3.0.0-1) stable; urgency=low
+
+  * Update foreman_ansible_core to 3.0.0
+
+ -- Marek Hulan <mhulan@redhat.com>  Thu, 18 Apr 2019 20:34:29 +0200
+
 ruby-foreman-ansible-core (2.2.1-1) stable; urgency=low
 
   * Update foreman_ansible_core to 2.2.1

--- a/dependencies/xenial/foreman_ansible_core/changelog
+++ b/dependencies/xenial/foreman_ansible_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-ansible-core (3.0.0-1) stable; urgency=low
+
+  * Update foreman_ansible_core to 3.0.0
+
+ -- Marek Hulan <mhulan@redhat.com>  Thu, 18 Apr 2019 20:34:29 +0200
+
 ruby-foreman-ansible-core (2.2.1-1) stable; urgency=low
 
   * Update foreman_ansible_core to 2.2.1

--- a/plugins/ruby-foreman-ansible/debian/changelog
+++ b/plugins/ruby-foreman-ansible/debian/changelog
@@ -1,3 +1,15 @@
+ruby-foreman-ansible (3.0.1-1) stable; urgency=low
+
+  * Update foreman_ansible to 3.0.1
+
+ -- Marek Hulan <mhulan@redhat.com>  Tue, 30 Apr 2019 21:19:51 +0200
+
+ruby-foreman-ansible (3.0.0-1) stable; urgency=low
+
+  * Update foreman-ansible to 3.0.0
+
+ -- Marek Hulan <mhulan@redhat.com>  Thu, 18 Apr 2019 20:33:25 +0200
+
 ruby-foreman-ansible (2.3.3-1) stable; urgency=low
 
   * Update foreman-ansible to 2.3.3

--- a/plugins/ruby-foreman-ansible/debian/control
+++ b/plugins/ruby-foreman-ansible/debian/control
@@ -2,16 +2,16 @@ Source: ruby-foreman-ansible
 Section: ruby
 Priority: extra
 Maintainer: Daniel Lobato Garcia <elobatocs@gmail.com>
-Build-Depends: debhelper, foreman (>= 1.18.0~rc1), ruby-foreman-deface (<<2.0.0),
-  foreman-assets(>= 1.18.0~rc1), ruby-foreman-tasks (>= 0.8.2-2), ruby-foreman-tasks (<<1.0.0),
+Build-Depends: debhelper, foreman (>= 1.22.0~rc1), ruby-foreman-deface (<<2.0.0),
+  foreman-assets(>= 1.22.0~rc1), ruby-foreman-tasks (>= 0.8.2-2), ruby-foreman-tasks (<<1.0.0),
   ruby-foreman-remote-execution (>= 1.7.0-1), ruby-foreman-remote-execution (<<2.0.0),
-  foreman-sqlite3 (>= 1.18.0~rc1)
+  foreman-sqlite3 (>= 1.22.0~rc1)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_ansible
 
 Package: ruby-foreman-ansible
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.18.0~rc1),
+Depends: ${misc:Depends}, bundler, foreman (>= 1.22.0~rc1),
   ruby-foreman-deface (<<2.0.0),
   ruby-foreman-tasks (>= 0.8.2-2), ruby-foreman-tasks (<<1.0.0),
   ruby-foreman-remote-execution (>= 1.7.0-1), ruby-foreman-remote-execution (<<2.0.0)

--- a/plugins/ruby-foreman-ansible/debian/gem.list
+++ b/plugins/ruby-foreman-ansible/debian/gem.list
@@ -1,2 +1,2 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_ansible-2.3.3.gem"
+GEMS="https://rubygems.org/downloads/foreman_ansible-3.0.1.gem"

--- a/plugins/ruby-foreman-ansible/foreman_ansible.rb
+++ b/plugins/ruby-foreman-ansible/foreman_ansible.rb
@@ -1,1 +1,1 @@
-gem 'foreman_ansible', '2.3.3'
+gem 'foreman_ansible', '3.0.1'

--- a/plugins/smart_proxy_ansible/ansible.rb
+++ b/plugins/smart_proxy_ansible/ansible.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_ansible', '2.1.2'
+gem 'smart_proxy_ansible', '3.0.0'

--- a/plugins/smart_proxy_ansible/changelog
+++ b/plugins/smart_proxy_ansible/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-ansible (3.0.0-1) stable; urgency=low
+
+  * Update smart_proxy_ansible to 3.0.0
+
+ -- Marek Hulan <mhulan@redhat.com>  Thu, 18 Apr 2019 20:35:03 +0200
+
 ruby-smart-proxy-ansible (2.1.2-1) stable; urgency=low
 
   * Update smart_proxy_ansible to 2.1.2

--- a/plugins/smart_proxy_ansible/control
+++ b/plugins/smart_proxy_ansible/control
@@ -10,7 +10,7 @@ XS-Ruby-Versions: all
 Package: ruby-smart-proxy-ansible
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.11.0~rc3),
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.22.0~rc1),
   ruby-smart-proxy-dynflow (>= 0.1.0), ruby-smart-proxy-dynflow (<< 1.0.0),
   ansible (>= 2.2.0)
 Description: Ansible support for Foreman smart proxy


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly (1.22 whatever happens sooner)
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
