### PR TITLE
Fixes #28872 - Update secure_headers to 6.3.0

### DIFF
--- a/packages/foreman/rubygem-secure_headers/rubygem-secure_headers.spec
+++ b/packages/foreman/rubygem-secure_headers/rubygem-secure_headers.spec
@@ -5,7 +5,7 @@
 
 Summary: Security related headers all in one gem
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 6.0.0
+Version: 6.3.0
 Release: 1%{?dist}
 Group: Development/Languages
 License: ASL 2.0
@@ -72,6 +72,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Tue Jan 28 2020 Michael Moll <mmoll@mmoll.at> 6.3.0-1
+- Update secure_headers to 6.3.0
+
 * Mon Sep 10 2018 Michael Moll <mmoll@mmoll.at> 6.0.0-1
 - Update secure_headers to 6.0.0
 

--- a/packages/foreman/rubygem-secure_headers/secure_headers-6.0.0.gem
+++ b/packages/foreman/rubygem-secure_headers/secure_headers-6.0.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/vV/61/SHA256E-s57344--85dda4a30ca2ad4ca34552b1543dd2078a5aea9ac733d0a3d68f6e2f51649d9d.0.gem/SHA256E-s57344--85dda4a30ca2ad4ca34552b1543dd2078a5aea9ac733d0a3d68f6e2f51649d9d.0.gem

--- a/packages/foreman/rubygem-secure_headers/secure_headers-6.3.0.gem
+++ b/packages/foreman/rubygem-secure_headers/secure_headers-6.3.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/KF/f0/SHA256E-s57344--b625fa76c071cba2dbc68b96d56cd092bb62ef9f5c6dcfd9d21ccebcaa226ec0.0.gem/SHA256E-s57344--b625fa76c071cba2dbc68b96d56cd092bb62ef9f5c6dcfd9d21ccebcaa226ec0.0.gem


### PR DESCRIPTION
(cherry picked from commit fe3e41daa971eda375987a8b00b5f6268acbf61d)