### PR TITLE
Fixes #27255 - katello-change-hostname cleans puppet certs

### DIFF
--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -63,7 +63,7 @@ module KatelloUtilities
     def get_fpc_answers
       register_in_foreman = false
       certs_tar = @options[:certs_tar]
-      " --foreman-proxy-register-in-foreman #{register_in_foreman} --foreman-proxy-content-certs-tar #{certs_tar}"
+      " --foreman-proxy-register-in-foreman #{register_in_foreman} --certs-tar-file #{certs_tar}"
     end
 
     def precheck
@@ -165,6 +165,12 @@ module KatelloUtilities
       scenario_answers["certs"]["server_cert"] &&
       scenario_answers["certs"]["server_key"] &&
       scenario_answers["certs"]["server_cert_req"]
+    end
+
+    def delete_puppet_certs
+      puppet_ssldir = @scenario_answers['puppet']['ssldir']
+
+      run_cmd("rm -rf '#{puppet_ssldir}'")
     end
 
     def all_custom_cert_options_present?
@@ -334,6 +340,8 @@ module KatelloUtilities
         self.run_cmd("rm -rf #{@scenario_answers["foreman"]["client_ssl_cert"]}")
         self.run_cmd("rm -rf #{@scenario_answers["foreman"]["client_ssl_key"]}")
       end
+
+      delete_puppet_certs
 
       STDOUT.puts "backed up #{public_dir} to #{public_backup_dir}"
       STDOUT.puts "updating hostname in /etc/hosts"

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -4,7 +4,7 @@
 %global homedir %{_datarootdir}/%{name}
 %global confdir common
 %global prerelease .master
-%global release 3
+%global release 4
 
 Name:       katello
 Version:    3.13.0
@@ -194,6 +194,10 @@ Useful utilities for managing Katello services
 %{_sysconfdir}/bash_completion.d/katello-service
 
 %changelog
+* Sun Jul 21 2019 Jonathon Turel <jturel@gmail.com> 3.13.0-0.4.master
+- katello-change-hostname: clean puppet certs
+- katello-change-hostname: s/foreman-proxy-content-certs-tar/certs-tar-file/
+
 * Fri Jun 07 2019 Lukas Zapletal <lzap+rpm@redhat.com> 3.13.0-0.3.master
 - BZ#1710625 - updated qpidd debug paths
 


### PR DESCRIPTION
Also fixes an additional bug when changing the hostname on a proxy
caused by giving the installer an invalid parameter
