### PR TITLE
Fixes #27083 - Add service file for smart_proxy_dynflow_core

### DIFF
--- a/plugins/smart_proxy_dynflow_core/control
+++ b/plugins/smart_proxy_dynflow_core/control
@@ -12,5 +12,5 @@ Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, ruby-dynflow (>= 1.1.0),
   ruby-dynflow (<< 2.0.0), ruby-foreman-tasks-core (>= 0.1.7),
-  ruby-rest-client, ruby-sequel, ruby-sqlite3
+  ruby-rest-client, ruby-sequel, ruby-sqlite3, ruby-rack, ruby-bundler-ext, ruby-sinatra
 Description: Dynflow runtime for Foreman smart proxy

--- a/plugins/smart_proxy_dynflow_core/dirs
+++ b/plugins/smart_proxy_dynflow_core/dirs
@@ -1,0 +1,3 @@
+usr/share/smart_proxy_dynflow_core/bin
+usr/share/smart_proxy_dynflow_core/bundler.d
+usr/share/smart_proxy_dynflow_core/lib

--- a/plugins/smart_proxy_dynflow_core/install
+++ b/plugins/smart_proxy_dynflow_core/install
@@ -1,1 +1,2 @@
 debian/dynflow_core.rb usr/share/foreman-proxy/bundler.d
+deploy/smart_proxy_dynflow_core.service lib/systemd/system

--- a/plugins/smart_proxy_dynflow_core/install
+++ b/plugins/smart_proxy_dynflow_core/install
@@ -1,2 +1,7 @@
-debian/dynflow_core.rb usr/share/foreman-proxy/bundler.d
-deploy/smart_proxy_dynflow_core.service lib/systemd/system
+smart_proxy_dynflow_core                 etc
+deploy/smart_proxy_dynflow_core.service  lib/systemd/system
+debian/dynflow_core.rb                   usr/share/foreman-proxy/bundler.d
+bin                                      usr/share/smart_proxy_dynflow_core
+Gemfile.in                               usr/share/smart_proxy_dynflow_core
+smart_proxy_dynflow_core.gemspec         usr/share/smart_proxy_dynflow_core
+lib_copy/*                               usr/share/smart_proxy_dynflow_core/lib

--- a/plugins/smart_proxy_dynflow_core/links
+++ b/plugins/smart_proxy_dynflow_core/links
@@ -1,0 +1,2 @@
+etc/smart_proxy_dynflow_core                          usr/share/smart_proxy_dynflow_core/config
+usr/bin/smart_proxy_dynflow_core                      usr/share/smart_proxy_dynflow_core/bin/smart_proxy_dynflow_core

--- a/plugins/smart_proxy_dynflow_core/postinst
+++ b/plugins/smart_proxy_dynflow_core/postinst
@@ -8,11 +8,19 @@ set -e
 USERNAME="foreman-proxy"
 GROUPNAME="foreman-proxy"
 DYNFLOW_DB_DIR="/var/lib/foreman-proxy/dynflow"
+FOREMAN_HOME="/usr/share/foreman-proxy"
 
 case "$1" in
   configure)
-    mkdir -p $DYNFLOW_DB_DIR
-    chown $USERNAME:$GROUPNAME $DYNFLOW_DB_DIR
+    getent group $GROUPNAME >/dev/null || groupadd -r $GROUPNAME
+    getent passwd $USERNAME >/dev/null || \
+      useradd -r -g $GROUPNAME -d $FOREMAN_HOME -s /usr/sbin/nologin -c "Foreman Proxy daemon user" $USERNAME
+
+    for dir in /var/{log,run}/foreman-proxy $DYNFLOW_DB_DIR; do
+        mkdir -p "$dir"
+	chown $USERNAME:$GROUPNAME "$dir"
+    done
+
     chmod 750 $DYNFLOW_DB_DIR
   ;;
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/plugins/smart_proxy_dynflow_core/rules
+++ b/plugins/smart_proxy_dynflow_core/rules
@@ -13,6 +13,7 @@ export DH_RUBY_IGNORE_TESTS=require-rubygems
 
 build:
 	/bin/sed -ri '/^ExecStart/ s#/usr/bin/smart_proxy_dynflow_core#/usr/bin/bundle exec smart_proxy_dynflow_core#' deploy/smart_proxy_dynflow_core.service
+	/bin/sed -ri '/^EnvironmentFile/ s#sysconfig#default#'
 
 %:
 	dh $@ --buildsystem=ruby --with ruby

--- a/plugins/smart_proxy_dynflow_core/rules
+++ b/plugins/smart_proxy_dynflow_core/rules
@@ -13,7 +13,7 @@ export DH_RUBY_IGNORE_TESTS=require-rubygems
 
 build:
 	/bin/sed -ri '/^ExecStart/ s#/usr/bin/smart_proxy_dynflow_core#/usr/bin/bundle exec smart_proxy_dynflow_core#' deploy/smart_proxy_dynflow_core.service
-	/bin/sed -ri '/^EnvironmentFile/ s#sysconfig#default#'
+	/bin/sed -ri '/^EnvironmentFile/ s#sysconfig#default#' deploy/smart_proxy_dynflow_core.service
 
 %:
 	dh $@ --buildsystem=ruby --with ruby

--- a/plugins/smart_proxy_dynflow_core/rules
+++ b/plugins/smart_proxy_dynflow_core/rules
@@ -12,7 +12,11 @@ export DH_RUBY_IGNORE_TESTS=require-rubygems
 #export DH_RUBY_GEMSPEC=gem.gemspec
 
 build:
-	/bin/sed -ri '/^ExecStart/ s#/usr/bin/smart_proxy_dynflow_core#/usr/bin/bundle exec smart_proxy_dynflow_core#' deploy/smart_proxy_dynflow_core.service
+	cp -a config smart_proxy_dynflow_core
+	rename 's/.example//' smart_proxy_dynflow_core/* smart_proxy_dynflow_core/settings.d/*
+	mv Gemfile Gemfile.in
+	cp -ar lib lib_copy
+	/bin/sed -ri '/^ExecStart/ s#/usr/bin/smart_proxy_dynflow_core#/usr/bin/ruby -I /usr/share/smart_proxy_dynflow_core/lib /usr/bin/smart_proxy_dynflow_core#' deploy/smart_proxy_dynflow_core.service
 	/bin/sed -ri '/^EnvironmentFile/ s#sysconfig#default#' deploy/smart_proxy_dynflow_core.service
 
 %:

--- a/plugins/smart_proxy_dynflow_core/rules
+++ b/plugins/smart_proxy_dynflow_core/rules
@@ -11,5 +11,8 @@ export DH_RUBY_IGNORE_TESTS=require-rubygems
 # If you need to specify the .gemspec (eg there is more than one)
 #export DH_RUBY_GEMSPEC=gem.gemspec
 
+build:
+	/bin/sed -ri '/^ExecStart/ s#/usr/bin/smart_proxy_dynflow_core#/usr/bin/bundle exec smart_proxy_dynflow_core#' deploy/smart_proxy_dynflow_core.service
+
 %:
 	dh $@ --buildsystem=ruby --with ruby


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 1.22
 * 1.21
 * 1.20

RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->

This will allow us to run smart proxy dynflow core the same way it is run on EL-based distros.
