### PR TITLE
also build netrc for nonSCL

### DIFF
--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -23,6 +23,7 @@
       <packagereq type="default">rubygem-logify</packagereq>
       <packagereq type="default">rubygem-mysql2</packagereq>
       <packagereq type="default">rubygem-net-ssh</packagereq>
+      <packagereq type="default">rubygem-netrc</packagereq>
       <packagereq type="default">rubygem-newt</packagereq>
       <packagereq type="default">rubygem-openscap</packagereq>
       <packagereq type="default">rubygem-radcli</packagereq>
@@ -152,6 +153,7 @@
       <packagereq type="default">rubygem-logify-doc</packagereq>
       <packagereq type="default">rubygem-mysql2-doc</packagereq>
       <packagereq type="default">rubygem-net-ssh-doc</packagereq>
+      <packagereq type="default">rubygem-netrc-doc</packagereq>
       <packagereq type="default">rubygem-newt-doc</packagereq>
       <packagereq type="default">rubygem-radcli-doc</packagereq>
       <packagereq type="default">rubygem-route53-doc</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -128,7 +128,10 @@ foreman_scl_packages:
       releasers:
         - koji-foreman
         - koji-foreman-plugins
-    rubygem-netrc: {}
+    rubygem-netrc:
+      releasers:
+        - koji-foreman
+        - koji-foreman-plugins
     rubygem-oauth: {}
     rubygem-optimist: {}
     rubygem-os: {}

--- a/packages/foreman/rubygem-netrc/rubygem-netrc.spec
+++ b/packages/foreman/rubygem-netrc/rubygem-netrc.spec
@@ -7,7 +7,7 @@
 Summary: Library to read and write netrc files
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.11.0
-Release: 3%{?dist}
+Release: 4%{?dist}
 Group: Development/Languages
 License: MIT
 URL: https://github.com/geemus/netrc
@@ -71,6 +71,9 @@ popd
 %{gem_instdir}/test
 
 %changelog
+* Mon Apr 29 2019 Evgeni Golov - 0.11.0-4
+- rebuilt
+
 * Wed Sep 05 2018 Eric D. Helms <ericdhelms@gmail.com> - 0.11.0-3
 - Rebuild for Rails 5.2 and Ruby 2.5
 

--- a/packages/foreman/rubygem-netrc/rubygem-netrc.spec
+++ b/packages/foreman/rubygem-netrc/rubygem-netrc.spec
@@ -50,11 +50,13 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %check
+%if 0%{?scl:1}
 pushd .%{gem_instdir}
 %{?scl:scl enable %{scl} - << \EOS}
 ruby -e 'Dir.glob "./test/**/test_*.rb", &method(:require)'
 %{?scl:EOS}
 popd
+%endif
 
 %files
 %dir %{gem_instdir}
@@ -72,7 +74,8 @@ popd
 
 %changelog
 * Mon Apr 29 2019 Evgeni Golov - 0.11.0-4
-- rebuilt
+- Build for both SCL and non-SCL
+- Disable tests for non-SCL due to too old MiniTest
 
 * Wed Sep 05 2018 Eric D. Helms <ericdhelms@gmail.com> - 0.11.0-3
 - Rebuild for Rails 5.2 and Ruby 2.5

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -433,6 +433,7 @@ whitelist = ansiblerole-insights-client
   rubygem-logify
   rubygem-mysql2
   rubygem-net-ssh
+  rubygem-netrc
   rubygem-newt
   rubygem-openscap
   rubygem-radcli


### PR DESCRIPTION
this is needed for `rest-client` for nonSCL (#3683)
