### PR TITLE
Fixes #26751 - delete new candlepin keystore paths (#3716)

### DIFF
--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -326,6 +326,8 @@ module KatelloUtilities
 
       unless @foreman_proxy_content
         self.run_cmd("rm -rf /etc/candlepin/certs/amqp{,.bak}")
+        self.run_cmd("rm -f /etc/candlepin/certs/candlepin-ca.crt /etc/candlepin/certs/candlepin-ca.key")
+        self.run_cmd("rm -f /etc/candlepin/certs/keystore")
         self.run_cmd("rm -f /etc/tomcat/keystore")
         self.run_cmd("rm -rf /etc/foreman/old-certs")
         self.run_cmd("rm -f /etc/pki/katello/keystore")

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -4,7 +4,7 @@
 %global homedir %{_datarootdir}/%{name}
 %global confdir common
 %global prerelease .rc1
-%global release 4
+%global release 5
 
 Name:       katello
 Version:    3.12.0
@@ -194,8 +194,14 @@ Useful utilities for managing Katello services
 %{_sysconfdir}/bash_completion.d/katello-service
 
 %changelog
+* Tue May 07 2019 Evgeni Golov - 3.12.0-0.5.rc1
+- delete new candlepin keystore paths in katello-change-hostname
+
 * Tue Apr 30 2019 Eric D. Helms <ericdhelms@gmail.com> - 3.12.0-0.4.rc1
 - Releaes 3.12 RC1
+
+* Tue Apr 23 2019 Evgeni Golov <evgeni@golov.de> - 3.13.0-0.1.master
+- Bump version to 3.13-master
 
 * Mon Jan 28 2019 Evgeni Golov - 3.12.0-0.3.master
 - Refs #25576 - add an empty files section to make foreman-proxy-content build


### PR DESCRIPTION
the way we deploy candlepin certs changed in Katello 3.12 so we need to
adjust how we force them to be regenerated.

(cherry picked from commit 65f5a44a7c81f4c26c0c3f93b6a6f83543aa1d72)

If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 1.22
 * 1.21
 * 1.20

RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
