### PR TITLE
Move omaha update script to correct directory for cron

### DIFF
--- a/plugins/smart_proxy_omaha/changelog
+++ b/plugins/smart_proxy_omaha/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-omaha (0.0.5-2) stable; urgency=medium
+
+  * Fix update script installation directory
+
+ -- Lennart Weller <lennart.weller@hansemerkur.de>  Wed, 08 Jan 2020 12:55:40 +0100
+
 ruby-smart-proxy-omaha (0.0.5-1) stable; urgency=medium
 
   * Initial release.

--- a/plugins/smart_proxy_omaha/install
+++ b/plugins/smart_proxy_omaha/install
@@ -1,3 +1,3 @@
 debian/omaha.rb usr/share/foreman-proxy/bundler.d
 settings.d/omaha.yml etc/foreman-proxy/settings.d
-extra/foreman-proxy-omaha-sync.cron /etc/cron.daily/foreman-proxy-omaha-sync
+extra/foreman-proxy-omaha-sync.cron /etc/cron.daily


### PR DESCRIPTION
By my mistake the update cron script is installed into a subdirectory of cron.daily which is not being executed by cron. This change corrects that mistake.