### PR TITLE
drop fedora29 from package manifest

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -686,8 +686,6 @@ foreman_client_packages:
         dist: '.el6'
       - name: foreman-client-2.1-rhel5
         dist: '.el5'
-      - name: foreman-client-2.1-fedora29
-        dist: '.fc29'
     repoclosure_target_repos:
       el8:
         - el8-foreman-client-2.1
@@ -697,8 +695,6 @@ foreman_client_packages:
         - el6-foreman-client-2.1
       rhel5:
         - el5-foreman-client-2.1
-      fedora29:
-        - f29-foreman-client-2.1
     repoclosure_lookaside_repos:
       el8:
         - el8-baseos
@@ -727,10 +723,6 @@ foreman_client_packages:
         - el5-puppet-6
         - el5-subscription-manager
         - el5-pulp
-      fedora29:
-        - f29-base
-        - f29-updates
-        - f29-puppet-6
   hosts:
     ansible-collection-theforeman-foreman: {}
     katello-host-tools: {}
@@ -1176,16 +1168,6 @@ repoclosures:
           - el5-puppet-6
           - el5-subscription-manager
           - el5-pulp
-    foreman-client-repoclosure-f29:
-      repoclosure_target_repos:
-        fedora29:
-          - f29-foreman-client-2.1
-      repoclosure_target_dist: fedora29
-      repoclosure_lookaside_repos:
-        fedora29:
-          - f29-base
-          - f29-updates
-          - f29-puppet-6
 
 pulpcore_packages:
   vars:
@@ -1320,8 +1302,6 @@ foreman_release_packages:
         dist: '.el6'
       - name: foreman-client-2.1-rhel5
         dist: '.el5'
-      - name: foreman-client-2.1-fedora29
-        dist: '.fc29'
     releasers:
       - koji-foreman
       - koji-foreman-client
@@ -1335,8 +1315,6 @@ foreman_release_packages:
         - el6-foreman-client-2.1
       rhel5:
         - el5-foreman-client-2.1
-      fedora29:
-        - f29-foreman-client-2.1
     repoclosure_lookaside_repos:
       el8:
         - el8-baseos
@@ -1365,9 +1343,5 @@ foreman_release_packages:
         - el5-puppet-6
         - el5-subscription-manager
         - el5-pulp
-      fedora29:
-        - f29-base
-        - f29-updates
-        - f29-puppet-6
   hosts:
     foreman-release: {}


### PR DESCRIPTION
it was droped from releasers/tito/koji, but not the manifest

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
