### PR TITLE
Update foreman-tasks to 2.0.0

### DIFF
--- a/plugins/ruby-foreman-tasks/debian/changelog
+++ b/plugins/ruby-foreman-tasks/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-tasks (2.0.0-1) stable; urgency=low
+
+  * 2.0.0 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Thu, 04 Jun 2020 10:46:04 +0200
+
 ruby-foreman-tasks (1.2.0-1) stable; urgency=low
 
   * 1.2.0 released

--- a/plugins/ruby-foreman-tasks/debian/gem.list
+++ b/plugins/ruby-foreman-tasks/debian/gem.list
@@ -1,5 +1,5 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman-tasks-1.2.0.gem"
+GEMS="https://rubygems.org/downloads/foreman-tasks-2.0.0.gem"
 GEMS="$GEMS https://rubygems.org/downloads/foreman-tasks-core-0.3.4.gem"
 GEMS="$GEMS https://rubygems.org/downloads/parse-cron-0.1.4.gem"
 GEMS="$GEMS https://rubygems.org/downloads/sinatra-2.0.8.1.gem"

--- a/plugins/ruby-foreman-tasks/foreman-tasks.rb
+++ b/plugins/ruby-foreman-tasks/foreman-tasks.rb
@@ -1,1 +1,1 @@
-gem 'foreman-tasks', '1.2.0'
+gem 'foreman-tasks', '2.0.0'


### PR DESCRIPTION
Dependency of foreman was bumped earlier, as part of introducing nulldb.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
