### PR TITLE
Blacklist surge from NPM dependencies

### DIFF
--- a/update-requirements
+++ b/update-requirements
@@ -23,6 +23,7 @@ NPM_BLACKLIST = [
     'react-test-renderer',
     'react-redux-test-utils',
     'redux-mock-store',
+    'surge',
     'webpack-bundle-analyzer',
     'webpack-dev-server',
 ]


### PR DESCRIPTION
This is a pure development dependency. Since NPM doesn't have build vs dev dependencies, we include development dependencies and blacklist non-build ones.