### PR TITLE
Use package names, not provides in Obsoletes of the tfm package

### DIFF
--- a/packages/foreman/tfm/tfm.spec
+++ b/packages/foreman/tfm/tfm.spec
@@ -21,7 +21,7 @@
 Summary: Package that installs %scl
 Name: %scl_name
 Version: 5.0
-Release: 10%{?dist}
+Release: 11%{?dist}
 License: GPLv2+
 Group: Applications/File
 Source0: README
@@ -61,10 +61,10 @@ Obsoletes: ruby193-ruby-wrapper
 
 # Obsolete packages no longer carried within this SCL to both clean up
 # and to ensure smooth upgrades when old packages deps aren't satisified
-Obsoletes: %{scl_prefix}npm(babel-preset-es2015) < 6.6.0-4
-Obsoletes: %{scl_prefix}npm(flux) < 2.1.1-2
-Obsoletes: %{scl_prefix}npm(intl) < 1.2.5-2
-Obsoletes: %{scl_prefix}npm(moment) < 2.17.1-2
+Obsoletes: %{scl_prefix}nodejs-babel-preset-es2015 < 6.6.0-4
+Obsoletes: %{scl_prefix}nodejs-flux < 2.1.1-2
+Obsoletes: %{scl_prefix}nodejs-intl < 1.2.5-2
+Obsoletes: %{scl_prefix}nodejs-moment < 2.17.1-2
 Obsoletes: %{scl_prefix}rubygem-ace-rails-ap < 4.1.1-2
 Obsoletes: %{scl_prefix}rubygem-ansi < 1.4.3-7
 Obsoletes: %{scl_prefix}rubygem-archive-tar-minitar < 0.5.2-12
@@ -306,6 +306,9 @@ selinuxenabled && load_policy || :
 %{_root_sysconfdir}/rpm/macros.%{scl_name}-scldevel
 
 %changelog
+* Mon Dec 02 2019 Evgeni Golov - 5.0-11
+- Use package names, not provides in Obsoletes
+
 * Mon Nov 18 2019 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 5.0-10
 - Obsolete foreman_custom_parameters
 


### PR DESCRIPTION
rpm 4.15 does not allow anything else but package names in obsoletes
anymore

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 1.24
 * 1.23
 * 1.22

RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
