### PR TITLE
Set mock package_manager on EL7

### DIFF
--- a/mock/el7-nonscl.cfg
+++ b/mock/el7-nonscl.cfg
@@ -7,6 +7,7 @@ config_opts['chroot_setup_cmd'] = 'install @buildsys-build yum vim'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 # beware RHEL use 7Server or 7Client
 config_opts['releasever'] = '7'
+config_opts['package_manager'] = 'yum'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock/el7-scl.cfg
+++ b/mock/el7-scl.cfg
@@ -5,6 +5,7 @@ config_opts['chroot_setup_cmd'] = 'install @buildsys-build scl-utils-build tfm-b
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 # beware RHEL use 7Server or 7Client
 config_opts['releasever'] = '7'
+config_opts['package_manager'] = 'yum'
 
 config_opts['yum.conf'] = """
 [main]


### PR DESCRIPTION
When building on Fedora 31, this is needed. Otherwise mock attempts to use dnf.