### PR TITLE
Add python-keycloak-httpd-client-install package

### DIFF
--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -121,8 +121,8 @@
       <packagereq type="default">tfm-nodejs-redux</packagereq>
       <packagereq type="default">tfm-nodejs-redux-thunk</packagereq>
       <packagereq type="default">tfm-nodejs-regenerator-runtime</packagereq>
-      <packagereq type="default">tfm-nodejs-reselect</packagereq>
       <packagereq type="default">tfm-nodejs-regenerator-runtime</packagereq>
+      <packagereq type="default">tfm-nodejs-reselect</packagereq>
       <packagereq type="default">tfm-nodejs-reselect</packagereq>
       <packagereq type="default">tfm-nodejs-sass-loader</packagereq>
       <packagereq type="default">tfm-nodejs-seamless-immutable</packagereq>
@@ -297,12 +297,14 @@
       <packagereq type="default">foreman-installer-katello</packagereq>
       <packagereq type="default">katello-certs-tools</packagereq>
       <packagereq type="default">katello-selinux</packagereq>
+      <packagereq type="default">keycloak-httpd-client-install</packagereq>	      
       <packagereq type="default">mod_passenger</packagereq>
       <packagereq type="default">pcp-mmvstatsd</packagereq>
       <packagereq type="default">puppet-agent-oauth</packagereq>
       <packagereq type="default">puppet-agent-puppet-strings</packagereq>
       <packagereq type="default">puppet-agent-rgen</packagereq>
       <packagereq type="default">puppet-agent-yard</packagereq>
+      <packagereq type="default">python2-keycloak-httpd-client-install</packagereq>
       <packagereq type="default">rubygem-bundler_ext</packagereq>
       <packagereq type="default">rubygem-clamp</packagereq>
       <packagereq type="default">rubygem-concurrent-ruby</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -410,6 +410,7 @@ foreman_nonscl_packages:
       build_package_tito_builder: "tito.builder.FetchBuilder"
     katello-certs-tools: {}
     katello-selinux: {}
+    keycloak-httpd-client-install: {}
     pcp-mmvstatsd: {}
     puppet-agent-oauth: {}
     puppet-agent-puppet-strings: {}

--- a/packages/foreman/keycloak-httpd-client-install/keycloak-httpd-client-install-1.2.2.tar.gz
+++ b/packages/foreman/keycloak-httpd-client-install/keycloak-httpd-client-install-1.2.2.tar.gz
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/K5/JG/SHA256E-s47282--983afacfc9a1a743e2f7a3812c2738c09f58a997c5d1549790aecbb7bb23ac71.tar.gz/SHA256E-s47282--983afacfc9a1a743e2f7a3812c2738c09f58a997c5d1549790aecbb7bb23ac71.tar.gz

--- a/packages/foreman/keycloak-httpd-client-install/keycloak-httpd-client-install.spec
+++ b/packages/foreman/keycloak-httpd-client-install/keycloak-httpd-client-install.spec
@@ -1,0 +1,73 @@
+# Created by pyp2rpm-3.3.2
+%global pypi_name keycloak-httpd-client-install
+%global summary Tools to configure Apache HTTPD as Keycloak client
+
+Name:           %{pypi_name}
+Version:        1.2.2
+Release:        1%{?dist}
+Summary:        %{summary}
+
+License:        GPLv3
+URL:            https://github.com/latchset/keycloak-httpd-client-install
+Source0:        https://files.pythonhosted.org/packages/source/k/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+ 
+BuildRequires:  python2-devel
+BuildRequires:  python2-setuptools
+
+Requires:       %{_bindir}/keycloak-httpd-client-install
+
+%description
+Keycloak is a federated Identity Provider (IdP). Apache HTTPD supports
+a variety of authentication modules which can be configured to utilize
+a Keycloak IdP to perform authentication. This package contains
+libraries and tools which can automate and simplify configuring an
+Apache HTTPD authentication module and registering as a client of a
+Keycloak IdP.
+
+%package -n     python2-%{pypi_name}
+Summary:        %{summary}
+
+%{?python_provide:%python_provide python2-%{pypi_name}}
+
+Requires:       %{name} = %{version}-%{release} 
+Requires:       python2-jinja2
+Requires:       python-lxml
+Requires:       python-requests
+Requires:       python2-requests-oauthlib
+Requires:       python-setuptools
+Requires:       python-six
+Requires:       %{_bindir}/keycloak-httpd-client-install
+
+%description -n python2-%{pypi_name}
+Keycloak is an authentication server. This package contains libraries and
+programs which can invoke the Keycloak REST API and configure clients
+of a Keycloak server.
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py2_build
+
+%install
+%py2_install
+install -d -m 755 %{buildroot}/%{_mandir}/man8
+install -c -m 644 doc/keycloak-httpd-client-install.8 %{buildroot}/%{_mandir}/man8
+
+%files
+%license LICENSE.txt
+%doc README.md doc/ChangeLog
+%{_datadir}/%{pypi_name}/
+
+%files -n python2-%{pypi_name}
+%{python2_sitelib}/*
+%{_bindir}/keycloak-httpd-client-install
+%{_bindir}/keycloak-rest
+%{_mandir}/man8/*
+
+%changelog
+* Wed Nov 20 2019 Amit Upadhye <upadhyeammit@gmail.com> - 1.2.2-1
+- Initial package.

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -25,6 +25,7 @@ whitelist = foreman-bootloaders-redhat
   foreman-selinux
   katello-certs-tools
   katello-selinux
+  keycloak-httpd-client-install
   pcp-mmvstatsd
   puppet-agent-oauth
   puppet-agent-puppet-strings


### PR DESCRIPTION
This package contains libraries and tools which can automate and simplify configuring an Apache HTTPD authentication module and registering as a client of a Keycloak IdP.
