### PR TITLE
Fix gofer cfg edit when already set to use python3

### DIFF
--- a/packages/client/katello-host-tools/katello-host-tools.spec
+++ b/packages/client/katello-host-tools/katello-host-tools.spec
@@ -16,7 +16,7 @@
 
 Name: katello-host-tools
 Version: 3.5.0
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: A set of commands and yum plugins that support a Katello host
 Group:   Development/Languages
 License: LGPLv2
@@ -388,11 +388,11 @@ exit 0
 %endif #build_tracer
 
 %changelog
+* Thu May 23 2019 Garret Rumohr - 3.5.0-4
+- Fixes #26837 - Corrects string replacement in /etc/sysconfig/goferd by RPM script
+
 * Thu May 23 2019 Evgeni Golov - 3.5.0-3
 - don't build the tracer plugin on RHEL < 7
-
-* Mon May 20 2019 Garret Rumohr - 3.5.0-3
-- Fixes #26837 - Corrects string replacement in /etc/sysconfig/goferd by RPM script
 
 * Tue Apr 23 2019 Evgeni Golov - 3.5.0-2
 - Don't ship fact-plugin on modern Fedora and EL

--- a/packages/client/katello-host-tools/katello-host-tools.spec
+++ b/packages/client/katello-host-tools/katello-host-tools.spec
@@ -262,7 +262,7 @@ rm -rf %{buildroot}
 %if %{build_agent}
 %post -n katello-agent
 %if %{dnf_install}
-sed 's/bin\/python/bin\/python3/' /etc/sysconfig/goferd -i
+sed 's/bin\/python$/bin\/python3/' /etc/sysconfig/goferd -i
 %endif
 
 %if 0%{?fedora} > 18 || 0%{?rhel} > 6

--- a/packages/client/katello-host-tools/katello-host-tools.spec
+++ b/packages/client/katello-host-tools/katello-host-tools.spec
@@ -391,6 +391,9 @@ exit 0
 * Thu May 23 2019 Evgeni Golov - 3.5.0-3
 - don't build the tracer plugin on RHEL < 7
 
+* Mon May 20 2019 Garret Rumohr - 3.5.0-3
+- Fixes #26837 - Corrects string replacement in /etc/sysconfig/goferd by RPM script
+
 * Tue Apr 23 2019 Evgeni Golov - 3.5.0-2
 - Don't ship fact-plugin on modern Fedora and EL
 


### PR DESCRIPTION
Fedora 30 ships with /etc/sysconfig/goferd default containing 
```
# Python interpreter.
PYTHON=/usr/bin/python3

# Python optimization (0=disabled, 1=enabled).
PYTHONOPTIMIZE=1
```
The scripted sed line will result in `PYTHON=/usr/bin/python33` causing goferd to fail to start since python33 is not present.  Adding the end of line match check should make the modification only if it's `PYTHON=/usr/bin/python`