### PR TITLE
Update rubygem-katello-3.10 to 3.10.1

### DIFF
--- a/packages/katello-3.10/rubygem-katello-3.10/katello-3.10.0.gem
+++ b/packages/katello-3.10/rubygem-katello-3.10/katello-3.10.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/QJ/jG/SHA256E-s2379264--2f5d76471b2e5fb5c34d8cadf8bbbf0169e8c9e63477a7774e8373add47d25e2.0.gem/SHA256E-s2379264--2f5d76471b2e5fb5c34d8cadf8bbbf0169e8c9e63477a7774e8373add47d25e2.0.gem

--- a/packages/katello-3.10/rubygem-katello-3.10/katello-3.10.1.gem
+++ b/packages/katello-3.10/rubygem-katello-3.10/katello-3.10.1.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/2z/56/SHA256E-s2380288--10d36b1f4a37bd337588097ad4abd71be8b0fd4b3b55f2b98c6de569651eeaaa.1.gem/SHA256E-s2380288--10d36b1f4a37bd337588097ad4abd71be8b0fd4b3b55f2b98c6de569651eeaaa.1.gem

--- a/packages/katello-3.10/rubygem-katello-3.10/rubygem-katello.spec
+++ b/packages/katello-3.10/rubygem-katello-3.10/rubygem-katello.spec
@@ -4,7 +4,7 @@
 %global foreman_min_version 1.18.0
 %global plugin_name katello
 %global gem_name katello
-%global mainver 3.10.0
+%global mainver 3.10.1
 #global prerelease .rc1.1
 %global release 1
 
@@ -359,6 +359,9 @@ rm -f %{buildroot}%{foreman_webpack_plugin}/*.js.map
 %{gem_instdir}/webpack
 
 %changelog
+* Wed Apr 24 2019 Eric D. Helms <ericdhelms@gmail.com> - 3.10.1-1
+- Release rubygem-katello-3.10 3.10.1
+
 * Sat Dec 15 2018 Eric D. Helms <ericdhelms@gmail.com> - 3.10.0-1
 - Release 3.10.0
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.22
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
