### PR TITLE
Fixes #27811 - satellite-change-hostname fails if locale is set to ja…

### DIFF
--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -151,7 +151,7 @@ module KatelloUtilities
     end
 
     def hammer_cmd(cmd, exit_codes=[0], message=nil)
-      run_cmd("hammer -u #{@options[:username].shellescape} -p #{@options[:password].shellescape} #{cmd}", exit_codes, message)
+      run_cmd("LANG=en_US.utf-8 hammer -u #{@options[:username].shellescape} -p #{@options[:password].shellescape} #{cmd}", exit_codes, message)
     end
 
     def get_default_proxy_id

--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -151,7 +151,7 @@ module KatelloUtilities
     end
 
     def hammer_cmd(cmd, exit_codes=[0], message=nil)
-      run_cmd("LANG=en_US.utf-8 hammer -u #{@options[:username].shellescape} -p #{@options[:password].shellescape} #{cmd}", exit_codes, message)
+      run_cmd("LANG=en_US.UTF-8 hammer -u #{@options[:username].shellescape} -p #{@options[:password].shellescape} #{cmd}", exit_codes, message)
     end
 
     def get_default_proxy_id


### PR DESCRIPTION
…_JP.UTF-8

satellite-change-hostname script should make sure it uses hammer with English locale only
to prevent possible issues with parsing special characters is locale of OS is set to language which has its own special alphabet. 

Supported Versions:

 * Nightly
 * 1.23
 * 1.22
 * 1.21

