### PR TITLE
Fixes #28939 - change-hostname: update DNS records when changing hostname

### DIFF
--- a/packages/katello/katello/helper.rb
+++ b/packages/katello/katello/helper.rb
@@ -12,6 +12,14 @@ module KatelloUtilities
       '/etc/foreman-installer/scenarios.d'
     end
 
+    def hammer_root_config_path
+      '/root/.hammer/cli.modules.d'
+    end
+
+    def hammer_config_path
+      '/etc/hammer/cli.modules.d'
+    end
+
     def last_scenario_yaml
       "#{scenarios_path}/last_scenario.yaml"
     end

--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -362,7 +362,7 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
         a_record = resolver.getresource(@old_hostname, Resolv::DNS::Resource::IN::A)
         commands << "update delete #{@old_hostname} A"
         commands << "update add #{@new_hostname} #{a_record.ttl} A #{a_record.address}"
-      rescue resolv.ResolvError
+      rescue Resolv::ResolvError
         # This is fine
       end
 
@@ -370,7 +370,7 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
         aaaa_record = resolver.getresource(@old_hostname, Resolv::DNS::Resource::IN::AAAA)
         commands << "update delete #{@old_hostname} AAAA"
         commands << "update add #{@new_hostname} #{aaaa_record.ttl} A #{aaaa_record.address}"
-      rescue resolv.ResolvError
+      rescue Resolv::ResolvError
         # This is fine
       end
 

--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -332,8 +332,7 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
       "echo -e \"#{dns_entries}\" | nsupdate -l -k #{key_file}"
     end
 
-    def update_zone(zone, nameserver_ip)
-      resolver = Resolv::DNS.new(nameserver: [nameserver_ip], search: [], ndots: 1)
+    def update_zone(zone, nameserver_ip, resolver)
       commands = []
 
       soa = resolver.getresource(zone, Resolv::DNS::Resource::IN::SOA)
@@ -370,12 +369,13 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
     end
 
     def assembled_nsupdate_command(d)
+      resolver = Resolv::DNS.new(nameserver: [nameserver_ip], search: [], ndots: 1)
       commands = ["local #{d.dns_server}", "zone #{d.zone}"]
-      commands += update_zone(d.zone, d.dns_server)
+      commands += update_zone(d.zone, d.dns_server, resolver)
       commands << "send\n"
       d.reverse_zones.each do |zone|
         commands << "zone #{zone}"
-        commands += update_zone(zone, d.dns_server)
+        commands += update_zone(zone, d.dns_server, resolver)
         commands << "send\n"
       end
       STDOUT.puts(commands.join("\n"))

--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -293,8 +293,7 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
     def dns_managed?
       @scenario_answers['foreman_proxy']['dns'] &&
         @scenario_answers['foreman_proxy']['dns_managed'] &&
-        %w[nsupdate nsupdate_gss]
-          .include?(@scenario_answers['foreman_proxy']['dns_provider'])
+        @scenario_answers['foreman_proxy']['dns_provider'] == 'nsupdate'
     end
 
     def should_update_dns?

--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -111,13 +111,11 @@ module KatelloUtilities
 
         @answers_dns_values.each do |field, v|
           next unless v.nil?
-            fail_with_message """
-      Error gathering DNS data: couldn't find value for '#{field}'.
-      Make sure /etc/foreman-installer/scenarios.d/#{@options[:scenario]}-answers.yaml
-      'foreman-proxy' section has values for dns_zone, dns_reverse, and keyfile.
-      Make sure A and SOA records are present for #{@old_hostname}.
-  """
-          end
+          fail_with_message """
+    Error gathering DNS data: couldn't find value for '#{field}'
+    Make sure #{scenarios_path}/#{@options[:scenario]}-answers.yaml
+    has not been modified, or re-run with the --skip-dns option.
+"""
         end
 
       end
@@ -293,7 +291,8 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
     end
 
     def dns_managed?
-      @scenario_answers['foreman_proxy']['dns'] &&
+      @scenario_answers['foreman_proxy'].is_a?(Hash) &&
+        @scenario_answers['foreman_proxy']['dns'] &&
         @scenario_answers['foreman_proxy']['dns_managed'] &&
         @scenario_answers['foreman_proxy']['dns_provider'] == 'nsupdate'
     end
@@ -307,7 +306,7 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
         nameserver_ip: @scenario_answers['foreman_proxy']['dns_server'],
         zone: @scenario_answers['foreman_proxy']['dns_zone'],
         key_file: @scenario_answers['foreman_proxy']['keyfile'],
-        reverse_zones: [@scenario_answers['foreman_proxy']['dns_reverse']].flatten
+        reverse_zones: [@scenario_answers['foreman_proxy']['dns_reverse']].flatten.compact
       }
     end
 

--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -343,7 +343,7 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
       commands << "update add #{zone}. 3600 IN NS #{@new_hostname}."
       commands << "update delete #{zone}. IN NS #{@old_hostname}"
 
-      return commands if zone.include?('arpa') # don't modify A records for reverse zones
+      return commands if zone.end_with?('arpa') # don't modify A records for reverse zones
 
       begin
         a_record = resolver.getresource(@old_hostname, Resolv::DNS::Resource::IN::A)


### PR DESCRIPTION
When applicable, this change updates DNS records using `nsupdate` during the `[scenario]-change-hostname` script.

To test on a sat-deploy box:
* make sure DNS is managed by satellite (run the satellite-provisioning playbook)
* View the contents of `/var/named/dynamic`

```
sudo su
cd /var/named/dynamic
ls -l
```
You should see a DNS zone file named for your zone, such as `db.example.com`.  Inspect the contents and note that they contain the current satellite hostname in the SOA, A, and NS records:
```
[root@sat-6-7-qa-rhel7 dynamic]# cat db.example.com
$TTL 10800
@ IN SOA sat-6-7-qa-rhel7.redhatlaptop.example.com. root.example.com. (
	1	;Serial
	86400	;Refresh
	3600	;Retry
	604800	;Expire
	3600	;Negative caching TTL
)

@ IN NS sat-6-7-qa-rhel7.redhatlaptop.example.com.

sat-6-7-qa-rhel7.redhatlaptop.example.com. IN A 192.168.73.1
```
The reverse zone file (named similar to `db.73.168.192.in-addr.arpa`) will also contain records referring to the current hostname.

* Set permissions on `hostname-change.rb`:
```
cd /usr/share/katello
chmod a+w hostname-change.rb
```

* On your local machine in the `sat-deploy` directory, run
```
vagrant ssh-config [box_name]
```
* Take note of the IdentityFile and HostName values (HostName will actually be an IP)

* Copy the new `hostname-change.rb` from this PR to the sat-deploy box using `scp`:
```
scp -i $IDENTITY_FILE $LOCAL_HOSTNAME_CHANGE.RB vagrant@$HOSTNAME:/usr/share/katello/hostname-change.rb
```
* Verify using `cat` or `vim` that the `hostname-change.rb` contents successfully copied over
* Repeat the above with `helper.rb`

* Run
```
vim /etc/foreman-installer/scenarios.d/satellite-answers.yaml
```
* Edit the `dns_provider` value (under `foreman_proxy:`) to read `nsupdate`

* Run 
```
satellite-change-hostname -u admin -p changeme newhost.mydomain.example.com
```
* View new output
```
gathering DNS data...
updating DNS records:
forward...
reverse...
updating dynamic zone files...
DNS records updated
```

* Verify that the contents of the zone files `/var/named/db.$ZONE` now reflect the new hostname

This should allow PXE discovery to continue to work properly.



