### PR TITLE
Make libmodulemd dependency versioned

### DIFF
--- a/packages/pulpcore/python-pulp-rpm/python-pulp-rpm.spec
+++ b/packages/pulpcore/python-pulp-rpm/python-pulp-rpm.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        3.3.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        RPM plugin for the Pulp Project
 
 License:        GPLv2+
@@ -25,7 +25,7 @@ Requires:       python36-gobject
 Requires:       libmodulemd2
 %else
 Requires:       python3-gobject
-Requires:       libmodulemd
+Requires:       libmodulemd >= 2.0
 %endif
 Requires:       python3-createrepo_c < 1.0
 Requires:       python3-createrepo_c >= 0.15.10
@@ -62,6 +62,9 @@ sed -i "/'solv'/d" setup.py
 %{python3_sitelib}/pulp_rpm-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Thu Jun 04 2020 Evgeni Golov - 3.3.1-5
+- Make libmodulemd dependency versioned
+
 * Thu Jun 04 2020 Evgeni Golov <evgeni@golov.de> - 3.3.1-4
 - Bump libcomps require to get a version with egg info
 


### PR DESCRIPTION
libmodulemd1 provide libmodulemd = 1.8.0, which satisfies the dependency
otherwise

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
