### PR TITLE
Fixes #26278 - GPG sign client repositories

### DIFF
--- a/packages/foreman/foreman-release/foreman-release.spec
+++ b/packages/foreman/foreman-release/foreman-release.spec
@@ -13,7 +13,7 @@
 %define repo_dist %{dist}
 %endif
 
-%global release 2
+%global release 3
 
 Name:     foreman-release
 Version:  1.20.2
@@ -53,6 +53,7 @@ Defines yum repositories for Foreman clients.
 
 %files -n foreman-client-release
 %config %{repo_dir}/foreman-client.repo
+%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman-client
 
 %if 0%{?rhel} == 6
 %config %{repo_dir}/pulp.repo
@@ -94,18 +95,25 @@ if [[ '%{release}' != *"develop"* ]];then
   VERSION="%{version}"
   sed "s/nightly/${VERSION%.*}/g" -i %{buildroot}%{repo_dir}/*.repo
   sed "s/gpgcheck=0/gpgcheck=1/g" -i %{buildroot}%{repo_dir}/foreman.repo
+  sed "s/gpgcheck=0/gpgcheck=1/g" -i %{buildroot}%{repo_dir}/foreman-client.repo
   sed "s/gpgcheck=0/gpgcheck=1/g" -i %{buildroot}%{repo_dir}/foreman-rails.repo
 fi
 
 install -Dpm0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman
+install -Dpm0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman-client
+install -Dpm0644 %{SOURCE4} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman-rails
 
 %files
 %config %{repo_dir}/foreman.repo
 %config %{repo_dir}/foreman-plugins.repo
 %config %{repo_dir}/foreman-rails.repo
-%{_sysconfdir}/pki/rpm-gpg/*
+%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman
+%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman-rails
 
 %changelog
+* Thu Jun 27 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.20.2-3
+- GPG sign foreman-client repository
+
 * Tue Mar 19 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.20.2-2
 - Remove GPG key from -client package
 


### PR DESCRIPTION
This enforces that the client repo is GPG signed with the same key as the main foreman repository.

(cherry picked from commit 0c9164e8eab5f3ea084654cece4eca98c3e761cb)