### PR TITLE
Drop sqlite

### DIFF
--- a/comps/comps-foreman-el8.xml
+++ b/comps/comps-foreman-el8.xml
@@ -36,7 +36,6 @@
       <packagereq type="default">foreman-release-scl</packagereq>
       <packagereq type="default">foreman-selinux</packagereq>
       <packagereq type="default">foreman-service</packagereq>
-      <packagereq type="default">foreman-sqlite</packagereq>
       <packagereq type="default">foreman-telemetry</packagereq>
       <packagereq type="default">foreman-vmware</packagereq>
       <packagereq type="default">gyp</packagereq>

--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -34,7 +34,6 @@
       <packagereq type="default">foreman-release-scl</packagereq>
       <packagereq type="default">foreman-selinux</packagereq>
       <packagereq type="default">foreman-service</packagereq>
-      <packagereq type="default">foreman-sqlite</packagereq>
       <packagereq type="default">foreman-telemetry</packagereq>
       <packagereq type="default">foreman-vmware</packagereq>
       <packagereq type="default">tfm</packagereq>

--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -9,7 +9,7 @@
 %global scl_ruby_bin /usr/bin/%{?scl:%{scl_prefix}}ruby
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 16
+%global release 17
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -31,6 +31,7 @@ Conflicts: foreman-tasks < 0.11.0-2
 Conflicts: foreman-release-scl < 7-1
 
 Obsoletes: foreman-compute < %{version}-%{release}
+Obsoletes: foreman-sqlite < %{version}-%{release}
 Obsoletes: %{?scl_prefix}rubygem-foreman_userdata
 
 Requires: %{?scl_prefix_ruby}ruby(release)
@@ -158,11 +159,6 @@ BuildRequires: %{?scl_prefix_ruby}rubygems
 BuildRequires: %{?scl_prefix_ruby}rubygem(rake) >= 0.8.3
 BuildRequires: %{?scl_prefix_ruby}rubygem(rdoc)
 BuildRequires: %{?scl_prefix}rubygem(bundler_ext)
-# start specfile sqlite BuildRequires
-BuildRequires: %{?scl_prefix}rubygem(sqlite3) >= 1.3.6
-BuildRequires: %{?scl_prefix}rubygem(sqlite3) < 2.0
-# end specfile sqlite BuildRequires
-
 
 # start specfile main BuildRequires
 BuildRequires: %{?scl_prefix}rubygem(rails) = 6.0.2.2
@@ -547,7 +543,6 @@ Summary: Foreman plugin support
 Group: Development/Libraries
 Requires: %{name} = %{version}-%{release}
 Requires: %{name}-build = %{version}-%{release}
-Requires: %{name}-sqlite = %{version}-%{release}
 Requires: %{?scl_prefix}rubygem(activerecord-nulldb-adapter)
 
 %description plugin
@@ -599,21 +594,6 @@ Meta Package to install requirements for postgresql support
 
 %files postgresql
 %{_datadir}/%{name}/bundler.d/postgresql.rb
-
-%package sqlite
-Summary: Foreman sqlite support
-Group:  Applications/System
-# start specfile sqlite Requires
-Requires: %{?scl_prefix}rubygem(sqlite3) >= 1.3.6
-Requires: %{?scl_prefix}rubygem(sqlite3) < 2.0
-# end specfile sqlite Requires
-Requires: %{name} = %{version}-%{release}
-
-%description sqlite
-Meta Package to install requirements for sqlite support
-
-%files sqlite
-%{_datadir}/%{name}/bundler.d/sqlite.rb
 
 %package telemetry
 Summary: Foreman telemetry support
@@ -1020,6 +1000,9 @@ exit 0
 %systemd_postun_with_restart %{name}.service
 
 %changelog
+* Fri May 1 2020 Tomer Brisker <tbrisker@gmail.com> - 2.1.0-0.17.develop
+- Drop sqlite
+
 * Thu Apr 30 2020 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 2.1.0-0.16.develop
 - Update Gem and NPM dependencies
 


### PR DESCRIPTION
This PR only drops the foreman-sqlite package. The rubygem-sqlite package is kept as it is being used by dynflow on smart proxy.
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
