### PR TITLE
also ignore .rubocop-disables.yml for gem2rpm

### DIFF
--- a/gem2rpm/foreman_plugin.spec.erb
+++ b/gem2rpm/foreman_plugin.spec.erb
@@ -30,6 +30,7 @@ config.rules[:doc] << /\/?CHANGES/
 config.rules[:doc] << /CODE_OF_CONDUCT(\.md)?/
 config.rules[:ignore] << '.hound.yml'
 config.rules[:ignore] << '.rubocop_todo.yml'
+config.rules[:ignore] << '.rubocop-disables.yml'
 config.rules[:ignore] << 'package.json'
 config.rules[:ignore] << '.ruby-gemset'
 config.rules[:ignore] << '.zuul.yaml'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.22
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
