### PR TITLE
Add images/ and fonts/ to exclude of plugin webpack builds

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -9,7 +9,7 @@
 %global scl_ruby_bin /usr/bin/%{?scl:%{scl_prefix}}ruby
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 6
+%global release 7
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -857,7 +857,10 @@ GEMFILE
 # Common assets locations
 %%%{name}_assets_plugin %%{gem_instdir}/public/assets/%%{gem_name}
 # Common webpack locations
-%%%{name}_webpack_plugin %%{gem_instdir}/public/webpack/%%{gem_name}
+%%%{name}_webpack_plugin \\
+%%{gem_instdir}/public/webpack/%%{gem_name} \\
+%%exclude %%{gem_instdir}/public/webpack/fonts/ \\
+%%exclude %%{gem_instdir}/public/webpack/images/
 %%%{name}_webpack_foreman %%{foreman_dir}/public/webpack/%%{gem_name}
 # Common apipie locations
 %%%{name}_apipie_cache_plugin %%{gem_instdir}/public/apipie-cache/plugin/%%{gem_name}
@@ -1003,6 +1006,9 @@ exit 0
 %systemd_postun_with_restart %{name}.service
 
 %changelog
+* Tue Apr 07 2020 Evgeni Golov - 2.1.0-0.7.develop
+- Add images/ and fonts/ to exclude of plugin webpack builds
+
 * Thu Mar 26 2020 Eric D. Helms <ericdhelms@gmail.com> - 2.1.0-0.6.develop
 - Stop dynflow service before removal
 


### PR DESCRIPTION
new @theforeman/vendor makes webpack deploy pf4 artifacts into those
folders, but they are only really needed for foreman itself, not plugins

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
