### PR TITLE
Create gem name folder to put nokogiri.so into it.

### DIFF
--- a/packages/foreman/rubygem-nokogiri/rubygem-nokogiri.spec
+++ b/packages/foreman/rubygem-nokogiri/rubygem-nokogiri.spec
@@ -6,7 +6,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.8.4
-Release: 4%{?dist}
+Release: 5%{?dist}
 Summary: Nokogiri (鋸) is an HTML, XML, SAX, and Reader parser
 Group: Development/Languages
 License: MIT
@@ -70,9 +70,9 @@ mkdir -p %{buildroot}%{gem_dir}
 cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
-mkdir -p %{buildroot}%{gem_extdir_mri}
+mkdir -p %{buildroot}%{gem_extdir_mri}/%{gem_name}
 cp -a .%{gem_extdir_mri}/gem.build_complete %{buildroot}%{gem_extdir_mri}/
-cp -a .%{gem_extdir_mri}/%{gem_name}/*.so %{buildroot}%{gem_extdir_mri}/%{gem_name}
+cp -a .%{gem_extdir_mri}/%{gem_name}/*.so %{buildroot}%{gem_extdir_mri}/%{gem_name}/
 
 
 # Prevent dangling symlink in -debuginfo (rhbz#878863).
@@ -123,6 +123,9 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 %{gem_instdir}/test
 
 %changelog
+* Tue Jan 21 2020 Zach Huntington-Meath <zhunting@redhat.com> 1.8.4-5
+- Bump to fix issue with nokogiri.so placement
+
 * Mon Jan 20 2020 Zach Huntington-Meath <zhunting@redhat.com> 1.8.4-4
 - Bump to fix issue with nokogiri.so placement
 


### PR DESCRIPTION
Realized that it wasn't copying over nokogiri.so correctly, it was instead renaming it as nokogiri. This creates the folder it's supposed to go into and then correclty copies nokogiri.so there.