### PR TITLE
Explicitly use python3 in add_gem_package.sh

### DIFF
--- a/add_gem_package.sh
+++ b/add_gem_package.sh
@@ -3,7 +3,7 @@
 usage() {
 	echo "Usage: $0 GEM_NAME TEMPLATE TITO_TAG [PACKAGE_SUBDIR]"
 	echo "Valid templates: $(ls gem2rpm | sed 's/.spec.erb//' | tr '\n' ' ')"
-	python -c "import ConfigParser ; c = ConfigParser.ConfigParser() ; c.read('rel-eng/tito.props') ; print 'Tito tags: ' + ' '.join(s for s in c.sections() if s not in ('requirements', 'buildconfig', 'builder'))"
+	python3 -c "import configparser ; c = configparser.ConfigParser() ; c.read('rel-eng/tito.props') ; print('Tito tags: ' + ' '.join(s for s in c.sections() if s not in ('requirements', 'buildconfig', 'builder')))"
 	exit 1
 }
 


### PR DESCRIPTION
With Python 2 going EOL soon, /usr/bin/python should no longer be used and an explicit choice is recommended. Especially when the code is incompatible. This updates it to use Python 3.