### PR TITLE
Cherry pick tfm changes to 2.0

### DIFF
--- a/packages/foreman/tfm/macros.tfm
+++ b/packages/foreman/tfm/macros.tfm
@@ -1,0 +1,13 @@
+%gem_install(d:n:) \
+mkdir -p %{-d*}%{!?-d:.%{gem_dir}} \
+\
+CONFIGURE_ARGS="--with-cflags='%{optflags}' $CONFIGURE_ARGS" \\\
+gem install \\\
+        -V \\\
+        --local \\\
+        --build-root %{-d*}%{!?-d:.} \\\
+        --force \\\
+        --document=ri,rdoc \\\
+        --bindir %{_bindir} \\\
+        %{-n*}%{!?-n:%{gem_name}-%{version}%{?prerelease}.gem} \
+%{nil}

--- a/packages/foreman/tfm/tfm.spec
+++ b/packages/foreman/tfm/tfm.spec
@@ -19,13 +19,14 @@
 Summary: Package that installs %scl
 Name: %scl_name
 Version: 6.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 License: GPLv2+
 Group: Applications/File
 Source0: README
 Source1: LICENSE
 Source2: tfm.attr
 Source3: nodejs-symlink-deps
+Source4: macros.tfm
 # This should be removed as soon as scl-utils automatically generate
 # dependencies on scl -runtime (rhbz#1054711).
 Requires: %{scl_runtime}
@@ -264,6 +265,7 @@ EOR
 EOF
 
 install -pm0755 %{SOURCE3} %{buildroot}%{_rpmconfigdir}/nodejs-symlink-deps
+install -m 644 %{SOURCE4} %{buildroot}%{_root_sysconfdir}/rpm/macros.tfm
 
 %post runtime
 # Simple copy of context from system root to DSC root.
@@ -294,6 +296,7 @@ selinuxenabled && load_policy || :
 %files build
 %license LICENSE
 %{_root_sysconfdir}/rpm/macros.%{scl}-config
+%{_root_sysconfdir}/rpm/macros.tfm
 %{_rpmconfigdir}/fileattrs
 %{_rpmconfigdir}/nodejs-symlink-deps
 
@@ -302,6 +305,9 @@ selinuxenabled && load_policy || :
 %{_root_sysconfdir}/rpm/macros.%{scl_name}-scldevel
 
 %changelog
+* Thu Feb 20 2020 Eric D. Helms <ericdhelms@gmail.com> - 6.0-3
+- Include gem install macro
+
 * Tue Feb 11 2020 Ondrej Ezr - 6.0-2
 - Obsoletes tfm-rubygem-jquery-turbolinks
 

--- a/packages/foreman/tfm/tfm.spec
+++ b/packages/foreman/tfm/tfm.spec
@@ -19,7 +19,7 @@
 Summary: Package that installs %scl
 Name: %scl_name
 Version: 6.0
-Release: 3%{?dist}
+Release: 4%{?dist}
 License: GPLv2+
 Group: Applications/File
 Source0: README
@@ -116,6 +116,10 @@ Obsoletes: %{scl_prefix}rubygem-foreman-opennebula < 4.8.0-7
 Obsoletes: %{scl_prefix}rubygem-fog < 1.42.1-3
 Obsoletes: %{scl_prefix}rubygem-extlib < 0.9.16-7
 Obsoletes: %{scl_prefix}rubygem-docker-api < 1.28.0-5
+
+# turbolinks isn't there to obsolete the tfm-ror52 package so this is explicit
+Obsoletes: tfm-ror52-rubygem-turbolinks < 2.5.4-3
+Obsoletes: tfm-ror52-rubygem-turbolinks-doc < 2.5.4-3
 
 %description runtime
 Package shipping essential scripts to work with %scl Software Collection.
@@ -305,6 +309,9 @@ selinuxenabled && load_policy || :
 %{_root_sysconfdir}/rpm/macros.%{scl_name}-scldevel
 
 %changelog
+* Wed Feb 26 2020 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 6.0-4
+- Obsolete tfm-ror52-rubygem-turbolinks (#29181)
+
 * Thu Feb 20 2020 Eric D. Helms <ericdhelms@gmail.com> - 6.0-3
 - Include gem install macro
 


### PR DESCRIPTION
This fixes the builds of Ruby packages that provide bins. It also obsoletes turbolinks which allows users to upgrade.