### PR TITLE
Fixes #27255 - katello-change-hostname cleans puppet certs

### DIFF
--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -63,7 +63,7 @@ module KatelloUtilities
     def get_fpc_answers
       register_in_foreman = false
       certs_tar = @options[:certs_tar]
-      " --foreman-proxy-register-in-foreman #{register_in_foreman} --foreman-proxy-content-certs-tar #{certs_tar}"
+      " --foreman-proxy-register-in-foreman #{register_in_foreman} --certs-tar-file #{certs_tar}"
     end
 
     def precheck
@@ -165,6 +165,12 @@ module KatelloUtilities
       scenario_answers["certs"]["server_cert"] &&
       scenario_answers["certs"]["server_key"] &&
       scenario_answers["certs"]["server_cert_req"]
+    end
+
+    def delete_puppet_certs
+      puppet_ssldir = @scenario_answers['puppet']['ssldir']
+
+      run_cmd("rm -rf '#{puppet_ssldir}'")
     end
 
     def all_custom_cert_options_present?
@@ -334,6 +340,8 @@ module KatelloUtilities
         self.run_cmd("rm -rf #{@scenario_answers["foreman"]["client_ssl_cert"]}")
         self.run_cmd("rm -rf #{@scenario_answers["foreman"]["client_ssl_key"]}")
       end
+
+      delete_puppet_certs
 
       STDOUT.puts "backed up #{public_dir} to #{public_backup_dir}"
       STDOUT.puts "updating hostname in /etc/hosts"

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -4,7 +4,7 @@
 %global homedir %{_datarootdir}/%{name}
 %global confdir common
 #global prerelease .rc2
-%global release 1
+%global release 2
 
 Name:       katello
 Version:    3.12.1
@@ -194,6 +194,10 @@ Useful utilities for managing Katello services
 %{_sysconfdir}/bash_completion.d/katello-service
 
 %changelog
+* Sun Jul 21 2019 Jonathon Turel <jturel@gmail.com> 3.12.1-2
+- katello-change-hostname: clean puppet certs
+- katello-change-hostname: s/foreman-proxy-content-certs-tar/certs-tar-file/
+
 * Wed Jul 17 2019 Evgeni Golov - 3.12.1-1
 - Release 3.12.1
 


### PR DESCRIPTION
Also fixes an additional bug when changing the hostname on a proxy
caused by giving the installer an invalid parameter

(cherry picked from commit 58b3bd781b8e67dbbf4d3f694d2ddb96f218f6b7)

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 1.23
 * 1.22
 * 1.21

RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
