### PR TITLE
[WIP] Regenerate plugin spec files

### DIFF
--- a/packages/katello/rubygem-foreman_scc_manager/rubygem-foreman_scc_manager.spec
+++ b/packages/katello/rubygem-foreman_scc_manager/rubygem-foreman_scc_manager.spec
@@ -1,32 +1,42 @@
+# template: foreman_plugin
 %{?scl:%scl_package rubygem-%{gem_name}}
 %{!?scl:%global pkg_name %{name}}
 
 %global gem_name foreman_scc_manager
 %global plugin_name scc_manager
+%global foreman_min_version 1.18.0
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.6.2
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Suse Customer Center plugin for Foreman
 Group: Applications/Systems
-License: GPLv3+
+License: GPLv3
 URL: https://www.orcharhino.com/
-Source0: https://rubygems.org/downloads/%{gem_name}-%{version}.gem
-Requires: foreman >= 1.18.0
+Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
+
+# start specfile generated dependencies
+Requires: foreman >= %{foreman_min_version}
+Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
-Requires: %{?scl_prefix}rubygem(foreman-tasks)
-Requires: %{?scl_prefix}rubygem(katello) >= 3.7
-BuildRequires: foreman-assets
-BuildRequires: foreman-plugin >= 1.18
-BuildRequires: %{?scl_prefix}rubygem(katello) >= 3.7
-BuildRequires: %{?scl_prefix}rubygem(foreman-tasks)
+Requires: %{?scl_prefix}rubygem(foreman-tasks) >= 0.10
+Requires: %{?scl_prefix}rubygem(foreman-tasks) < 1
+Requires: %{?scl_prefix_ror}rubygem(rails) >= 5.1
+Requires: %{?scl_prefix_ror}rubygem(rails) < 6
+BuildRequires: foreman-assets >= %{foreman_min_version}
+BuildRequires: foreman-plugin >= %{foreman_min_version}
+BuildRequires: %{?scl_prefix}rubygem(foreman-tasks) >= 0.10
+BuildRequires: %{?scl_prefix}rubygem(foreman-tasks) < 1
+BuildRequires: %{?scl_prefix_ror}rubygem(rails) >= 5.1
+BuildRequires: %{?scl_prefix_ror}rubygem(rails) < 6
 BuildRequires: %{?scl_prefix_ruby}ruby(release)
 BuildRequires: %{?scl_prefix_ruby}ruby
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
-Provides: foreman-plugin-%{plugin_name}
+Provides: foreman-plugin-%{plugin_name} = %{version}
+# end specfile generated dependencies
 
 %description
 Foreman plugin to sync SUSE Customer Center products and repositories into
@@ -95,10 +105,12 @@ cp -pa .%{gem_dir}/* \
 %posttrans
 %{foreman_db_migrate}
 %{foreman_restart}
-/usr/bin/systemctl restart foreman-tasks
 exit 0
 
 %changelog
+* Tue Jul 02 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 1.6.2-2
+- Regenerate spec file based on the current template
+
 * Mon May 06 2019 Markus Bucher <bucher@atix.de> 1.6.2-1
 - Update to 1.6.2
 - Add recurring-sync of repositories

--- a/packages/katello/rubygem-foreman_virt_who_configure/rubygem-foreman_virt_who_configure.spec
+++ b/packages/katello/rubygem-foreman_virt_who_configure/rubygem-foreman_virt_who_configure.spec
@@ -1,32 +1,36 @@
+# template: foreman_plugin
 %{?scl:%scl_package rubygem-%{gem_name}}
 %{!?scl:%global pkg_name %{name}}
 
 %global gem_name foreman_virt_who_configure
 %global plugin_name virt_who_configure
+%global foreman_min_version 1.20.0
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.4.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: A plugin to make virt-who configuration easy
 Group: Applications/Systems
 License: GPLv3
 URL: https://github.com/theforeman/foreman_virt_who_configure
-
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
-Requires: foreman >= 1.11
+
+# start specfile generated dependencies
+Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
-Requires: %{?scl_prefix}rubygem(katello) >= 3.0
-BuildRequires: foreman-assets
-BuildRequires: foreman-plugin >= 1.11
-BuildRequires: %{?scl_prefix}rubygem(katello) >= 3.0
+Requires: %{?scl_prefix}rubygem(katello)
+BuildRequires: foreman-assets >= %{foreman_min_version}
+BuildRequires: foreman-plugin >= %{foreman_min_version}
+BuildRequires: %{?scl_prefix}rubygem(katello)
 BuildRequires: %{?scl_prefix_ruby}ruby(release)
 BuildRequires: %{?scl_prefix_ruby}ruby
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
-Provides: foreman-plugin-%{plugin_name}
+Provides: foreman-plugin-%{plugin_name} = %{version}
+# end specfile generated dependencies
 
 %description
 A plugin to make virt-who configuration easy.
@@ -42,12 +46,27 @@ BuildArch: noarch
 Documentation for %{pkg_name}.
 
 %prep
-%setup -n %{pkg_name}-%{version} -q -c -T
-%{?scl:scl enable %{scl} - <<EOF}
-%gem_install -n %{SOURCE0}
+%{?scl:scl enable %{scl} - << \EOF}
+gem unpack %{SOURCE0}
+%{?scl:EOF}
+
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+%{?scl:scl enable %{scl} - << \EOF}
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
 %{?scl:EOF}
 
 %build
+# Create the gem as gem install only works on a gem file
+%{?scl:scl enable %{scl} - << \EOF}
+gem build %{gem_name}.gemspec
+%{?scl:EOF}
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%{?scl:scl enable %{scl} - << \EOF}
+%gem_install
+%{?scl:EOF}
 
 %install
 mkdir -p %{buildroot}%{gem_dir}
@@ -65,11 +84,11 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/db
 %{gem_libdir}
 %{gem_instdir}/locale
-%foreman_apipie_cache_foreman
-%foreman_apipie_cache_plugin
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
+%{foreman_apipie_cache_foreman}
+%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 
 %files doc
@@ -80,11 +99,14 @@ cp -pa .%{gem_dir}/* \
 
 %posttrans
 %{foreman_db_migrate}
-%{foreman_db_seed}
+%{foreman_apipie_cache}
 %{foreman_restart}
 exit 0
 
 %changelog
+* Tue Jul 02 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 0.4.1-2
+- Regenerate the spec file
+
 * Thu May 23 2019 Marek Hulan <mhulan@redhat.com> 0.4.1-1
 - Update to 0.4.1
 

--- a/packages/plugins/rubygem-smart_proxy_chef/rubygem-smart_proxy_chef.spec
+++ b/packages/plugins/rubygem-smart_proxy_chef/rubygem-smart_proxy_chef.spec
@@ -1,77 +1,97 @@
+# template: smart_proxy_plugin
 %global gem_name smart_proxy_chef
+%global plugin_name chef
 
-%global foreman_proxy_dir /usr/share/foreman-proxy
+%global foreman_proxy_min_version 1.6.0
+%global foreman_proxy_dir %{_datarootdir}/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
-Summary: Chef support for Foreman Smart-Proxy
 Name: rubygem-%{gem_name}
 Version: 0.2.0
-Release: 1%{?dist}
-Group: Applications/System
+Release: 2%{?foremandist}%{?dist}
+Summary: Chef support for Foreman Smart-Proxy
+Group: Applications/Internet
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_chef
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-Requires: ruby(rubygems)
-Requires: foreman-proxy >= 1.6.0
+# start specfile generated dependencies
+Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: ruby(release)
+Requires: ruby
+Requires: ruby(rubygems)
 Requires: rubygem(chef-api)
-
 BuildRequires: ruby(release)
+BuildRequires: ruby
 BuildRequires: rubygems-devel
-BuildRequires: ruby(rubygems)
-
 BuildArch: noarch
-
 Provides: rubygem(%{gem_name}) = %{version}
-Provides: foreman-proxy-plugin-chef
+Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
+# end specfile generated dependencies
 
 %description
 Chef support for Foreman Smart-Proxy.
 
+
 %package doc
-BuildArch:  noarch
-Requires:   %{name} = %{version}-%{release}
-Summary:    Documentation for rubygem-%{gem_name}
+Summary: Documentation for %{name}
+Group: Documentation
+Requires: %{name} = %{version}-%{release}
+BuildArch: noarch
 
 %description doc
-This package contains documentation for rubygem-%{gem_name}.
+Documentation for %{name}.
 
 %prep
+gem unpack %{SOURCE0}
 
-%setup -q -c -T
-%gem_install -n %{SOURCE0}
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
 
 %build
+# Create the gem as gem install only works on a gem file
+gem build %{gem_name}.gemspec
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%gem_install
 
 %install
 mkdir -p %{buildroot}%{gem_dir}
-cp -pa .%{gem_dir}/* \
+cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
+# bundler file
 mkdir -p %{buildroot}%{foreman_proxy_bundlerd_dir}
-cp -pa .%{gem_instdir}/bundler.d/chef.rb %{buildroot}%{foreman_proxy_bundlerd_dir}
-mkdir -p  %{buildroot}%{foreman_proxy_settingsd_dir}
-cp -pa .%{gem_instdir}/settings.d/chef.yml.example %{buildroot}%{foreman_proxy_settingsd_dir}/chef.yml
+mv %{buildroot}%{gem_instdir}/bundler.d/%{plugin_name}.rb \
+   %{buildroot}%{foreman_proxy_bundlerd_dir}
+
+# sample config
+mkdir -p %{buildroot}%{foreman_proxy_settingsd_dir}
+mv %{buildroot}%{gem_instdir}/settings.d/chef.yml.example \
+   %{buildroot}%{foreman_proxy_settingsd_dir}/chef.yml
 
 %files
 %dir %{gem_instdir}
+%config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/chef.yml
+%license %{gem_instdir}/LICENSE
 %{gem_instdir}/bundler.d
 %{gem_libdir}
 %{gem_instdir}/settings.d
-%{foreman_proxy_bundlerd_dir}/chef.rb
-%config(noreplace) %{foreman_proxy_settingsd_dir}/chef.yml
-%doc %{gem_instdir}/LICENSE
-
+%{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
 %exclude %{gem_cache}
-%exclude %{gem_instdir}/Gemfile
 %{gem_spec}
 
 %files doc
 %doc %{gem_docdir}
+%{gem_instdir}/Gemfile
 
 %changelog
+* Tue Jul 02 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 0.2.0-2
+- Regenerate spec file
+
 * Mon Jan 30 2017 Dominic Cleal <dominic@cleal.org> 0.2.0-1
 - Update smart_proxy_chef to 0.2.0 (mhulan@redhat.com)
 

--- a/packages/plugins/rubygem-smart_proxy_dhcp_device42/rubygem-smart_proxy_dhcp_device42.spec
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_device42/rubygem-smart_proxy_dhcp_device42.spec
@@ -1,19 +1,23 @@
+# template: smart_proxy_plugin
 %global gem_name smart_proxy_dhcp_device42
 %global plugin_name dhcp_device42
 
+%global foreman_proxy_min_version 1.16.0
 %global foreman_proxy_dir %{_datarootdir}/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
 Name: rubygem-%{gem_name}
 Version: 1.0.7
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Summary: Device42 DHCP provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
 URL: https://www.device42.com
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
-Requires: foreman-proxy >= 1.16
+
+# start specfile generated dependencies
+Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: ruby(release)
 Requires: ruby
 Requires: ruby(rubygems)
@@ -24,7 +28,8 @@ BuildRequires: ruby
 BuildRequires: rubygems-devel
 BuildArch: noarch
 Provides: rubygem(%{gem_name}) = %{version}
-Provides: foreman-proxy-plugin-%{plugin_name}
+Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
+# end specfile generated dependencies
 
 %description
 Device42 DHCP provider plugin for Foreman's smart proxy.
@@ -85,6 +90,9 @@ mv %{buildroot}%{gem_instdir}/config/dhcp_device42.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Tue Jul 02 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 1.0.7-3
+- Regenerate spec file based on the current template
+
 * Wed Sep 12 2018 Bryan Kearney <bryan.kearney@gmail.com> - 1.0.7-2
 - Move licenes which are GPL-* to GPLv3
 

--- a/packages/plugins/rubygem-smart_proxy_dhcp_infoblox/rubygem-smart_proxy_dhcp_infoblox.spec
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_infoblox/rubygem-smart_proxy_dhcp_infoblox.spec
@@ -1,38 +1,36 @@
-# Generated from smart_proxy_dhcp_infoblox-0.0.3.gem by gem2rpm -*- rpm-spec -*-
+# template: smart_proxy_plugin
 %global gem_name smart_proxy_dhcp_infoblox
 %global plugin_name dhcp_infoblox
 
+%global foreman_proxy_min_version 1.17.0
 %global foreman_proxy_dir %{_datarootdir}/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
 Name: rubygem-%{gem_name}
 Version: 0.0.14
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Infoblox DHCP provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_dhcp_infoblox
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
-Requires: foreman-proxy >= 1.17.0
-%if 0%{?rhel} == 6
-Requires: ruby(abi)
-%else
+
+# start specfile generated dependencies
+Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: ruby(release)
-%endif
 Requires: ruby
 Requires: ruby(rubygems)
+Requires: rubygem(infoblox) >= 2.0
+Requires: rubygem(infoblox) < 3
 Requires: rubygem(infoblox) >= 2.0.4
-%if 0%{?rhel} == 6
-BuildRequires: ruby(abi)
-%else
 BuildRequires: ruby(release)
-%endif
 BuildRequires: ruby
 BuildRequires: rubygems-devel
 BuildArch: noarch
 Provides: rubygem(%{gem_name}) = %{version}
-Provides: foreman-proxy-plugin-%{plugin_name}
+Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
+# end specfile generated dependencies
 
 %description
 Infoblox DHCP provider plugin for Foreman's smart proxy.
@@ -80,7 +78,7 @@ mv %{buildroot}%{gem_instdir}/config/dhcp_infoblox.yml.example \
 %files
 %dir %{gem_instdir}
 %config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/dhcp_infoblox.yml
-%doc %{gem_instdir}/LICENSE
+%license %{gem_instdir}/LICENSE
 %{gem_instdir}/bundler.d
 %{gem_instdir}/config
 %{gem_libdir}
@@ -94,6 +92,9 @@ mv %{buildroot}%{gem_instdir}/config/dhcp_infoblox.yml.example \
 %{gem_instdir}/test
 
 %changelog
+* Tue Jul 02 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 0.0.14-2
+- Regenerate spec file based on smart_proxy_plugin
+
 * Wed Dec 12 2018 Lukas Zapletal <lzap+rpm@redhat.com> 0.0.14-1
 - New upstream version
 

--- a/packages/plugins/rubygem-smart_proxy_dhcp_remote_isc/rubygem-smart_proxy_dhcp_remote_isc.spec
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_remote_isc/rubygem-smart_proxy_dhcp_remote_isc.spec
@@ -1,28 +1,33 @@
-# Generated from smart_proxy_dhcp_remote_isc-0.0.1.gem by gem2rpm -*- rpm-spec -*-
+# template: smart_proxy_plugin
 %global gem_name smart_proxy_dhcp_remote_isc
 %global plugin_name dhcp_remote_isc
 
+%global foreman_proxy_min_version 1.16.0
 %global foreman_proxy_dir %{_datarootdir}/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
 Name: rubygem-%{gem_name}
 Version: 0.0.4
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Smart-Proxy dhcp module provider for NFS-accessible ISC dhcpd installations
 Group: Applications/Internet
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_dhcp_remote_isc
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
-Requires: foreman-proxy >= 1.16.0
+
+# start specfile generated dependencies
+Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: ruby(release)
 Requires: ruby
 Requires: ruby(rubygems)
 BuildRequires: ruby(release)
+BuildRequires: ruby
 BuildRequires: rubygems-devel
 BuildArch: noarch
 Provides: rubygem(%{gem_name}) = %{version}
-Provides: foreman-proxy-plugin-%{plugin_name}
+Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
+# end specfile generated dependencies
 
 %description
 Smart-Proxy dhcp module provider for NFS-accessible ISC dhcpd installations.
@@ -84,6 +89,9 @@ mv %{buildroot}%{gem_instdir}/config/dhcp_remote_isc.yml.example \
 %{gem_instdir}/test
 
 %changelog
+* Tue Jul 02 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 0.0.4-2
+- Regenerate spec file based on smart_proxy_plugin
+
 * Mon Jan 22 2018 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 0.0.4-1
 - Updated dhcp_remote_isc to 0.0.4 (dmitri@appliedlogic.ca)
 

--- a/packages/plugins/rubygem-smart_proxy_discovery_image/rubygem-smart_proxy_discovery_image.spec
+++ b/packages/plugins/rubygem-smart_proxy_discovery_image/rubygem-smart_proxy_discovery_image.spec
@@ -1,64 +1,71 @@
+# template: smart_proxy_plugin
 %global gem_name smart_proxy_discovery_image
+%global plugin_name discovery_image
 
+%global foreman_proxy_min_version 1.7.0
 %global foreman_proxy_dir %{_datarootdir}/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
 Name: rubygem-%{gem_name}
 Version: 1.0.9
-Release: 1%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Discovery image (node) plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_discovery_image
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-Requires: ruby(rubygems)
-Requires: foreman-proxy >= 1.7.0
-
-
-%if 0%{?rhel} == 6
-Requires: ruby(abi)
-BuildRequires: ruby(abi)
-%else
+# start specfile generated dependencies
+Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: ruby(release)
+Requires: ruby
+Requires: ruby(rubygems)
 BuildRequires: ruby(release)
-%endif
+BuildRequires: ruby
 BuildRequires: rubygems-devel
-BuildRequires: ruby(rubygems)
-
 BuildArch: noarch
-
 Provides: rubygem(%{gem_name}) = %{version}
-Provides: foreman-proxy-plugin-discovery-image
+Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
+# end specfile generated dependencies
 
 %description
 Smart Proxy plugin providing Image API on discovered nodes. This plugin is only
 useful on discovered nodes, do not install on regular Smart Proxy deployments.
 
+
 %package doc
 Summary: Documentation for %{name}
 Group: Documentation
-Requires:%{name} = %{version}-%{release}
+Requires: %{name} = %{version}-%{release}
+BuildArch: noarch
 
 %description doc
-Documentation for %{name}
+Documentation for %{name}.
 
 %prep
+gem unpack %{SOURCE0}
 
-%setup -q -c -T
-%gem_install -n %{SOURCE0}
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
 
 %build
+# Create the gem as gem install only works on a gem file
+gem build %{gem_name}.gemspec
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%gem_install
 
 %install
 mkdir -p %{buildroot}%{gem_dir}
 cp -a .%{gem_dir}/* \
-       %{buildroot}%{gem_dir}/
+        %{buildroot}%{gem_dir}/
 
 # bundler file
 mkdir -p %{buildroot}%{foreman_proxy_bundlerd_dir}
-mv %{buildroot}%{gem_instdir}/bundler.d/discovery_image.rb \
+mv %{buildroot}%{gem_instdir}/bundler.d/%{plugin_name}.rb \
    %{buildroot}%{foreman_proxy_bundlerd_dir}
 
 # sample config
@@ -68,20 +75,22 @@ mv %{buildroot}%{gem_instdir}/settings.d/discovery_image.yml.example \
 
 %files
 %dir %{gem_instdir}
+%config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/discovery_image.yml
+%license %{gem_instdir}/LICENSE
 %{gem_libdir}
-%{gem_spec}
-%{foreman_proxy_bundlerd_dir}/discovery_image.rb
-%config %{foreman_proxy_settingsd_dir}/discovery_image.yml
-%doc %{gem_instdir}/LICENSE
+%{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
 %exclude %{gem_cache}
-%exclude %{gem_instdir}/Gemfile
-
+%{gem_spec}
 
 %files doc
-%{gem_docdir}
-%{gem_instdir}/README.md
+%doc %{gem_docdir}
+%{gem_instdir}/Gemfile
+%doc %{gem_instdir}/README.md
 
 %changelog
+* Tue Jul 02 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 1.0.9-2
+- Regenerate spec file based on smart_proxy_plugin
+
 * Tue Nov 07 2017 Daniel Lobato Garcia <me@daniellobato.me> 1.0.9-1
 - Updated smart_proxy_discovery_image to 1.0.9 (lzap@redhat.com)
 - Use HTTPS URLs for github and rubygems (ewoud@kohlvanwijngaarden.nl)

--- a/packages/plugins/rubygem-smart_proxy_dns_infoblox/rubygem-smart_proxy_dns_infoblox.spec
+++ b/packages/plugins/rubygem-smart_proxy_dns_infoblox/rubygem-smart_proxy_dns_infoblox.spec
@@ -1,38 +1,33 @@
-# Generated from smart_proxy_dns_infoblox-0.0.3.gem by gem2rpm -*- rpm-spec -*-
+# template: smart_proxy_plugin
 %global gem_name smart_proxy_dns_infoblox
 %global plugin_name dns_infoblox
 
+%global foreman_proxy_min_version 1.16.0
 %global foreman_proxy_dir %{_datarootdir}/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
 Name: rubygem-%{gem_name}
 Version: 0.0.9
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Infoblox DNS provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_dns_infoblox
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
-Requires: foreman-proxy >= 1.13.0
-%if 0%{?rhel} == 6
-Requires: ruby(abi)
-%else
+
+# start specfile generated dependencies
+Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: ruby(release)
-%endif
 Requires: ruby
 Requires: ruby(rubygems)
-Requires: rubygem(infoblox)
-%if 0%{?rhel} == 6
-BuildRequires: ruby(abi)
-%else
 BuildRequires: ruby(release)
-%endif
 BuildRequires: ruby
 BuildRequires: rubygems-devel
 BuildArch: noarch
 Provides: rubygem(%{gem_name}) = %{version}
-Provides: foreman-proxy-plugin-%{plugin_name}
+Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
+# end specfile generated dependencies
 
 %description
 Infoblox DNS provider plugin for Foreman's smart proxy.
@@ -80,9 +75,7 @@ mv %{buildroot}%{gem_instdir}/config/dns_infoblox.yml.example \
 %files
 %dir %{gem_instdir}
 %config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/dns_infoblox.yml
-%doc %{gem_instdir}/LICENSE
-%{gem_instdir}/bundler.d
-%{gem_instdir}/config
+%license %{gem_instdir}/LICENSE
 %{gem_libdir}
 %{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
 %exclude %{gem_cache}
@@ -94,6 +87,9 @@ mv %{buildroot}%{gem_instdir}/config/dns_infoblox.yml.example \
 %{gem_instdir}/test
 
 %changelog
+* Tue Jul 02 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 0.0.9-2
+- Regenerate spec file based on smart_proxy_plugin
+
 * Tue May 07 2019 Lukas Zapletal <lzap+rpm@redhat.com> 0.0.9-1
 - Updated to 0.0.9 upstream version
 

--- a/packages/plugins/rubygem-smart_proxy_dns_route53/rubygem-smart_proxy_dns_route53.spec
+++ b/packages/plugins/rubygem-smart_proxy_dns_route53/rubygem-smart_proxy_dns_route53.spec
@@ -1,20 +1,23 @@
-# Generated from smart_proxy_dns_route53-2.0.0.gem by gem2rpm -*- rpm-spec -*-
+# template: smart_proxy_plugin
 %global gem_name smart_proxy_dns_route53
 %global plugin_name dns_route53
 
+%global foreman_proxy_min_version 1.16.0
 %global foreman_proxy_dir %{_datarootdir}/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
 Name: rubygem-%{gem_name}
 Version: 3.0.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Route 53 DNS provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_dns_route53
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
-Requires: foreman-proxy >= 1.13
+
+# start specfile generated dependencies
+Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: ruby(release)
 Requires: ruby
 Requires: ruby(rubygems)
@@ -24,7 +27,8 @@ BuildRequires: ruby
 BuildRequires: rubygems-devel
 BuildArch: noarch
 Provides: rubygem(%{gem_name}) = %{version}
-Provides: foreman-proxy-plugin-%{plugin_name}
+Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
+# end specfile generated dependencies
 
 %description
 Route 53 DNS provider plugin for Foreman's smart proxy.
@@ -71,7 +75,7 @@ mv %{buildroot}%{gem_instdir}/config/%{plugin_name}.yml \
 
 %files
 %dir %{gem_instdir}
-%doc %{gem_instdir}/LICENSE
+%license %{gem_instdir}/LICENSE
 %{gem_instdir}/bundler.d
 %{gem_instdir}/config
 %{gem_libdir}
@@ -86,6 +90,9 @@ mv %{buildroot}%{gem_instdir}/config/%{plugin_name}.yml \
 %{gem_instdir}/test
 
 %changelog
+* Tue Jul 02 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 3.0.1-2
+- Regenerate spec file based on smart_proxy_plugin
+
 * Thu Feb 09 2017 Dominic Cleal <dominic@cleal.org> 3.0.1-1
 - Update smart_proxy_dns_route53 to 3.0.1 (dominic@cleal.org)
 

--- a/packages/plugins/rubygem-smart_proxy_dynflow/rubygem-smart_proxy_dynflow.spec
+++ b/packages/plugins/rubygem-smart_proxy_dynflow/rubygem-smart_proxy_dynflow.spec
@@ -1,21 +1,20 @@
+# template: smart_proxy_plugin
 %global gem_name smart_proxy_dynflow
+%global plugin_name dynflow
 
-%global foreman_proxy_dir /usr/share/foreman-proxy
+%global foreman_proxy_min_version 1.12.0
+%global foreman_proxy_dir %{_datarootdir}/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
-Summary: Dynflow runtime for Foreman smart proxy
 Name: rubygem-%{gem_name}
 Version: 0.2.3
-Release: 1%{?dist}
-Group: Applications/System
+Release: 2%{?foremandist}%{?dist}
+Summary: Dynflow runtime for Foreman smart proxy
+Group: Applications/Internet
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_dynflow
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
-
-Requires: ruby(release)
-Requires: ruby(rubygems)
-Requires: foreman-proxy >= 1.12.0
 
 %if 0%{?rhel} == 7
 Requires: tfm-rubygem(smart_proxy_dynflow_core) >= 0.2.0
@@ -25,62 +24,80 @@ Requires: rubygem(smart_proxy_dynflow_core) >= 0.2.0
 Requires: rubygem(smart_proxy_dynflow_core) < 0.3.0
 %endif
 
+# start specfile generated dependencies
+Requires: foreman-proxy >= %{foreman_proxy_min_version}
+Requires: ruby(release)
+Requires: ruby
+Requires: ruby(rubygems)
 BuildRequires: ruby(release)
+BuildRequires: ruby
 BuildRequires: rubygems-devel
 BuildArch: noarch
-
 Provides: rubygem(%{gem_name}) = %{version}
-Provides: foreman-proxy-plugin-dynflow
+Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
+# end specfile generated dependencies
 
 %description
-Dynflow runtime for Foreman smart proxy
+Use the Dynflow inside Foreman smart proxy.
+
 
 %package doc
-BuildArch:  noarch
-Requires:   %{name} = %{version}-%{release}
-Summary:    Documentation for rubygem-%{gem_name}
+Summary: Documentation for %{name}
+Group: Documentation
+Requires: %{name} = %{version}-%{release}
+BuildArch: noarch
 
 %description doc
-This package contains documentation for rubygem-%{gem_name}.
+Documentation for %{name}.
 
 %prep
+gem unpack %{SOURCE0}
 
-%setup -q -c -T
-%gem_install -n %{SOURCE0}
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
 
 %build
+# Create the gem as gem install only works on a gem file
+gem build %{gem_name}.gemspec
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%gem_install
 
 %install
 mkdir -p %{buildroot}%{gem_dir}
-
-mkdir -p %{buildroot}%{_localstatedir}/lib/foreman-proxy/dynflow
-
-cp -pa .%{gem_dir}/* \
+cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
+# bundler file
 mkdir -p %{buildroot}%{foreman_proxy_bundlerd_dir}
-cp -pa .%{gem_instdir}/bundler.plugins.d/dynflow.rb %{buildroot}%{foreman_proxy_bundlerd_dir}
-mkdir -p  %{buildroot}%{foreman_proxy_settingsd_dir}
-cp -pa .%{gem_instdir}/settings.d/dynflow.yml.example %{buildroot}%{foreman_proxy_settingsd_dir}/dynflow.yml
+mv %{buildroot}%{gem_instdir}/bundler.d/%{plugin_name}.rb \
+   %{buildroot}%{foreman_proxy_bundlerd_dir}
+
+# sample config
+mkdir -p %{buildroot}%{foreman_proxy_settingsd_dir}
+mv %{buildroot}%{gem_instdir}/settings.d/dynflow.yml.example \
+   %{buildroot}%{foreman_proxy_settingsd_dir}/dynflow.yml
 
 %files
 %dir %{gem_instdir}
-%dir %attr(750, foreman-proxy, foreman-proxy) %{_localstatedir}/lib/foreman-proxy/dynflow
-%{gem_instdir}/lib
-%{gem_instdir}/settings.d
-%{foreman_proxy_bundlerd_dir}/dynflow.rb
-%config %{foreman_proxy_settingsd_dir}/dynflow.yml
-%doc %{gem_instdir}/LICENSE
-
-%exclude %{gem_instdir}/bundler.plugins.d
-%exclude %{gem_instdir}/Gemfile
+%dir %attr(750, foreman-proxy, foreman-proxy) %{_sharedstatedir}/foreman-proxy/dynflow
+%config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/dynflow.yml
+%license %{gem_instdir}/LICENSE
+%{gem_libdir}
+%{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
 %exclude %{gem_cache}
 %{gem_spec}
 
 %files doc
 %doc %{gem_docdir}
+%{gem_instdir}/Gemfile
 
 %changelog
+* Tue Jul 02 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 0.2.3-2
+- Regenerate spec file based on smart_proxy_plugin
+
 * Tue Jun 11 2019 Ivan Nečas <inecas@redhat.com> 0.2.3-1
 - Update to 0.2.3
 

--- a/packages/plugins/rubygem-smart_proxy_monitoring/rubygem-smart_proxy_monitoring.spec
+++ b/packages/plugins/rubygem-smart_proxy_monitoring/rubygem-smart_proxy_monitoring.spec
@@ -1,19 +1,23 @@
+# template: smart_proxy_plugin
 %global gem_name smart_proxy_monitoring
 %global plugin_name monitoring
 
+%global foreman_proxy_min_version 1.12.0
 %global foreman_proxy_dir %{_datarootdir}/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
 Name: rubygem-%{gem_name}
 Version: 0.1.2
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Monitoring plug-in for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_monitoring
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
-Requires: foreman-proxy >= 1.12
+
+# start specfile generated dependencies
+Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: ruby(release)
 Requires: ruby
 Requires: ruby(rubygems)
@@ -24,7 +28,8 @@ BuildRequires: ruby
 BuildRequires: rubygems-devel
 BuildArch: noarch
 Provides: rubygem(%{gem_name}) = %{version}
-Provides: foreman-proxy-plugin-%{plugin_name}
+Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
+# end specfile generated dependencies
 
 %description
 Monitoring plug-in for Foreman's smart proxy.
@@ -81,10 +86,8 @@ mkdir -p %{buildroot}%{_sysconfdir}/foreman-proxy/monitoring
 %config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/monitoring.yml
 %config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/monitoring_icinga2.yml
 %config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/monitoring_icingadirector.yml
-%doc %{gem_instdir}/LICENSE
-%{gem_instdir}/bundler.d
+%license %{gem_instdir}/LICENSE
 %{gem_libdir}
-%{gem_instdir}/settings.d
 %{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
 %exclude %{gem_cache}
 %{gem_spec}
@@ -95,6 +98,9 @@ mkdir -p %{buildroot}%{_sysconfdir}/foreman-proxy/monitoring
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Tue Jul 02 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 0.1.2-2
+- Regenerate spec file based on smart_proxy_plugin
+
 * Tue Jun 12 2018 Timo Goebel <mail@timogoebel.name> - 0.1.2-1
 - Update smart_proxy_monitoring to 0.1.2
 

--- a/packages/plugins/rubygem-smart_proxy_omaha/rubygem-smart_proxy_omaha.spec
+++ b/packages/plugins/rubygem-smart_proxy_omaha/rubygem-smart_proxy_omaha.spec
@@ -1,22 +1,27 @@
+# template: smart_proxy_plugin
 %global gem_name smart_proxy_omaha
 %global plugin_name omaha
 
+%global foreman_proxy_min_version 1.12.0
 %global foreman_proxy_dir %{_datarootdir}/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
-%global content_dir %{_var}/lib/foreman-proxy/omaha/content
-%global proxy_user foreman-proxy
+%global content_dir %{_sharedstatedir}/foreman-proxy/omaha/content
 
 Name: rubygem-%{gem_name}
 Version: 0.0.5
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Omaha protocol support for smart-proxy
 Group: Applications/Internet
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_omaha
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
-Requires: foreman-proxy >= 1.12
+
 Requires: crontabs
+
+# start specfile generated dependencies
+Requires: foreman-proxy >= %{foreman_proxy_min_version}
+Requires: ruby(release)
 Requires: ruby
 Requires: ruby(rubygems)
 Requires: rubygem(nokogiri) >= 1.5.11
@@ -26,7 +31,8 @@ BuildRequires: ruby
 BuildRequires: rubygems-devel
 BuildArch: noarch
 Provides: rubygem(%{gem_name}) = %{version}
-Provides: foreman-proxy-plugin-%{plugin_name}
+Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
+# end specfile generated dependencies
 
 %description
 This plug-in adds support for the Omaha Procotol to Foreman's Smart Proxy.
@@ -86,29 +92,32 @@ mkdir -p %{buildroot}%{content_dir}
 
 %files
 %dir %{gem_instdir}
-%config(noreplace) %attr(0640, root, %{proxy_user}) %{foreman_proxy_settingsd_dir}/omaha.yml
-%attr(-,%{proxy_user},%{proxy_user}) %{content_dir}
-%doc %{gem_instdir}/LICENSE
-%{gem_instdir}/bin
-%{gem_instdir}/bundler.d
-%{gem_libdir}
-%{gem_instdir}/settings.d
 %{_bindir}/smart-proxy-omaha-sync
+%config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/omaha.yml
+%dir %attr(-, foreman-proxy, foreman-proxy) %{content_dir}
+%license %{gem_instdir}/LICENSE
+%{gem_instdir}/bin
+%exclude %{gem_instdir}/bundler.d
+%exclude %{gem_instdir}/extra
+%exclude %{gem_instdir}/settings.d
+%{gem_libdir}
 %{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
 %config(noreplace) %attr(0644, root, root) %{_sysconfdir}/cron.d/%{name}
 %exclude %{gem_cache}
-%exclude %{gem_instdir}/extra
-%exclude %{gem_instdir}/%{gem_name}.gemspec
-%exclude %{gem_instdir}/Gemfile
-%exclude %{gem_instdir}/Rakefile
-%exclude %{gem_instdir}/test
 %{gem_spec}
 
 %files doc
 %doc %{gem_docdir}
+%{gem_instdir}/Gemfile
 %doc %{gem_instdir}/README.md
+%{gem_instdir}/Rakefile
+%{gem_instdir}/smart_proxy_omaha.gemspec
+%{gem_instdir}/test
 
 %changelog
+* Tue Jul 02 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 0.0.5-2
+- Regenerate spec file based on smart_proxy_plugin
+
 * Fri Aug 24 2018 Timo Goebel <mail@timogoebel.name> - 0.0.5-1
 - Update smart_proxy_omaha to 0.0.5
 

--- a/packages/plugins/rubygem-smart_proxy_pulp/rubygem-smart_proxy_pulp.spec
+++ b/packages/plugins/rubygem-smart_proxy_pulp/rubygem-smart_proxy_pulp.spec
@@ -1,81 +1,102 @@
+# template: smart_proxy_plugin
 %global gem_name smart_proxy_pulp
+%global plugin_name pulp
 
-%global foreman_proxy_dir /usr/share/foreman-proxy
+%global foreman_proxy_min_version 1.22.0
+%global foreman_proxy_dir %{_datarootdir}/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
-Summary: Basic Pulp support for Foreman Smart-Proxy
 Name: rubygem-%{gem_name}
 Version: 1.4.1
-Release: 1%{?dist}
-Group: Applications/System
+Release: 2%{?foremandist}%{?dist}
+Summary: Basic Pulp support for Foreman Smart-Proxy
+Group: Applications/Internet
 License: GPLv3
-URL: https://github.com/theforeman/smart_proxy_pulp
+URL: https://github.com/theforeman/smart-proxy-pulp-plugin
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-Requires: ruby(rubygems)
-Requires: foreman-proxy >= 1.22.0
-
+# start specfile generated dependencies
+Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: ruby(release)
+Requires: ruby
+Requires: ruby(rubygems)
 BuildRequires: ruby(release)
+BuildRequires: ruby
 BuildRequires: rubygems-devel
-
-BuildRequires: ruby(rubygems)
 BuildArch: noarch
-
 Provides: rubygem(%{gem_name}) = %{version}
-Provides: foreman-proxy-plugin-pulp
+Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
+# end specfile generated dependencies
 
 %description
 Basic Pulp support for Foreman Smart-Proxy.
 
+
 %package doc
-BuildArch:  noarch
-Requires:   %{name} = %{version}-%{release}
-Summary:    Documentation for rubygem-%{gem_name}
+Summary: Documentation for %{name}
+Group: Documentation
+Requires: %{name} = %{version}-%{release}
+BuildArch: noarch
 
 %description doc
-This package contains documentation for rubygem-%{gem_name}.
+Documentation for %{name}.
 
 %prep
+gem unpack %{SOURCE0}
 
-%setup -q -c -T
-%gem_install -n %{SOURCE0}
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
 
 %build
+# Create the gem as gem install only works on a gem file
+gem build %{gem_name}.gemspec
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%gem_install
 
 %install
 mkdir -p %{buildroot}%{gem_dir}
-cp -pa .%{gem_dir}/* \
+cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
+# bundler file
 mkdir -p %{buildroot}%{foreman_proxy_bundlerd_dir}
-cp -pa .%{gem_instdir}/bundler.d/pulp.rb %{buildroot}%{foreman_proxy_bundlerd_dir}
-mkdir -p  %{buildroot}%{_sysconfdir}/foreman-proxy/settings.d/
-cp -pa .%{gem_instdir}/settings.d/pulp3.yml.example %{buildroot}%{foreman_proxy_settingsd_dir}/pulp3.yml
-cp -pa .%{gem_instdir}/settings.d/pulp.yml.example %{buildroot}%{foreman_proxy_settingsd_dir}/pulp.yml
-cp -pa .%{gem_instdir}/settings.d/pulpnode.yml.example %{buildroot}%{foreman_proxy_settingsd_dir}/pulpnode.yml
+mv %{buildroot}%{gem_instdir}/bundler.d/%{plugin_name}.rb \
+   %{buildroot}%{foreman_proxy_bundlerd_dir}
+
+# sample config
+mkdir -p %{buildroot}%{foreman_proxy_settingsd_dir}
+mv %{buildroot}%{gem_instdir}/settings.d/pulp.yml.example \
+   %{buildroot}%{foreman_proxy_settingsd_dir}/pulp.yml
+mv %{buildroot}%{gem_instdir}/settings.d/pulp3.yml.example \
+   %{buildroot}%{foreman_proxy_settingsd_dir}/pulp3.yml
+mv %{buildroot}%{gem_instdir}/settings.d/pulpnode.yml.example \
+   %{buildroot}%{foreman_proxy_settingsd_dir}/pulpnode.yml
 
 %files
 %dir %{gem_instdir}
-%{gem_instdir}/lib
-%{gem_instdir}/bundler.d
-%{gem_instdir}/settings.d
-%{foreman_proxy_bundlerd_dir}/pulp.rb
-%config(noreplace) %{_sysconfdir}/foreman-proxy/settings.d/pulp3.yml
-%config(noreplace) %{_sysconfdir}/foreman-proxy/settings.d/pulp.yml
-%config(noreplace) %{_sysconfdir}/foreman-proxy/settings.d/pulpnode.yml
+%config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/pulp.yml
+%config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/pulp3.yml
+%config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/pulpnode.yml
 %license %{gem_instdir}/LICENSE
-
+%exclude %{gem_instdir}/bundler.d
+%{gem_libdir}
+%exclude %{gem_instdir}/settings.d
+%{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
 %exclude %{gem_cache}
-%exclude %{gem_instdir}/Gemfile
 %{gem_spec}
 
 %files doc
 %doc %{gem_docdir}
-
+%{gem_instdir}/Gemfile
 
 %changelog
+* Tue Jul 02 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 1.4.1-2
+- Regenerate spec file based on smart_proxy_plugin
+
 * Fri Mar 08 2019 Justin Sherrill <jsherril@redhat.com> 1.4.1-1
 - Updated samrt_proxy_pulp to version 1.4.1
  

--- a/packages/plugins/rubygem-smart_proxy_realm_ad_plugin/rubygem-smart_proxy_realm_ad_plugin.spec
+++ b/packages/plugins/rubygem-smart_proxy_realm_ad_plugin/rubygem-smart_proxy_realm_ad_plugin.spec
@@ -1,19 +1,23 @@
+# template: smart_proxy_plugin
 %global gem_name smart_proxy_realm_ad_plugin
 %global plugin_name realm_ad_plugin
 
+%global foreman_proxy_min_version 1.15.0
 %global foreman_proxy_dir %{_datarootdir}/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
 Name: rubygem-%{gem_name}
 Version: 0.1
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Summary: A realm ad provider plugin for Foreman's smart proxy
 Group: Applications/Internet
-License: GPLv3+
+License: GPLv3
 URL: https://github.com/martencassel/smart_proxy_realm_ad_plugin
-Source0: https://rubygems.org/downloads/%{gem_name}-%{version}.gem
-Requires: foreman-proxy >= 1.15
+Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
+
+# start specfile generated dependencies
+Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: ruby(release)
 Requires: ruby
 Requires: ruby(rubygems)
@@ -24,7 +28,8 @@ BuildRequires: ruby
 BuildRequires: rubygems-devel
 BuildArch: noarch
 Provides: rubygem(%{gem_name}) = %{version}
-Provides: foreman-proxy-plugin-%{plugin_name}
+Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
+# end specfile generated dependencies
 
 %description
 A realm ad provider plugin for Foreman's smart proxy.
@@ -86,6 +91,9 @@ mv %{buildroot}%{gem_instdir}/config/realm_ad.yml.example \
 %{gem_instdir}/test
 
 %changelog
+* Tue Jul 02 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 0.1-3
+- Regenerate spec file based on smart_proxy_plugin
+
 * Wed Sep 12 2018 Bryan Kearney <bryan.kearney@gmail.com> - 0.1-2
 - Move licenes which are GPL-* to GPLv3
 


### PR DESCRIPTION
This PR regenerates a lot of plugins, mostly in the smart proxy based on the current template. This gives us:
* Better permission handling (cleaner rpm -qV output)
* Automatic dependency updates on bump
* Remove EL6 cruft

There is a significant risk I messed up some %files section or somewhere else. This is based on an older branch that I want to get merged rather than get stale.