### PR TITLE
Refs #28068 - Include dynflow-sidekiq.rb

### DIFF
--- a/debian/bionic/foreman/foreman-dynflow-sidekiq.install
+++ b/debian/bionic/foreman/foreman-dynflow-sidekiq.install
@@ -1,3 +1,4 @@
+extras/dynflow-sidekiq.rb /usr/share/foreman/extras
 extras/systemd/dynflow-sidekiq@.service /lib/systemd/system
 bundler.d/dynflow_sidekiq.rb /usr/share/foreman/bundler.d
 config/dynflow/orchestrator.yml etc/foreman/dynflow

--- a/debian/buster/foreman/foreman-dynflow-sidekiq.install
+++ b/debian/buster/foreman/foreman-dynflow-sidekiq.install
@@ -1,3 +1,4 @@
+extras/dynflow-sidekiq.rb /usr/share/foreman/extras
 extras/systemd/dynflow-sidekiq@.service /lib/systemd/system
 bundler.d/dynflow_sidekiq.rb /usr/share/foreman/bundler.d
 config/dynflow/orchestrator.yml etc/foreman/dynflow


### PR DESCRIPTION
This file is needed to start dynflow-sidekiq@.service since it's mentioned as a --require path.