### PR TITLE
Update rubygem-smart_proxy_dynflow to 0.2.3

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_dynflow/rubygem-smart_proxy_dynflow.spec
+++ b/packages/plugins/rubygem-smart_proxy_dynflow/rubygem-smart_proxy_dynflow.spec
@@ -6,8 +6,8 @@
 
 Summary: Dynflow runtime for Foreman smart proxy
 Name: rubygem-%{gem_name}
-Version: 0.2.2
-Release: 2%{?dist}
+Version: 0.2.3
+Release: 1%{?dist}
 Group: Applications/System
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_dynflow
@@ -81,6 +81,9 @@ cp -pa .%{gem_instdir}/settings.d/dynflow.yml.example %{buildroot}%{foreman_prox
 %doc %{gem_docdir}
 
 %changelog
+* Tue Jun 11 2019 Ivan Nečas <inecas@redhat.com> 0.2.3-1
+- Update to 0.2.3
+
 * Thu May 16 2019 Eric D. Helms <ericdhelms@gmail.com> - 0.2.2-2
 - Only require tfm- packages on RHEL7
 

--- a/packages/plugins/rubygem-smart_proxy_dynflow/smart_proxy_dynflow-0.2.2.gem
+++ b/packages/plugins/rubygem-smart_proxy_dynflow/smart_proxy_dynflow-0.2.2.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/V3/pV/SHA256E-s19456--34ac88d4eab2a58782d15011c25cddb1adfde92027704d5d20a14fbd7d242699.2.gem/SHA256E-s19456--34ac88d4eab2a58782d15011c25cddb1adfde92027704d5d20a14fbd7d242699.2.gem

--- a/packages/plugins/rubygem-smart_proxy_dynflow/smart_proxy_dynflow-0.2.3.gem
+++ b/packages/plugins/rubygem-smart_proxy_dynflow/smart_proxy_dynflow-0.2.3.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/Gv/0J/SHA256E-s19456--24f0cc49ddfe0f1869a7dde71ed81ae87ffb7fe4ef73fc0d7124d413efc7c0bf.3.gem/SHA256E-s19456--24f0cc49ddfe0f1869a7dde71ed81ae87ffb7fe4ef73fc0d7124d413efc7c0bf.3.gem


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.22
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---