### PR TITLE
Update rubygem-dynflow to 1.3.0

### DIFF
--- a/packages/foreman/rubygem-dynflow/dynflow-1.2.3.gem
+++ b/packages/foreman/rubygem-dynflow/dynflow-1.2.3.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/VQ/jX/SHA256E-s968704--3ecd05e9319fca152d157dc5ee9f92011aa608c8fd873ddc15d9caefbe252240.3.gem/SHA256E-s968704--3ecd05e9319fca152d157dc5ee9f92011aa608c8fd873ddc15d9caefbe252240.3.gem

--- a/packages/foreman/rubygem-dynflow/dynflow-1.3.0.gem
+++ b/packages/foreman/rubygem-dynflow/dynflow-1.3.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/6W/9g/SHA256E-s969216--d4d4c7fc568d7dcae26d8eabf0de25284779206a2b01242fed60ca1a99f3eba3.0.gem/SHA256E-s969216--d4d4c7fc568d7dcae26d8eabf0de25284779206a2b01242fed60ca1a99f3eba3.0.gem

--- a/packages/foreman/rubygem-dynflow/rubygem-dynflow.spec
+++ b/packages/foreman/rubygem-dynflow/rubygem-dynflow.spec
@@ -5,7 +5,7 @@
 
 Summary: DYNamic workFLOW engine
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 1.2.3
+Version: 1.3.0
 Release: 1%{?foremandist}%{?dist}
 Group: Development/Languages
 License: MIT
@@ -88,6 +88,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/examples
 
 %changelog
+* Thu Aug 15 2019 Adam Ruzicka <aruzicka@redhat.com> 1.3.0-1
+- Update to 1.3.0
+
 * Fri May 03 2019 Ivan Nečas <inecas@redhat.com> 1.2.3-1
 - Update to 1.2.3
 

--- a/packages/foreman/rubygem-dynflow/rubygem-dynflow.spec
+++ b/packages/foreman/rubygem-dynflow/rubygem-dynflow.spec
@@ -21,7 +21,7 @@ BuildRequires: %{?scl_prefix_ruby}ruby(release)
 %endif
 
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
-Requires: %{?scl_prefix_ruby}ruby
+Requires: %{?scl_prefix_ruby}ruby >= 2.3.0
 Requires: %{?scl_prefix}rubygem(algebrick) >= 0.7.0
 Requires: %{?scl_prefix}rubygem(algebrick) < 0.8.0
 Requires: %{?scl_prefix_ror}rubygem(concurrent-ruby) >= 1.1.3


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 1.23
 * 1.22
 * 1.21

RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->

Is the second commit needed? In previous versions we depended on ruby >= 2.0.0, but the dependency was not mentioned anywhere.
