### PR TITLE
Let tfm-runtime obsolete tfm-ror52-runtime

### DIFF
--- a/packages/foreman/tfm/tfm.spec
+++ b/packages/foreman/tfm/tfm.spec
@@ -18,8 +18,8 @@
 
 Summary: Package that installs %scl
 Name: %scl_name
-Version: 6.0
-Release: 4%{?dist}
+Version: 6.1
+Release: 0.1%{?dist}
 License: GPLv2+
 Group: Applications/File
 Source0: README
@@ -53,6 +53,7 @@ Requires: %{scl_prefix_ruby}runtime
 Requires: %{_root_bindir}/scl_source
 Requires(post): policycoreutils-python
 Obsoletes: ruby193-ruby-wrapper
+Obsoletes: tfm-ror52-runtime
 
 # Obsolete packages no longer carried within this SCL to both clean up
 # and to ensure smooth upgrades when old packages deps aren't satisified
@@ -309,6 +310,9 @@ selinuxenabled && load_policy || :
 %{_root_sysconfdir}/rpm/macros.%{scl_name}-scldevel
 
 %changelog
+* Thu May 28 2020 Evgeni Golov - 6.1-0.1
+- Obsolete tfm-ror52-runtime
+
 * Wed Feb 26 2020 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 6.0-4
 - Obsolete tfm-ror52-rubygem-turbolinks (#29181)
 


### PR DESCRIPTION
(cherry picked from commit 24b26be4f0370a02233cdc1fe539cc0204f3f0dd)

slightly odd versioning as we don't want *all* the changes between 6.0-4 and 6.1-1 (esp not the rackspace one), but 6.0-4.1 also felt weird for that change.