### PR TITLE
Update smart_proxy_dynflow to 0.2.3

### DIFF
--- a/plugins/smart_proxy_dynflow/changelog
+++ b/plugins/smart_proxy_dynflow/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-dynflow (0.2.3-1) stable; urgency=low
+
+  * 0.2.3 released
+
+ -- Ivan Nečas <inecas@redhat.com>  Tue, 11 Jun 2019 15:25:47 +0200
+
 ruby-smart-proxy-dynflow (0.2.2-1) stable; urgency=low
 
   * 0.2.2 released

--- a/plugins/smart_proxy_dynflow/dynflow.rb
+++ b/plugins/smart_proxy_dynflow/dynflow.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_dynflow', '0.2.2'
+gem 'smart_proxy_dynflow', '0.2.3'


### PR DESCRIPTION
For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [x] 1.22
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---