### PR TITLE
Update rubygem-smart_proxy_remote_execution_ssh to 0.2.1 (rpm)

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
+++ b/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
@@ -7,8 +7,8 @@
 
 Summary: SSH remote execution provider for Foreman smart proxy
 Name: rubygem-%{gem_name}
-Version: 0.2.0
-Release: 2%{?dist}
+Version: 0.2.1
+Release: 1%{?dist}
 Group: Applications/System
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_remote_execution_ssh
@@ -19,6 +19,7 @@ Requires: %{?rhel:tfm-}rubygem(foreman_remote_execution_core)
 Requires: foreman-proxy >= 1.11.0
 Requires: rubygem(smart_proxy_dynflow) >= 0.1.0
 Requires: rubygem(smart_proxy_dynflow) < 0.3.0
+Requires: rubygem(net-ssh)
 
 Requires: ruby
 Requires: ruby(rubygems)
@@ -95,6 +96,9 @@ EOF
 %doc %{gem_docdir}
 
 %changelog
+* Wed Apr 24 2019 Ivan Nečas <inecas@redhat.com> 0.2.1-1
+- Update to 0.2.1
+
 * Tue May 29 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 0.2.0-2
 - Handle .ssh symlinks
 

--- a/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/smart_proxy_remote_execution_ssh-0.2.0.gem
+++ b/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/smart_proxy_remote_execution_ssh-0.2.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/GJ/vq/SHA256E-s18432--116ebd54999988af18ac7a2ddd69aa15fe008f054b94b9f7da94a63f1409caca.0.gem/SHA256E-s18432--116ebd54999988af18ac7a2ddd69aa15fe008f054b94b9f7da94a63f1409caca.0.gem

--- a/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/smart_proxy_remote_execution_ssh-0.2.1.gem
+++ b/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/smart_proxy_remote_execution_ssh-0.2.1.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/vm/7q/SHA256E-s20992--9ef4025521fa7a9cc0070ef16fe0d52943054fd87e92caee52cc70e331f06eb2.1.gem/SHA256E-s20992--9ef4025521fa7a9cc0070ef16fe0d52943054fd87e92caee52cc70e331f06eb2.1.gem


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---