### PR TITLE
Update rubygem-foreman_remote_execution to 1.8.3

### DIFF
--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -98,6 +98,7 @@
       <packagereq type="default">tfm-rubygem-foreman_probing</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_probing_core</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_remote_execution</packagereq>
+      <packagereq type="default">tfm-rubygem-foreman_remote_execution-cockpit</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_remote_execution_core</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_rescue</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_salt</packagereq>

--- a/packages/plugins/rubygem-foreman_remote_execution/foreman_remote_execution-1.8.2.gem
+++ b/packages/plugins/rubygem-foreman_remote_execution/foreman_remote_execution-1.8.2.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/v6/z9/SHA256E-s241152--5de8362a9d9967b7f4091aee791b59ebbfe053f0839f3b33329fa3c0adb4c2a9.2.gem/SHA256E-s241152--5de8362a9d9967b7f4091aee791b59ebbfe053f0839f3b33329fa3c0adb4c2a9.2.gem

--- a/packages/plugins/rubygem-foreman_remote_execution/foreman_remote_execution-1.8.3.gem
+++ b/packages/plugins/rubygem-foreman_remote_execution/foreman_remote_execution-1.8.3.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/fm/WP/SHA256E-s242688--16fb870aa8c023bef4ecb24b5dea2c87a47e6fb980dded21e2df23394c43da1e.3.gem/SHA256E-s242688--16fb870aa8c023bef4ecb24b5dea2c87a47e6fb980dded21e2df23394c43da1e.3.gem

--- a/packages/plugins/rubygem-foreman_remote_execution/rubygem-foreman_remote_execution.spec
+++ b/packages/plugins/rubygem-foreman_remote_execution/rubygem-foreman_remote_execution.spec
@@ -104,7 +104,6 @@ install -Dp -m0644 %{buildroot}%{gem_instdir}/extra/cockpit/settings.yml.example
 exit 0
 
 %post cockpit
-%systemd_postun_with_restart foreman-cockpit.service
 %systemd_post foreman-cockpit.service
 
 %preun cockpit
@@ -112,7 +111,6 @@ exit 0
 
 %postun cockpit
 %systemd_postun_with_restart foreman-cockpit.service
-%systemd_post foreman-cockpit.service
 
 %files
 %dir %{gem_instdir}

--- a/packages/plugins/rubygem-foreman_remote_execution/rubygem-foreman_remote_execution.spec
+++ b/packages/plugins/rubygem-foreman_remote_execution/rubygem-foreman_remote_execution.spec
@@ -13,7 +13,7 @@
 
 Summary:    Plugin that brings remote execution capabilities to Foreman
 Name:       %{?scl_prefix}rubygem-%{gem_name}
-Version:    1.8.2
+Version:    1.8.3
 Release:    1%{?foremandist}%{?dist}
 Group:      Applications/System
 License:    GPLv3
@@ -116,6 +116,9 @@ exit 0
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Sun Aug 18 2019 Ivan Nečas <inecas@redhat.com> 1.8.3-1
+- Update to 1.8.3
+
 * Tue Jul 16 2019 Adam Ruzicka <aruzicka@redhat.com> 1.8.2-1
 - Update to 1.8.2
 


### PR DESCRIPTION
Adds rubygem-foreman_remote_execution-cockpit subpackage with the cockpit integration bits and pieces

For plugin updates, please indicate which repos this should be built into:

* [x] Nightly
* [ ] 1.21
* [ ] 1.20

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.

---