### PR TITLE
Add Dockerfile for building and running repoclosure

### DIFF
--- a/repoclosure/Dockerfile
+++ b/repoclosure/Dockerfile
@@ -1,0 +1,8 @@
+FROM centos:8
+
+RUN dnf -y install dnf-utils
+
+RUN mkdir -p /app/repoclosure
+WORKDIR /app/repoclosure
+
+ENTRYPOINT ["/usr/bin/dnf", "repoclosure"]


### PR DESCRIPTION
We face a problem where EL7 based repoclosure tool can't handle EL8. Therefore, on our CI we need to run the dnf repoclosure. This would require either EL8 based Jenkins nodes or running via a container. This adds a simple Dockerfile that builds a container that can run repoclosure:

For example:

```
podman run --rm --volume $(pwd)/:/app/repoclosure/:Z repoclosure -c repoclosure/yum.conf --check downloaded_rpms --repofrompath=downloaded_rpms,downloaded_rpms/rhel7 --repo downloaded_rpms
```

If wrapped in a script it would look like:

```
./repoclosure.sh  -c repoclosure/yum.conf --check downloaded_rpms --repofrompath=downloaded_rpms,downloaded_rpms/rhel7 --repo downloaded_rpms
```

And obal would look none the wiser:

```
obal repoclosure
```

Further, we can wrap this into a script or build it directly into Obal as part of the repoclosure command to pull the container image and run repoclosure. I am raising here to get some thoughts from others on where this should live and how we should call it.