### PR TITLE
Add release version to the repo ids

### DIFF
--- a/packages/foreman/foreman-release/foreman-client.repo
+++ b/packages/foreman/foreman-release/foreman-client.repo
@@ -1,11 +1,11 @@
-[foreman-client]
+[foreman-client-nightly]
 name=Foreman client nightly
 baseurl=https://yum.theforeman.org/client/nightly/$DIST/$basearch
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman-client
 
-[foreman-client-source]
+[foreman-client-nightly-source]
 name=Foreman client nightly - source
 baseurl=https://yum.theforeman.org/client/nightly/$DIST/source
 enabled=0

--- a/packages/foreman/foreman-release/foreman-plugins.repo
+++ b/packages/foreman/foreman-release/foreman-plugins.repo
@@ -1,4 +1,4 @@
-[foreman-plugins]
+[foreman-plugins-nightly]
 name=Foreman plugins nightly
 baseurl=https://yum.theforeman.org/plugins/nightly/$DIST/$basearch
 enabled=1
@@ -6,7 +6,7 @@ gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 module_hotfixes=1
 
-[foreman-plugins-source]
+[foreman-plugins-nightly-source]
 name=Foreman plugins nightly - source
 baseurl=https://yum.theforeman.org/plugins/nightly/$DIST/source
 enabled=0

--- a/packages/foreman/foreman-release/foreman-release.spec
+++ b/packages/foreman/foreman-release/foreman-release.spec
@@ -13,7 +13,7 @@
 %define repo_dist %{dist}
 %endif
 
-%global release 3
+%global release 4
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -109,6 +109,9 @@ install -Dpm0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-f
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman
 
 %changelog
+* Thu May 28 2020 Evgeni Golov - 2.2.0-0.4.develop
+- Add release version to the repo ids
+
 * Wed May 13 2020 Eric D. Helms <ericdhelms@gmail.com> - 2.2.0-0.3.develop
 - Bump version to 2.2-develop
 

--- a/packages/foreman/foreman-release/foreman.repo
+++ b/packages/foreman/foreman-release/foreman.repo
@@ -1,4 +1,4 @@
-[foreman]
+[foreman-nightly]
 name=Foreman nightly
 baseurl=https://yum.theforeman.org/releases/nightly/$DIST/$basearch
 enabled=1
@@ -6,7 +6,7 @@ gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 module_hotfixes=1
 
-[foreman-source]
+[foreman-nightly-source]
 name=Foreman nightly - source
 baseurl=https://yum.theforeman.org/releases/nightly/$DIST/source
 enabled=0

--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -7,7 +7,7 @@
 
 %global prereleasesource nightly
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 1
+%global release 2
 
 Name:           katello-repos
 Version:        4.0.0
@@ -80,6 +80,9 @@ rm -rf %{buildroot}
 %config %{repo_dir}/*.repo
 
 %changelog
+* Thu May 28 2020 Evgeni Golov - 4.0.0-0.2.nightly
+- Add release version to the repo ids
+
 * Thu May 14 2020 Eric D. Helms <ericdhelms@gmail.com> - 4.0.0-0.1.nightly
 - Update to 4.0
 

--- a/packages/katello/katello-repos/katello.repo
+++ b/packages/katello/katello-repos/katello.repo
@@ -1,6 +1,6 @@
 # Place this file in your /etc/yum.repos.d/ directory
 
-[katello]
+[katello-@REPO_VERSION@]
 name=Katello @REPO_NAME@
 baseurl=https://fedorapeople.org/groups/katello/releases/yum/@REPO_VERSION@/katello/@DIST@/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
@@ -8,7 +8,7 @@ enabled=1
 gpgcheck=@REPO_GPGCHECK@
 module_hotfixes=1
 
-[pulp]
+[pulp-@PULP_VERSION@]
 name=Pulp Community Release
 baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/@PULP_URL_MIDDLE@/$releasever/$basearch
 gpgkey=https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2
@@ -19,7 +19,7 @@ module_hotfixes=1
 # Candlepin RPMs as supported by Katello - This is a coordinated
 # copy of Candlepin's packages in order to ensure compatibility
 
-[katello-candlepin]
+[katello-candlepin-@REPO_VERSION@]
 name=Candlepin: an open source entitlement management system.
 baseurl=https://fedorapeople.org/groups/katello/releases/yum/@REPO_VERSION@/candlepin/@DIST@/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
@@ -27,7 +27,7 @@ enabled=1
 gpgcheck=@REPO_GPGCHECK@
 module_hotfixes=1
 
-[katello-pulpcore]
+[katello-pulpcore-@REPO_VERSION@]
 name=pulpcore: Fetch, Upload, Organize, and Distribute Software Packages.
 baseurl=https://fedorapeople.org/groups/katello/releases/yum/@REPO_VERSION@/pulpcore/@DIST@/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
@@ -37,28 +37,28 @@ module_hotfixes=1
 
 # source repositories
 
-[katello-source]
+[katello-@REPO_VERSION@-source]
 name=Katello @REPO_NAME@ Source
 baseurl=https://fedorapeople.org/groups/katello/releases/source/srpm/@REPO_VERSION@/katello/@DIST@/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=0
 gpgcheck=@REPO_GPGCHECK@
 
-[pulp-source]
+[pulp-@PULP_VERSION@-source]
 name=Pulp Community Release Source
 baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/@PULP_URL_MIDDLE@/$releasever/src/
 gpgkey=https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2
 enabled=0
 gpgcheck=@PULP_GPG_CHECK@
 
-[katello-candlepin-source]
+[katello-@REPO_VERSION@-candlepin-source]
 name=Katello Candlepin source
 baseurl=https://fedorapeople.org/groups/katello/releases/source/srpm/@REPO_VERSION@/candlepin/@DIST@/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=0
 gpgcheck=@REPO_GPGCHECK@
 
-[katello-pulpcore-source]
+[katello-@REPO_VERSION@-pulpcore-source]
 name=Katello pulpcore source
 baseurl=https://fedorapeople.org/groups/katello/releases/source/srpm/@REPO_VERSION@/pulpcore/@DIST@/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman


### PR DESCRIPTION
this removes the need to call `yum clean` on upgrades as the repo id is
used as the cache key buy yum, and if that changes it will download the
metadata again

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
