### PR TITLE
Refs #29144 - Use systemd socket activation

### DIFF
--- a/debian/bionic/foreman/foreman-service.install
+++ b/debian/bionic/foreman/foreman-service.install
@@ -1,2 +1,3 @@
 extras/systemd/foreman.service /lib/systemd/system
+extras/systemd/foreman.socket /lib/systemd/system
 bundler.d/service.rb /usr/share/foreman/bundler.d

--- a/debian/bionic/foreman/rules
+++ b/debian/bionic/foreman/rules
@@ -24,7 +24,7 @@ build:
 	/bin/rm db/production.sqlite3
 	/bin/sed -ri '1sXenv rubyXenv foreman-rubyX' bin/*
 	/bin/sed -ri 's~^BUNDLER_CMD=""~BUNDLER_CMD="/usr/bin/foreman-ruby /usr/bin/bundle exec"~' script/foreman-rake
-	/bin/sed -ri '/^ExecStart/ s#/usr/bin/rails#/usr/bin/bundle exec rails#' extras/systemd/foreman.service
+	/bin/sed -ri '/^ExecStart/ s#=#=/usr/bin/bundle exec --keep-file-descriptors #' extras/systemd/foreman.service
 	/bin/sed -ri '/^ExecStart/ s#/usr/bin/sidekiq#/usr/bin/bundle exec sidekiq#' extras/systemd/dynflow-sidekiq@.service
 	/bin/mkdir -p .ssh
 	/usr/bin/touch build
@@ -36,6 +36,6 @@ override_dh_installinit:
 	dh_installinit
 
 override_dh_systemd_enable:
-	dh_systemd_enable
+	dh_systemd_enable --package=foreman-service
 	dh_systemd_enable --name=dynflow-sidekiq@orchestrator --package=foreman-dynflow-sidekiq
 	dh_systemd_enable --name=dynflow-sidekiq@worker --package=foreman-dynflow-sidekiq

--- a/debian/buster/foreman/foreman-service.install
+++ b/debian/buster/foreman/foreman-service.install
@@ -1,2 +1,3 @@
 extras/systemd/foreman.service /lib/systemd/system
+extras/systemd/foreman.socket /lib/systemd/system
 bundler.d/service.rb /usr/share/foreman/bundler.d

--- a/debian/buster/foreman/rules
+++ b/debian/buster/foreman/rules
@@ -21,7 +21,7 @@ build:
 	/bin/rm db/production.sqlite3
 	/bin/sed -ri '1sXenv rubyXenv foreman-rubyX' bin/*
 	/bin/sed -ri 's~^BUNDLER_CMD=""~BUNDLER_CMD="/usr/bin/foreman-ruby /usr/bin/bundle exec"~' script/foreman-rake
-	/bin/sed -ri '/^ExecStart/ s#/usr/bin/rails#/usr/bin/bundle exec rails#' extras/systemd/foreman.service
+	/bin/sed -ri '/^ExecStart/ s#=#=/usr/bin/bundle exec --keep-file-descriptors #' extras/systemd/foreman.service
 	/bin/sed -ri '/^ExecStart/ s#/usr/bin/sidekiq#/usr/bin/bundle exec sidekiq#' extras/systemd/dynflow-sidekiq@.service
 	/bin/mkdir -p .ssh
 	/usr/bin/touch build
@@ -33,6 +33,6 @@ override_dh_installinit:
 	dh_installinit
 
 override_dh_systemd_enable:
-	dh_systemd_enable
+	dh_systemd_enable --package=foreman-service
 	dh_systemd_enable --name=dynflow-sidekiq@orchestrator --package=foreman-dynflow-sidekiq
 	dh_systemd_enable --name=dynflow-sidekiq@worker --package=foreman-dynflow-sidekiq


### PR DESCRIPTION
This gives reliable service restarts since systemd keeps the socket open. bundle exec needs to be called with --keep-file-descriptors since systemd passes these in. The replacement is changed since the service now uses /usr/share/foreman/bin/rails which doesn't need replacing.

It also makes sure the service enable is called on the foreman-service subpackage rather than the main package.

Depends on theforeman/foreman#7536

This PR replaces https://github.com/theforeman/foreman-packaging/pull/4894 with a correct branch name.