### PR TITLE
Update foreman_fog_proxmox to 0.7.0

### DIFF
--- a/plugins/ruby-foreman-fog-proxmox/debian/changelog
+++ b/plugins/ruby-foreman-fog-proxmox/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-fog-proxmox (0.7.0-1) stable; urgency=low
+
+  * 0.7.0 released
+
+ -- Tristan Robert <tristan.robert.44@gmail.com>  Sat, 20 Apr 2019 18:01:19 +0200
+
 ruby-foreman-fog-proxmox (0.5.5-2) stable; urgency=low
 
   * 0.5.5-2 released. Update fog-proxmox dependency to 0.5.5.

--- a/plugins/ruby-foreman-fog-proxmox/debian/control
+++ b/plugins/ruby-foreman-fog-proxmox/debian/control
@@ -2,12 +2,12 @@ Source: ruby-foreman-fog-proxmox
 Section: ruby
 Priority: extra
 Maintainer: Tristan Robert <tristan.robert.44@gmail.com>
-Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.17.0), foreman (>= 1.17.0), ruby-foreman-deface, foreman-sqlite3
+Build-Depends: debhelper (>= 8.0.0), foreman-assets (>= 1.22.0), foreman (>= 1.22.0), ruby-foreman-deface, foreman-sqlite3
 Standards-Version: 3.9.3
-Homepage: https://github.com/tristanrobert/foreman_fog_proxmox
+Homepage: https://github.com/theforeman/foreman_fog_proxmox
 
 Package: ruby-foreman-fog-proxmox
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 1.17.0), ruby-foreman-deface
+Depends: ${misc:Depends}, bundler, foreman (>= 1.22.0), ruby-foreman-deface
 Description: Foreman plugin that adds Proxmox VE compute resource using fog-proxmox
- Foreman plugin adds Proxmox VE compute resource using fog-proxmox. It is compatible with Foreman 1.17+
+ Foreman plugin adds Proxmox VE compute resource using fog-proxmox. It is compatible with Foreman 1.22+

--- a/plugins/ruby-foreman-fog-proxmox/debian/copyright
+++ b/plugins/ruby-foreman-fog-proxmox/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: ruby-foreman-fog-proxmox
-Source: https://github.com/tristanrobert/foreman_fog_proxmox
+Source: https://github.com/theforeman/foreman_fog_proxmox
 
 Files: *
 Copyright: 2018 Tristan Robert <tristan.robert.44@gmail.com>

--- a/plugins/ruby-foreman-fog-proxmox/debian/gem.list
+++ b/plugins/ruby-foreman-fog-proxmox/debian/gem.list
@@ -1,3 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_fog_proxmox-0.5.5.gem"
-GEMS="$GEMS https://rubygems.org/downloads/fog-proxmox-0.5.5.gem"
+GEMS="https://rubygems.org/downloads/foreman_fog_proxmox-0.7.0.gem"
+GEMS="$GEMS https://rubygems.org/downloads/fog-proxmox-0.7.0.gem"

--- a/plugins/ruby-foreman-fog-proxmox/foreman_fog_proxmox.rb
+++ b/plugins/ruby-foreman-fog-proxmox/foreman_fog_proxmox.rb
@@ -1,2 +1,2 @@
-gem 'foreman_fog_proxmox', '0.5.5'
-gem 'fog-proxmox', '0.5.5'
+gem 'foreman_fog_proxmox', '0.7.0'
+gem 'fog-proxmox', '0.7.0'


### PR DESCRIPTION
Suitable with foreman 1.22, fog-core 2.1 and Proxmox VE 5.4

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
