### PR TITLE
Refs #26591 - Drop support for Puppet 3 in proxy

### DIFF
--- a/debian/bionic/foreman-proxy/foreman-proxy.install
+++ b/debian/bionic/foreman-proxy/foreman-proxy.install
@@ -5,7 +5,6 @@ bundler.d/dhcp_isc.rb                     usr/share/foreman-proxy/bundler.d
 bundler.d/krb5.rb                         usr/share/foreman-proxy/bundler.d
 bundler.d/libvirt.rb                      usr/share/foreman-proxy/bundler.d
 bundler.d/puppetca_token_whitelisting.rb  usr/share/foreman-proxy/bundler.d
-bundler.d/puppet.rb                       usr/share/foreman-proxy/bundler.d
 bundler.d/realm_freeipa.rb                usr/share/foreman-proxy/bundler.d
 config.ru                                 usr/share/foreman-proxy
 extra/migrate_settings.rb                 usr/share/foreman-proxy/extra

--- a/debian/stretch/foreman-proxy/foreman-proxy.install
+++ b/debian/stretch/foreman-proxy/foreman-proxy.install
@@ -5,7 +5,6 @@ bundler.d/dhcp_isc.rb                     usr/share/foreman-proxy/bundler.d
 bundler.d/krb5.rb                         usr/share/foreman-proxy/bundler.d
 bundler.d/libvirt.rb                      usr/share/foreman-proxy/bundler.d
 bundler.d/puppetca_token_whitelisting.rb  usr/share/foreman-proxy/bundler.d
-bundler.d/puppet.rb                       usr/share/foreman-proxy/bundler.d
 bundler.d/realm_freeipa.rb                usr/share/foreman-proxy/bundler.d
 config.ru                                 usr/share/foreman-proxy
 extra/migrate_settings.rb                 usr/share/foreman-proxy/extra

--- a/debian/xenial/foreman-proxy/foreman-proxy.install
+++ b/debian/xenial/foreman-proxy/foreman-proxy.install
@@ -5,7 +5,6 @@ bundler.d/dhcp_isc.rb                     usr/share/foreman-proxy/bundler.d
 bundler.d/krb5.rb                         usr/share/foreman-proxy/bundler.d
 bundler.d/libvirt.rb                      usr/share/foreman-proxy/bundler.d
 bundler.d/puppetca_token_whitelisting.rb  usr/share/foreman-proxy/bundler.d
-bundler.d/puppet.rb                       usr/share/foreman-proxy/bundler.d
 bundler.d/realm_freeipa.rb                usr/share/foreman-proxy/bundler.d
 config.ru                                 usr/share/foreman-proxy
 extra/migrate_settings.rb                 usr/share/foreman-proxy/extra


### PR DESCRIPTION
The proxy has dropped support for Puppet 3 and that means no additional gems are required.