### PR TITLE
Make repoclosure_target_repos a dict

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -713,7 +713,8 @@ repoclosures:
     katello-repoclosure-el7:
       repoclosure_target_dist: rhel7
       repoclosure_target_repos:
-        - el7-katello-3.11
+        rhel7:
+          - el7-katello-3.11
       repoclosure_lookaside_repos:
         rhel7:
           - el7-base


### PR DESCRIPTION
Possibly a fix for https://ci.theforeman.org/blue/organizations/jenkins/foreman-packaging-rpm-pr-test/detail/foreman-packaging-rpm-pr-test/619/pipeline/ but unsure