### PR TITLE
Update smart_proxy_remote_execution_ssh to 0.2.1 (deb)

### DIFF
--- a/plugins/smart_proxy_remote_execution_ssh/changelog
+++ b/plugins/smart_proxy_remote_execution_ssh/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-remote-execution-ssh (0.2.1-1) stable; urgency=low
+
+  * 0.2.1 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Wed, 24 Apr 2019 14:32:02 +0200
+
 ruby-smart-proxy-remote-execution-ssh (0.2.0-2) stable; urgency=low
 
   * Move .ssh to /var/lib/foreman-proxy

--- a/plugins/smart_proxy_remote_execution_ssh/control
+++ b/plugins/smart_proxy_remote_execution_ssh/control
@@ -12,6 +12,6 @@ Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.11.0~rc3),
   ruby-foreman-remote-execution-core (>= 1.0.0),
-  ruby-smart-proxy-dynflow (>= 0.1.0), ruby-smart-proxy-dynflow (<< 0.3.0)
+  ruby-smart-proxy-dynflow (>= 0.1.0), ruby-smart-proxy-dynflow (<< 0.3.0), ruby-net-ssh
 Description: SSH remote execution provider for Foreman smart proxy
  SSH remote execution provider for Foreman smart proxy - the API part

--- a/plugins/smart_proxy_remote_execution_ssh/remote_execution_ssh.rb
+++ b/plugins/smart_proxy_remote_execution_ssh/remote_execution_ssh.rb
@@ -1,2 +1,2 @@
-gem 'smart_proxy_remote_execution_ssh', '0.2.0'
+gem 'smart_proxy_remote_execution_ssh', '0.2.1'
 gem 'foreman_remote_execution_core'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---