### PR TITLE
Bump katello 3.11.1 update katello 3.11.1 update katello repos 3.11.1

### DIFF
--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -8,7 +8,7 @@
 %global release 1
 
 Name:           katello-repos
-Version:        3.11.0
+Version:        3.11.1
 Release:        %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:        Definition of yum repositories for Katello
 
@@ -76,6 +76,9 @@ rm -rf %{buildroot}
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-katello
 
 %changelog
+* Mon Apr 29 2019 Eric D. Helms <ericdhelms@gmail.com> - 3.11.1-1
+- Release katello-repos 3.11.1
+
 * Wed Mar 13 2019 Eric D. Helms <ericdhelms@gmail.com> - 3.11.0-1
 - Release 3.11.0
 

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -6,7 +6,7 @@
 %global release 1
 
 Name:       katello
-Version:    3.11.0
+Version:    3.11.1
 Release:    %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:    A package for managing application life-cycle for Linux systems
 BuildArch:  noarch
@@ -195,6 +195,9 @@ Useful utilities for managing Katello services
 %{_sysconfdir}/bash_completion.d/katello-service
 
 %changelog
+* Mon Apr 29 2019 Eric D. Helms <ericdhelms@gmail.com> - 3.11.1-1
+- Release katello 3.11.1
+
 * Wed Mar 13 2019 Eric D. Helms <ericdhelms@gmail.com> - 3.11.0-1
 - Release 3.11.0
 


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.22
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
