### PR TITLE
Drop katello-host-tools for F28

### DIFF
--- a/comps/comps-foreman-client-fedora28.xml
+++ b/comps/comps-foreman-client-fedora28.xml
@@ -11,10 +11,6 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="default">foreman-client-release</packagereq>
-      <packagereq type="default">katello-agent</packagereq>
-      <packagereq type="default">katello-host-tools</packagereq>
-      <packagereq type="default">katello-host-tools-fact-plugin</packagereq>
-      <packagereq type="default">katello-host-tools-tracer</packagereq>
       <packagereq type="default">python2-apypie</packagereq>
       <packagereq type="default">python3-apypie</packagereq>
       <packagereq type="default">rubygem-foreman_scap_client</packagereq>

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -522,7 +522,6 @@ whitelist = foreman-release
 [foreman-client-nightly-fedora28]
 disttag = .fc28
 whitelist = foreman-release
-  katello-host-tools
   python-apypie
   rubygem-foreman_scap_client
 


### PR DESCRIPTION
I was looking into katello-host-tools build failures and noticed separately that the foreman-client repos are missing katello-agent for EL5 in nightly and other released versions. Not sure if it's something to be fixed here, but I found a few other cleanups.

- https://yum.theforeman.org/client/nightly/el5/x86_64/
- https://yum.theforeman.org/client/1.22/el5/x86_64/
- https://yum.theforeman.org/client/1.21/el5/x86_64/
- https://yum.theforeman.org/client/1.20/el5/x86_64/

I also noticed that EL5 and EL6 repos for clients are missing gofer and its related packages. Since we started building gofer I think we need to have them there, like this: https://yum.theforeman.org/client/1.20/el7/x86_64/