### PR TITLE
Drop 'Generated from' headers from gem2rpm templates

### DIFF
--- a/gem2rpm/foreman_plugin.spec.erb
+++ b/gem2rpm/foreman_plugin.spec.erb
@@ -2,7 +2,6 @@
 #   1. Edit foreman requirement(s) and specify minimum version
 #   2. Delete these lines
 #
-# Generated from <%= package.spec.file_name %> by gem2rpm -*- rpm-spec -*-
 # template: foreman_plugin
 <%-
 require 'json'

--- a/gem2rpm/hammer_plugin.spec.erb
+++ b/gem2rpm/hammer_plugin.spec.erb
@@ -1,4 +1,3 @@
-# Generated from <%= package.spec.file_name %> by gem2rpm -*- rpm-spec -*-
 # template: hammer_plugin
 <%-
 require 'json'

--- a/gem2rpm/nonscl.spec.erb
+++ b/gem2rpm/nonscl.spec.erb
@@ -1,4 +1,3 @@
-# Generated from <%= package.spec.file_name %> by gem2rpm -*- rpm-spec -*-
 # template: nonscl
 %global gem_name <%= spec.name %>
 

--- a/gem2rpm/scl.spec.erb
+++ b/gem2rpm/scl.spec.erb
@@ -1,4 +1,3 @@
-# Generated from <%= package.spec.file_name %> by gem2rpm -*- rpm-spec -*-
 # template: scl
 <%-
 require 'json'

--- a/gem2rpm/smart_proxy_plugin.spec.erb
+++ b/gem2rpm/smart_proxy_plugin.spec.erb
@@ -2,7 +2,6 @@
 #   1. Edit foreman-proxy requirement and specify minimum version
 #   2. Delete these lines
 #
-# Generated from <%= package.spec.file_name %> by gem2rpm -*- rpm-spec -*-
 # template: smart_proxy_plugin
 %global gem_name <%= spec.name %>
 %global plugin_name <%= spec.name.sub(/\Asmart_proxy_/, '') %>


### PR DESCRIPTION
The [add_gem_package.sh](https://github.com/theforeman/foreman-packaging/blob/rpm/develop/add_gem_package.sh) script adds a similar line in the initial changelog so this is redundant. They are usually deleted anyway.