### PR TITLE
Regenerate rubygem-smart_proxy_discovery spec

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_discovery/rubygem-smart_proxy_discovery.spec
+++ b/packages/plugins/rubygem-smart_proxy_discovery/rubygem-smart_proxy_discovery.spec
@@ -94,8 +94,6 @@ mv %{buildroot}%{gem_instdir}/settings.d/discovery.yml.example \
 %changelog
 * Fri Apr 26 2019 Evgeni Golov 1.0.5-1
 - Update to 1.0.5-1
-
-* Fri Apr 26 2019 Evgeni Golov 1.0.4-2
 - Regenerate RPM spec based on latest template
 
 * Fri Apr 29 2016 Dominic Cleal <dominic@cleal.org> 1.0.4-1

--- a/packages/plugins/rubygem-smart_proxy_discovery/rubygem-smart_proxy_discovery.spec
+++ b/packages/plugins/rubygem-smart_proxy_discovery/rubygem-smart_proxy_discovery.spec
@@ -80,9 +80,7 @@ mv %{buildroot}%{gem_instdir}/settings.d/discovery.yml.example \
 %dir %{gem_instdir}
 %config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/discovery.yml
 %license %{gem_instdir}/LICENSE
-%{gem_instdir}/bundler.d
 %{gem_libdir}
-%{gem_instdir}/settings.d
 %{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
 %exclude %{gem_cache}
 %{gem_spec}

--- a/packages/plugins/rubygem-smart_proxy_discovery/rubygem-smart_proxy_discovery.spec
+++ b/packages/plugins/rubygem-smart_proxy_discovery/rubygem-smart_proxy_discovery.spec
@@ -1,38 +1,36 @@
+# Generated from smart_proxy_discovery-1.0.4.gem by gem2rpm -*- rpm-spec -*-
+# template: smart_proxy_plugin
 %global gem_name smart_proxy_discovery
+%global plugin_name discovery
 
+%global foreman_proxy_min_version 1.7.0
 %global foreman_proxy_dir %{_datarootdir}/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
 Name: rubygem-%{gem_name}
 Version: 1.0.4
-Release: 1%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Discovery plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_discovery
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-Requires: ruby(rubygems)
-Requires: foreman-proxy >= 1.7.0
-Requires: rubygem(rest-client) > 1.6.2
-Requires: rubygem(rest-client) < 2.0
-
-
-%if 0%{?rhel} == 6
-Requires: ruby(abi)
-BuildRequires: ruby(abi)
-%else
+# start specfile generated dependencies
+Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: ruby(release)
+Requires: ruby
+Requires: ruby(rubygems)
+Requires: rubygem(rest-client) > 1.6.2
+Requires: rubygem(rest-client) < 2
 BuildRequires: ruby(release)
-%endif
+BuildRequires: ruby
 BuildRequires: rubygems-devel
-BuildRequires: ruby(rubygems)
-
 BuildArch: noarch
-
 Provides: rubygem(%{gem_name}) = %{version}
-Provides: foreman-proxy-plugin-discovery
+Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
+# end specfile generated dependencies
 
 %description
 This smart proxy plugin, together with a Foreman plugin, add the capability to
@@ -42,26 +40,35 @@ communicate with Foreman instance and vice versa.
 %package doc
 Summary: Documentation for %{name}
 Group: Documentation
-Requires:%{name} = %{version}-%{release}
+Requires: %{name} = %{version}-%{release}
+BuildArch: noarch
 
 %description doc
-Documentation for %{name}
+Documentation for %{name}.
 
 %prep
+gem unpack %{SOURCE0}
 
-%setup -q -c -T
-%gem_install -n %{SOURCE0}
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
 
 %build
+# Create the gem as gem install only works on a gem file
+gem build %{gem_name}.gemspec
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%gem_install
 
 %install
 mkdir -p %{buildroot}%{gem_dir}
 cp -a .%{gem_dir}/* \
-       %{buildroot}%{gem_dir}/
+        %{buildroot}%{gem_dir}/
 
 # bundler file
 mkdir -p %{buildroot}%{foreman_proxy_bundlerd_dir}
-mv %{buildroot}%{gem_instdir}/bundler.d/discovery.rb \
+mv %{buildroot}%{gem_instdir}/bundler.d/%{plugin_name}.rb \
    %{buildroot}%{foreman_proxy_bundlerd_dir}
 
 # sample config
@@ -71,19 +78,23 @@ mv %{buildroot}%{gem_instdir}/settings.d/discovery.yml.example \
 
 %files
 %dir %{gem_instdir}
+%config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/discovery.yml
+%license %{gem_instdir}/LICENSE
+%{gem_instdir}/bundler.d
 %{gem_libdir}
-%{gem_spec}
-%{foreman_proxy_bundlerd_dir}/discovery.rb
-%config(noreplace) %{foreman_proxy_settingsd_dir}/discovery.yml
-%doc %{gem_instdir}/LICENSE
+%{gem_instdir}/settings.d
+%{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
 %exclude %{gem_cache}
-
+%{gem_spec}
 
 %files doc
-%{gem_docdir}
-%{gem_instdir}/README.md
+%doc %{gem_docdir}
+%doc %{gem_instdir}/README.md
 
 %changelog
+* Fri Apr 26 2019 Evgeni Golov 1.0.4-2
+- Regenerate RPM spec based on latest template
+
 * Fri Apr 29 2016 Dominic Cleal <dominic@cleal.org> 1.0.4-1
 - Update smart_proxy_discovery to 1.0.4 (dominic@cleal.org)
 

--- a/packages/plugins/rubygem-smart_proxy_discovery/rubygem-smart_proxy_discovery.spec
+++ b/packages/plugins/rubygem-smart_proxy_discovery/rubygem-smart_proxy_discovery.spec
@@ -1,4 +1,4 @@
-# Generated from smart_proxy_discovery-1.0.4.gem by gem2rpm -*- rpm-spec -*-
+# Generated from smart_proxy_discovery-1.0.5.gem by gem2rpm -*- rpm-spec -*-
 # template: smart_proxy_plugin
 %global gem_name smart_proxy_discovery
 %global plugin_name discovery
@@ -9,8 +9,8 @@
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
 Name: rubygem-%{gem_name}
-Version: 1.0.4
-Release: 2%{?foremandist}%{?dist}
+Version: 1.0.5
+Release: 1%{?foremandist}%{?dist}
 Summary: Discovery plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -22,8 +22,7 @@ Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: ruby(release)
 Requires: ruby
 Requires: ruby(rubygems)
-Requires: rubygem(rest-client) > 1.6.2
-Requires: rubygem(rest-client) < 2
+Requires: rubygem(rest-client)
 BuildRequires: ruby(release)
 BuildRequires: ruby
 BuildRequires: rubygems-devel
@@ -36,6 +35,7 @@ Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 This smart proxy plugin, together with a Foreman plugin, add the capability to
 discover unknown bare-metal. This plugin provides proxy API for nodes to
 communicate with Foreman instance and vice versa.
+
 
 %package doc
 Summary: Documentation for %{name}
@@ -92,6 +92,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/discovery.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Fri Apr 26 2019 Evgeni Golov 1.0.5-1
+- Update to 1.0.5-1
+
 * Fri Apr 26 2019 Evgeni Golov 1.0.4-2
 - Regenerate RPM spec based on latest template
 

--- a/packages/plugins/rubygem-smart_proxy_discovery/smart_proxy_discovery-1.0.4.gem
+++ b/packages/plugins/rubygem-smart_proxy_discovery/smart_proxy_discovery-1.0.4.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/XV/5K/SHA256E-s18432--2bfe96b84eeb210c6841ca2b36eb7c6c8be6bac1df312b48da0369eef7007636.4.gem/SHA256E-s18432--2bfe96b84eeb210c6841ca2b36eb7c6c8be6bac1df312b48da0369eef7007636.4.gem

--- a/packages/plugins/rubygem-smart_proxy_discovery/smart_proxy_discovery-1.0.5.gem
+++ b/packages/plugins/rubygem-smart_proxy_discovery/smart_proxy_discovery-1.0.5.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/Jf/K2/SHA256E-s18432--6da034e5a640d7da392bd41bf3661efd86c523cbaadfbe521a1994b98b02ba7c.5.gem/SHA256E-s18432--6da034e5a640d7da392bd41bf3661efd86c523cbaadfbe521a1994b98b02ba7c.5.gem


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.22
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
