### PR TITLE
Fix ability to build an srpm for nightly packages

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -41,6 +41,8 @@ foreman_scl_packages:
       build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
       nightly_package_tito_releaser_args:
         - "--arg jenkins_job=foreman-develop-source-release"
+        - "--arg jenkins_url=https://ci.theforeman.org"
+        - "--builder 'tito.builder.FetchBuilder'"
     rubygem-activerecord-session_store: {}
     rubygem-addressable: {}
     rubygem-algebrick: {}
@@ -103,12 +105,16 @@ foreman_scl_packages:
       build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
       nightly_package_tito_releaser_args:
         - "--arg jenkins_job=hammer-cli-master-source-release"
+        - "--arg jenkins_url=https://ci.theforeman.org"
+        - "--builder 'tito.builder.FetchBuilder'"
     rubygem-hammer_cli_foreman:
       releasers:
         - "{{ nightly_releaser }}"
       build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
       nightly_package_tito_releaser_args:
         - "--arg jenkins_job=hammer-cli-foreman-master-source-release"
+        - "--arg jenkins_url=https://ci.theforeman.org"
+        - "--builder 'tito.builder.FetchBuilder'"
     rubygem-hirb-unicode-steakknife: {}
     rubygem-hirb: {}
     rubygem-hoe: {}
@@ -222,12 +228,16 @@ foreman_nonscl_packages:
       build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
       nightly_package_tito_releaser_args:
         - "--arg jenkins_job=foreman-installer-develop-source-release"
+        - "--arg jenkins_url=https://ci.theforeman.org"
+        - "--builder 'tito.builder.FetchBuilder'"
     foreman-proxy:
       releasers:
         - "{{ nightly_releaser }}"
       build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
       nightly_package_tito_releaser_args:
         - "--arg jenkins_job=smart-proxy-develop-source-release"
+        - "--arg jenkins_url=https://ci.theforeman.org"
+        - "--builder 'tito.builder.FetchBuilder'"
     foreman-release:
       diff_package_tags:
         - foreman-nightly-nonscl-rhel7
@@ -246,6 +256,8 @@ foreman_nonscl_packages:
       build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
       nightly_package_tito_releaser_args:
         - "--arg jenkins_job=foreman-selinux-develop-source-release"
+        - "--arg jenkins_url=https://ci.theforeman.org"
+        - "--builder 'tito.builder.FetchBuilder'"
     katello-certs-tools: {}
     katello-selinux: {}
     nodejs-argv-parse: {}
@@ -562,12 +574,16 @@ katello_packages:
       build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
       nightly_package_tito_releaser_args:
         - "--arg jenkins_job=hammer-cli-katello-master-source-release"
+        - "--arg jenkins_url=https://ci.theforeman.org"
+        - "--builder 'tito.builder.FetchBuilder'"
     rubygem-katello:
       releasers:
         - "{{ nightly_releaser }}"
       build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
       nightly_package_tito_releaser_args:
         - "--arg jenkins_job=katello-master-source-release"
+        - "--arg jenkins_url=https://ci.theforeman.org"
+        - "--builder 'tito.builder.FetchBuilder'"
     rubygem-pulpcore_client: {}
     rubygem-pulp_ansible_client: {}
     rubygem-pulp_docker_client: {}


### PR DESCRIPTION
This is a bit repetitive and not pretty but it fixes `obal srpm` for now which is helpful in testing. I think the overall design needs some work and I would ask we not hold this up.