### PR TITLE
Ignore strscan and stringio as dependencies

### DIFF
--- a/get-gemfile-deps
+++ b/get-gemfile-deps
@@ -15,6 +15,7 @@ def source(url)
 end
 
 def gem(name, *requirements)
+  return if ['strscan', 'stringio'].include?(name)
   requirements.pop if requirements.last.kind_of?(Hash)
   if requirements.empty?
       puts "#{$require}: #{package(name)}"


### PR DESCRIPTION
These are optional dependencies that trigger a gem() call with Ruby 2.6 on Fedora 30. We can skip these.