### PR TITLE
Revert "Build rubygem-sprockets for rails6" to build Foreman

### DIFF
--- a/packages/foreman/rubygem-sprockets/rubygem-sprockets.spec
+++ b/packages/foreman/rubygem-sprockets/rubygem-sprockets.spec
@@ -5,8 +5,8 @@
 %global gem_name sprockets
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 4.0.0
-Release: 1%{?dist}
+Version: 3.7.2
+Release: 6%{?dist}
 Summary: Rack-based asset packaging system
 Group: Development/Languages
 License: MIT
@@ -80,6 +80,7 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 %files
 %dir %{gem_instdir}
 %{_bindir}/sprockets
+%license %{gem_instdir}/LICENSE
 %{gem_instdir}/bin
 %{gem_libdir}
 %exclude %{gem_cache}
@@ -91,9 +92,6 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 %doc %{gem_instdir}/README.md
 
 %changelog
-* Mon Apr 13 2020 Zach Huntington-Meath <zhunting@redhat.com> - 4.0.0-1
-- Release rubygem-sprockets 4.0.0
-
 * Tue Mar 17 2020 Zach Huntington-Meath <zhunting@redhat.com> - 3.7.2-6
 - Bump packages to build for el8
 

--- a/packages/foreman/rubygem-sprockets/sprockets-3.7.2.gem
+++ b/packages/foreman/rubygem-sprockets/sprockets-3.7.2.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/Pf/7G/SHA256E-s72704--5ea1d7facd09203c1aa196afd6178208cd25abdbcc2a9978810a2f0754e152a0.2.gem/SHA256E-s72704--5ea1d7facd09203c1aa196afd6178208cd25abdbcc2a9978810a2f0754e152a0.2.gem

--- a/packages/foreman/rubygem-sprockets/sprockets-4.0.0.gem
+++ b/packages/foreman/rubygem-sprockets/sprockets-4.0.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/2F/wG/SHA256E-s80384--57bdad17013f843ba2b884025f18ccd0ad9639a8cab4cc65cf2ad4bdef3fa34a.0.gem/SHA256E-s80384--57bdad17013f843ba2b884025f18ccd0ad9639a8cab4cc65cf2ad4bdef3fa34a.0.gem


### PR DESCRIPTION
Currently Foreman will not build with the updated version of sprockets, thus we are downgrading it.