### PR TITLE
python3-createrepo_c needs same version of createrepo_c

### DIFF
--- a/comps/comps-katello-pulpcore-el8.xml
+++ b/comps/comps-katello-pulpcore-el8.xml
@@ -10,6 +10,9 @@
     <description>pulpcore Packages</description>
     <uservisible>true</uservisible>
     <packagelist>
+      <packagereq type="default">createrepo_c</packagereq>
+      <packagereq type="default">createrepo_c-devel</packagereq>
+      <packagereq type="default">createrepo_c-libs</packagereq>
       <packagereq type="default">libsolv</packagereq>
       <packagereq type="default">libsolv-demo</packagereq>
       <packagereq type="default">libsolv-devel</packagereq>


### PR DESCRIPTION
```
   Problem: package python3-pulp-rpm-3.3.1-1.el8.noarch requires python3-createrepo_c >= 0.15.10, but none of the providers can be installed
    - conflicting requests
    - nothing provides createrepo_c-libs = 0.15.10-1.el8 needed by python3-createrepo_c-0.15.10-1.el8.x86_64
```

@evgeni Seems we have to go this route due to tight coupling