### PR TITLE
Update GH pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,6 @@
 For plugin updates, please indicate which repos this should be built into:
 
-* [x] Nightly
-* [ ] 1.21
-* [ ] 1.20
+* Nightly
 
 See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
 


### PR DESCRIPTION
We are not doing good job in keeping this one up to date in `deb/develop` and `rpm/develop` branches. Only CLI GH tools use them, GH Web appears to be using the template from master. It's expected that CLI user knowns what she is doing, so simplified version is ok.