### PR TITLE
don't build the tracer plugin on RHEL < 7

### DIFF
--- a/packages/client/katello-host-tools/katello-host-tools.spec
+++ b/packages/client/katello-host-tools/katello-host-tools.spec
@@ -2,7 +2,7 @@
 %global yum_install ((0%{?rhel} <= 7) && (0%{?rhel} >= 5)) || ((0%{?fedora} < 27) && (0%{?fedora} > 0))
 %global zypper_install (0%{?suse_version} > 0)
 
-%global build_tracer (0%{?suse_version} == 0)
+%global build_tracer 0%{?rhel} >= 7 || 0%{?fedora}
 
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 
@@ -16,7 +16,7 @@
 
 Name: katello-host-tools
 Version: 3.5.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: A set of commands and yum plugins that support a Katello host
 Group:   Development/Languages
 License: LGPLv2
@@ -233,6 +233,7 @@ cp extra/katello-tracer-upload-dnf %{buildroot}%{_sbindir}/katello-tracer-upload
 %if %{build_tracer}
 #do nothing
 %else
+rm %{buildroot}%{plugins_dir}/tracer_upload.py*
 rm %{buildroot}%{katello_libdir}/tracer.py
 rm %{buildroot}%{_sbindir}/katello-tracer-upload
 rm %{buildroot}%{plugins_confdir}/tracer_upload.conf
@@ -387,6 +388,9 @@ exit 0
 %endif #build_tracer
 
 %changelog
+* Thu May 23 2019 Evgeni Golov - 3.5.0-3
+- don't build the tracer plugin on RHEL < 7
+
 * Tue Apr 23 2019 Evgeni Golov - 3.5.0-2
 - Don't ship fact-plugin on modern Fedora and EL
 


### PR DESCRIPTION
this was found while working on https://github.com/theforeman/foreman-packaging/pull/3616

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 1.22
 * 1.21
 * 1.20

RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
