### PR TITLE
Fixes #27225: Fix the Foreman restart macro

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -2,13 +2,14 @@
 %global confdir extras/packaging/rpm/sources
 %global foreman_rake %{_sbindir}/%{name}-rake
 %global executor_service_name dynflowd
+%global foreman_restart (touch %{homedir}/tmp/restart.txt ; /bin/systemctl try-restart %{name}.service) >/dev/null 2>&1
 
 # explicitly define, as we build on top of an scl, not inside with scl_package
 %{?scl:%global scl_prefix %{scl}-}
 %global scl_ruby_bin /usr/bin/%{?scl:%{scl_prefix}}ruby
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 1
+%global release 2
 
 Name:    foreman
 Version: 1.22.0
@@ -1135,7 +1136,7 @@ cat > %{buildroot}%{_sysconfdir}/rpm/macros.%{name} << EOF
 %%%{name}_rake         %{foreman_rake}
 %%%{name}_db_migrate   %%{%{name}_rake} db:migrate >> %%{%{name}_log_dir}/db_migrate.log 2>&1 || :
 %%%{name}_db_seed      %%{%{name}_rake} db:seed >> %%{%{name}_log_dir}/db_seed.log 2>&1 || :
-%%%{name}_restart      (touch %{homedir}/tmp/restart.txt ; /bin/systemctl try-restart %{name}.service) >/dev/null 2>&1
+%%%{name}_restart      %{foreman_restart}
 EOF
 
 # Keep a copy of the schema for quick initialisation of plugin builds
@@ -1326,6 +1327,9 @@ exit 0
 %systemd_postun_with_restart %{name}.service
 
 %changelog
+* Wed Jul 03 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.22.0-2
+- Define foreman_restart macro
+
 * Tue Jun 04 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.22.0-1
 - Release 1.22.0
 


### PR DESCRIPTION
Previously it relied on the Foreman build macros to be defined but this is not defined as a build dependency so the macro is not expanded. This results in an error:

    /var/tmp/rpm-tmp.eSpJPO: line 7: fg: no job control

(cherry picked from commit d2314333bce3da45473151bd798cf288a8bb2751)