### PR TITLE
Use package names, not provides in Obsoletes of the f_openscap package

### DIFF
--- a/packages/plugins/rubygem-foreman_openscap/rubygem-foreman_openscap.spec
+++ b/packages/plugins/rubygem-foreman_openscap/rubygem-foreman_openscap.spec
@@ -8,7 +8,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 2.0.2
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman plug-in for displaying OpenSCAP audit reports
 Group: Applications/Systems
 License: GPLv3
@@ -30,8 +30,7 @@ BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
-%{?scl:Obsoletes: ruby193-rubygem-%{gem_name}}
-Obsoletes: %{?scl_prefix}rubygem(scaptimony) < 0.3.2-3
+Obsoletes: %{?scl_prefix}rubygem-scaptimony < 0.3.2-3
 
 %description
 Foreman plug-in for managing security compliance reports.
@@ -41,7 +40,6 @@ Foreman plug-in for managing security compliance reports.
 Summary: Documentation for %{pkg_name}
 Group: Documentation
 Requires: %{?scl_prefix}%{pkg_name} = %{version}-%{release}
-%{?scl:Obsoletes: ruby193-rubygem-%{gem_name}-doc}
 BuildArch: noarch
 
 %description doc
@@ -106,6 +104,9 @@ cp -pa .%{gem_dir}/* \
 exit 0
 
 %changelog
+* Mon Dec 02 2019 Evgeni Golov - 2.0.2-2
+- Use package names, not provides in Obsoletes
+
 * Fri Nov 15 2019 Ondrej Prazak <oprazak@redhat.com> 2.0.2-1
 - Update to 2.0.2
 


### PR DESCRIPTION
rpm 4.15 does not allow anything else but package names in obsoletes
anymore

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 1.24
 * 1.23
 * 1.22

RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
