### PR TITLE
Add module_hotfixes to repo configurations

### DIFF
--- a/packages/foreman/foreman-release/foreman-plugins.repo
+++ b/packages/foreman/foreman-release/foreman-plugins.repo
@@ -4,6 +4,7 @@ baseurl=https://yum.theforeman.org/plugins/nightly/$DIST/$basearch
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+module_hotfixes=1
 
 [foreman-plugins-source]
 name=Foreman plugins nightly - source

--- a/packages/foreman/foreman-release/foreman-release.spec
+++ b/packages/foreman/foreman-release/foreman-release.spec
@@ -13,7 +13,7 @@
 %define repo_dist %{dist}
 %endif
 
-%global release 2
+%global release 3
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -109,6 +109,9 @@ install -Dpm0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-f
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman
 
 %changelog
+* Wed Apr 22 2020 Eric D. Helms <ericdhelms@gmail.com> - 2.1.0-0.3.develop
+- Add module_hotfixes to repo files
+
 * Tue Apr 07 2020 Zach Huntington-Meath <zhunting@redhat.com> - 2.1.0-0.2.develop
 - Bump to release for EL8
 

--- a/packages/foreman/foreman-release/foreman.repo
+++ b/packages/foreman/foreman-release/foreman.repo
@@ -4,6 +4,7 @@ baseurl=https://yum.theforeman.org/releases/nightly/$DIST/$basearch
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+module_hotfixes=1
 
 [foreman-source]
 name=Foreman nightly - source

--- a/packages/foreman/foreman-release/pulp.repo
+++ b/packages/foreman/foreman-release/pulp.repo
@@ -4,3 +4,4 @@ baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/stable/latest/$releasever
 gpgkey=https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2
 enabled=1
 gpgcheck=1
+module_hotfixes=1

--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -7,7 +7,7 @@
 
 %global prereleasesource nightly
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 3
+%global release 4
 
 Name:           katello-repos
 Version:        3.15.0
@@ -80,6 +80,9 @@ rm -rf %{buildroot}
 %config %{repo_dir}/*.repo
 
 %changelog
+* Wed Apr 22 2020 Eric D. Helms <ericdhelms@gmail.com> - 3.15.0-0.4.nightly
+- Add module_hotfixes to repo files
+
 * Fri Dec 13 2019 Evgeni Golov - 3.15.0-0.3.nightly
 - Add pulpcore repository
 

--- a/packages/katello/katello-repos/katello.repo
+++ b/packages/katello/katello-repos/katello.repo
@@ -6,6 +6,7 @@ baseurl=https://fedorapeople.org/groups/katello/releases/yum/@REPO_VERSION@/kate
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=@REPO_GPGCHECK@
+module_hotfixes=1
 
 [pulp]
 name=Pulp Community Release
@@ -13,6 +14,7 @@ baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/@PULP_URL_MIDDLE@/$releas
 gpgkey=https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2
 enabled=1
 gpgcheck=@PULP_GPG_CHECK@
+module_hotfixes=1
 
 # Candlepin RPMs as supported by Katello - This is a coordinated
 # copy of Candlepin's packages in order to ensure compatibility
@@ -23,6 +25,7 @@ baseurl=https://fedorapeople.org/groups/katello/releases/yum/@REPO_VERSION@/cand
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=@REPO_GPGCHECK@
+module_hotfixes=1
 
 [katello-pulpcore]
 name=pulpcore: Fetch, Upload, Organize, and Distribute Software Packages.
@@ -30,6 +33,7 @@ baseurl=https://fedorapeople.org/groups/katello/releases/yum/@REPO_VERSION@/pulp
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=@REPO_GPGCHECK@
+module_hotfixes=1
 
 # source repositories
 


### PR DESCRIPTION
This avoids issues where a module provides the same RPM as the
repositories and creates a conflict at install time. An RPM from
a module is preferred over a non-modular repository without this
change.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
