### PR TITLE
Fixes #26278 - GPG sign client repositories

### DIFF
--- a/packages/foreman/foreman-release/foreman-release.spec
+++ b/packages/foreman/foreman-release/foreman-release.spec
@@ -13,7 +13,7 @@
 %define repo_dist %{dist}
 %endif
 
-%global release 1
+%global release 2
 
 Name:     foreman-release
 Version:  1.22.0
@@ -54,6 +54,7 @@ Defines yum repositories for Foreman clients.
 
 %files -n foreman-client-release
 %config %{repo_dir}/foreman-client.repo
+%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman-client
 
 %if 0%{?rhel} == 6
 %config %{repo_dir}/pulp.repo
@@ -95,19 +96,25 @@ if [[ '%{release}' != *"develop"* ]];then
   VERSION="%{version}"
   sed "s/nightly/${VERSION%.*}/g" -i %{buildroot}%{repo_dir}/*.repo
   sed "s/gpgcheck=0/gpgcheck=1/g" -i %{buildroot}%{repo_dir}/foreman.repo
+  sed "s/gpgcheck=0/gpgcheck=1/g" -i %{buildroot}%{repo_dir}/foreman-client.repo
   sed "s/gpgcheck=0/gpgcheck=1/g" -i %{buildroot}%{repo_dir}/foreman-rails.repo
 fi
 
 install -Dpm0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman
+install -Dpm0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman-client
 install -Dpm0644 %{SOURCE4} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman-rails
 
 %files
 %config %{repo_dir}/foreman.repo
 %config %{repo_dir}/foreman-plugins.repo
 %config %{repo_dir}/foreman-rails.repo
-%{_sysconfdir}/pki/rpm-gpg/*
+%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman
+%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman-rails
 
 %changelog
+* Thu Jun 27 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.22.0-2
+- GPG sign foreman-client repository
+
 * Tue Jun 04 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.22.0-1
 - Release 1.22.0
 


### PR DESCRIPTION
This enforces that the client repo is GPG signed with the same key as the main foreman repository.

(cherry picked from commit 92da00fdf47d80f2c089207c421708c29b4026a9)