### PR TITLE
Cherry pick a PostgreSQL upgrade bug

### DIFF
--- a/packages/foreman/foreman-installer/foreman-installer-2.0.0-upstream-postgresql-upgrade.patch
+++ b/packages/foreman/foreman-installer/foreman-installer-2.0.0-upstream-postgresql-upgrade.patch
@@ -1,0 +1,31 @@
+From f08b7849c358c93fe4a8c144183a2474dd3ff438 Mon Sep 17 00:00:00 2001
+From: Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl>
+Date: Thu, 5 Mar 2020 20:11:40 +0100
+Subject: [PATCH] Refs #28903 - Swap the postgresql{,-server} removal
+
+postgresql can't be removed until postgresql-server is removed.
+72d7c3f67fd4e1b131871c946d03808c9d26a124 caused the order to be swapped.
+This ensures a correct order.
+
+(cherry picked from commit 9674a9585efc15d32a3aff4a3551e99dab3d7144)
+---
+ hooks/pre/30-el7_upgrade_postgresql.rb | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/hooks/pre/30-el7_upgrade_postgresql.rb b/hooks/pre/30-el7_upgrade_postgresql.rb
+index 0fa9931..8f0a8a8 100644
+--- a/hooks/pre/30-el7_upgrade_postgresql.rb
++++ b/hooks/pre/30-el7_upgrade_postgresql.rb
+@@ -10,7 +10,8 @@ def postgresql_12_upgrade
+   ensure_packages(server_packages, 'installed')
+ 
+   execute(%(scl enable rh-postgresql12 "PGSETUP_INITDB_OPTIONS='--lc-collate=#{collate} --lc-ctype=#{ctype} --locale=#{collate}' postgresql-setup --upgrade"))
+-  ensure_packages(['postgresql', 'postgresql-server'], 'absent')
++  ensure_packages(['postgresql-server'], 'absent')
++  ensure_packages(['postgresql'], 'absent')
+   execute('rm -f /etc/systemd/system/postgresql.service')
+   ensure_packages(['rh-postgresql12-syspaths'], 'installed')
+ end
+-- 
+2.24.1
+

--- a/packages/foreman/foreman-installer/foreman-installer.spec
+++ b/packages/foreman/foreman-installer/foreman-installer.spec
@@ -1,4 +1,4 @@
-%global release 2
+%global release 3
 %global prereleasesource rc2
 %global prerelease %{?prereleasesource}
 
@@ -11,6 +11,8 @@ Group:      Applications/System
 License:    GPLv3+ and ASL 2.0
 URL:        https://theforeman.org
 Source0:    https://downloads.theforeman.org/%{name}/%{name}-%{version}%{?prerelease:-}%{?prerelease}.tar.bz2
+
+Patch0:     foreman-installer-2.0.0-upstream-postgresql-upgrade.patch
 
 BuildArch:  noarch
 
@@ -50,6 +52,8 @@ Various scenarios and tools for the Katello ecosystem
 
 %prep
 %setup -q -n %{name}-%{version}%{?prerelease:-}%{?prerelease}
+
+%patch0 -p1
 
 %build
 #replace shebangs for SCL
@@ -141,6 +145,9 @@ done
 %{_sbindir}/foreman-proxy-certs-generate
 
 %changelog
+* Mon Mar 09 2020 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1:2.0.0-0.3.rc2
+- Cherry pick a PostgreSQL upgrade bug (#28903)
+
 * Thu Mar 05 2020 Evgeni Golov - 1:2.0.0-0.2.rc2
 - Release foreman-installer 2.0.0
 


### PR DESCRIPTION
PostgreSQL can't be removed until postgresql-server is removed. This prevents upgrades. It's done as a packaging only patch since this only affects EL7.