### PR TITLE
Fixes #26751 - delete new candlepin keystore paths

### DIFF
--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -326,6 +326,8 @@ module KatelloUtilities
 
       unless @foreman_proxy_content
         self.run_cmd("rm -rf /etc/candlepin/certs/amqp{,.bak}")
+        self.run_cmd("rm -f /etc/candlepin/certs/candlepin-ca.crt /etc/candlepin/certs/candlepin-ca.key")
+        self.run_cmd("rm -f /etc/candlepin/certs/keystore")
         self.run_cmd("rm -f /etc/tomcat/keystore")
         self.run_cmd("rm -rf /etc/foreman/old-certs")
         self.run_cmd("rm -f /etc/pki/katello/keystore")

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -4,7 +4,7 @@
 %global homedir %{_datarootdir}/%{name}
 %global confdir common
 %global prerelease .master
-%global release 1
+%global release 2
 
 Name:       katello
 Version:    3.13.0
@@ -194,6 +194,9 @@ Useful utilities for managing Katello services
 %{_sysconfdir}/bash_completion.d/katello-service
 
 %changelog
+* Tue May 07 2019 Evgeni Golov - 3.13.0-0.2.master
+- delete new candlepin keystore paths in katello-change-hostname
+
 * Tue Apr 23 2019 Evgeni Golov <evgeni@golov.de> - 3.13.0-0.1.master
 - Bump version to 3.13-master
 


### PR DESCRIPTION
the way we deploy candlepin certs changed in Katello 3.12 so we need to
adjust how we force them to be regenerated.

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.22
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---
