### PR TITLE
add the owner to namespaced npm packages

### DIFF
--- a/add_npm_package.sh
+++ b/add_npm_package.sh
@@ -7,7 +7,14 @@ TITO_TAG=foreman-nightly-nonscl-rhel7
 DISTRO=${TITO_TAG##*-}
 BASE_DIR=${4:-foreman}
 
-PACKAGE_NAME=nodejs-${NPM_MODULE_NAME##*/}
+PACKAGE_MODULE=${NPM_MODULE_NAME##*/}
+PACKAGE_VENDOR=${NPM_MODULE_NAME%%/*}
+PACKAGE_VENDOR=${PACKAGE_VENDOR##@}
+if [[ $NPM_MODULE_NAME == */* ]]; then
+  PACKAGE_NAME=nodejs-${PACKAGE_VENDOR}-${PACKAGE_MODULE}
+else
+  PACKAGE_NAME=nodejs-${PACKAGE_MODULE}
+fi
 PACKAGE_DIR=packages/$BASE_DIR/$PACKAGE_NAME
 
 ROOT=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
npm2rpm 5.0.0 introduced a new package naming scheme, let's follow suit

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 1.22
 * 1.21
 * 1.20

RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
