### PR TITLE
Add recognition of cronjobs to gem2rpm templates

### DIFF
--- a/gem2rpm/foreman_plugin.spec.erb
+++ b/gem2rpm/foreman_plugin.spec.erb
@@ -11,6 +11,7 @@ LICENSES = JSON.load(File.read(File.join(root, 'licenses.json')))
 -%>
 %{?scl:%scl_package rubygem-%{gem_name}}
 %{!?scl:%global pkg_name %{name}}
+%{!?_root_sysconfdir:%global _root_sysconfdir %{_sysconfdir}}
 
 %global gem_name <%= spec.name %>
 %global plugin_name <%= spec.name.sub(/\Aforeman_/, '') %>
@@ -18,6 +19,7 @@ LICENSES = JSON.load(File.read(File.join(root, 'licenses.json')))
 <%
 has_assets = spec.files.any? { |f| f.start_with?('app/assets/') }
 has_apidoc = spec.files.any? { |f| f =~ %r{\Aapp/controllers/?.*/(api|concerns)/} }
+has_cronjob = spec.files.any? { |f| f =~ %r{\Aextra/.*\.cron\z} }
 has_db_migrations = spec.files.any? { |f| f.start_with?('db/migrate/') }
 has_db_seeds = spec.files.any? { |f| f.start_with?('db/seeds.d/') }
 has_webpack = spec.files.any? { |f| f.start_with?('webpack/') }
@@ -141,6 +143,10 @@ mkdir -p %{buildroot}%{gem_dir}
 cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
+<% if has_cronjob -%>
+mkdir -p %{buildroot}%{_root_sysconfdir}/cron.d/
+mv %{buildroot}%{gem_instdir}/extra/*.cron %{buildroot}%{_root_sysconfdir}/cron.d/%{gem_name}
+<% end -%>
 <% unless spec.extensions.empty? -%>
 mkdir -p %{buildroot}%{gem_extdir_mri}
 cp -a .%{gem_extdir_mri}/{gem.build_complete,*.so} %{buildroot}%{gem_extdir_mri}/
@@ -188,6 +194,9 @@ find %{buildroot}%{gem_instdir}/<%= spec.bindir %> -type f | xargs chmod a+x
 <% end -%>
 <% if has_assets -%>
 %{foreman_assets_plugin}
+<% end -%>
+<% if has_cronjob -%>
+%config(noreplace) %{_root_sysconfdir}/cron.d/%{gem_name}
 <% end -%>
 <% if has_webpack -%>
 %{foreman_webpack_plugin}

--- a/gem2rpm/smart_proxy_plugin.spec.erb
+++ b/gem2rpm/smart_proxy_plugin.spec.erb
@@ -4,6 +4,7 @@ require 'json'
 root = `git rev-parse --show-toplevel`.strip
 SCL_PREFIXES = JSON.load(File.read(File.join(root, 'scl_prefixes.json')))
 LICENSES = JSON.load(File.read(File.join(root, 'licenses.json')))
+has_cronjob = spec.files.any? { |f| f =~ %r{\Aextra/.*\.cron\z }
 -%>
 %{?scl:%scl_package rubygem-%{gem_name}}
 %{!?scl:%global pkg_name %{name}}
@@ -133,6 +134,10 @@ mkdir -p %{buildroot}%{foreman_proxy_settingsd_dir}
 <% config_file = config_file_path.split('/').last -%>
 mv %{buildroot}%{gem_instdir}/<%= config_file_path %> \
    %{buildroot}%{foreman_proxy_settingsd_dir}/<%= config_file.chomp('.example') %>
+<% if has_cronjob -%>
+mkdir -p %{buildroot}%{_root_sysconfdir}/cron.d/
+mv %{buildroot}%{gem_instdir}/extra/*.cron %{buildroot}%{_root_sysconfdir}/cron.d/%{gem_name}
+<% end -%>
 <% end -%>
 
 %files
@@ -148,6 +153,9 @@ mv %{buildroot}%{gem_instdir}/<%= config_file_path %> \
 <% config_file_paths = config_file_paths.map { |path| path.split('/').last.chomp('.example') } -%>
 <% config_file_paths.each do |config_file_path| -%>
 %config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/<%= config_file_path %>
+<% if has_cronjob -%>
+%config(noreplace) %{_root_sysconfdir}/cron.d/%{gem_name}
+<% end -%>
 <% end -%>
 <%= main_file_entries(spec) %>
 <% unless doc_subpackage -%>


### PR DESCRIPTION
I think this would be a useful addition to the templates, so we hopefully do not lose a cronjob if someone regenerates a spec. 

Search for them in a subdirectory `extra` from the gem with pattern `*cron*` was my best idea and it works at least for one cronjob, but if someone has a better idea, I am more than happy to change the logic.