### PR TITLE
Update foreman_remote_execution to 1.8.0

### DIFF
--- a/plugins/ruby-foreman-remote-execution/debian/changelog
+++ b/plugins/ruby-foreman-remote-execution/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution (1.8.0-1) stable; urgency=low
+
+  * 1.8.0 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Tue, 21 May 2019 17:44:07 +0200
+
 ruby-foreman-remote-execution (1.7.1-1) stable; urgency=low
 
   * 1.7.1 released

--- a/plugins/ruby-foreman-remote-execution/debian/gem.list
+++ b/plugins/ruby-foreman-remote-execution/debian/gem.list
@@ -1,3 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.7.1.gem"
-GEMS="$GEMS https://rubygems.org/downloads/foreman_remote_execution_core-1.1.6.gem"
+GEMS="https://rubygems.org/downloads/foreman_remote_execution-1.8.0.gem"
+GEMS="$GEMS https://rubygems.org/downloads/foreman_remote_execution_core-1.2.0.gem"

--- a/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
+++ b/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
@@ -1,1 +1,1 @@
-gem 'foreman_remote_execution', '1.7.1'
+gem 'foreman_remote_execution', '1.8.0'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.22
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---