### PR TITLE
Install bootstrap.py without executable bit

### DIFF
--- a/packages/katello/katello-client-bootstrap/katello-client-bootstrap.spec
+++ b/packages/katello/katello-client-bootstrap/katello-client-bootstrap.spec
@@ -18,7 +18,7 @@
 
 Name:           katello-client-bootstrap
 Version:        1.7.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Client bootstrap utility for Foreman and Katello
 
 Group:          System Environment/Base
@@ -38,9 +38,7 @@ Client bootstrap utility for Foreman and Katello
 %build
 
 %install
-
-mkdir -p %{buildroot}/%{_var}/www/html/pub/
-cp bootstrap.py %{buildroot}%{_var}/www/html/pub/bootstrap.py
+install -m644 -D bootstrap.py %{buildroot}%{_var}/www/html/pub/bootstrap.py
 
 %files
 %doc README.md
@@ -50,6 +48,9 @@ cp bootstrap.py %{buildroot}%{_var}/www/html/pub/bootstrap.py
 %{_var}/www/html/pub/bootstrap.py
 
 %changelog
+* Thu Apr 18 2019 Evgeni Golov - 1.7.2-2
+- Install bootstrap.py without executable bit
+
 * Mon Apr 01 2019 Evgeni Golov - 1.7.2-1
 - Release katello-client-boostrap 1.7.2
 


### PR DESCRIPTION
The file is there to be downloaded, not executed.
This also helps with RPM trying to be smart and detect a "wrong" shebang
on EL8-based setups.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
