### PR TITLE
Make optionality of parameters more explicit

### DIFF
--- a/add_gem_package.sh
+++ b/add_gem_package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 usage() {
-	echo "Usage: $0 GEM_NAME TEMPLATE TITO_TAG [PACKAGE_SUBDIR]"
+	echo "Usage: $0 GEM_NAME [TEMPLATE [TITO_TAG [PACKAGE_SUBDIR]]]"
 	echo "Valid templates: $(ls gem2rpm | sed 's/.spec.erb//' | tr '\n' ' ')"
 	python3 -c "import configparser ; c = configparser.ConfigParser() ; c.read('rel-eng/tito.props') ; print('Tito tags: ' + ' '.join(s for s in c.sections() if s not in ('requirements', 'buildconfig', 'builder')))"
 	exit 1


### PR DESCRIPTION
In most places, the parameters to add_gem_package.sh can be inferred
from the gem_name. The usage message should reflect that.