### PR TITLE
make postgresql deb ext not require root

### DIFF
--- a/packages/pulpcore/postgresql-debversion/0002-set_superuser.patch
+++ b/packages/pulpcore/postgresql-debversion/0002-set_superuser.patch
@@ -1,0 +1,7 @@
+--- a/debversion.control.old 2018-06-13 13:23:18.000000000 -0400
++++ b/debversion.control     2020-06-09 15:37:29.731605944 -0400
+@@ -2,3 +2,4 @@
+ default_version = '1.1'
+ module_pathname = '$libdir/debversion'
+ relocatable = true
++superuser=false

--- a/packages/pulpcore/postgresql-debversion/postgresql-debversion.spec
+++ b/packages/pulpcore/postgresql-debversion/postgresql-debversion.spec
@@ -7,7 +7,7 @@
 
 Name:     %{?scl_prefix}postgresql-debversion
 Version:  1.1.1
-Release:  1%{?dist}
+Release:  2%{?dist}
 Summary:  Debian version number type for PostgreSQL
 
 Group:    Applications/System
@@ -15,7 +15,7 @@ License:  GPLv3
 URL:      https://salsa.debian.org/postgresql/postgresql-debversion
 Source0:  https://salsa.debian.org/postgresql/postgresql-debversion/-/archive/v%{version}/postgresql-debversion-v%{version}.tar.gz
 Patch0:   0001-Copy-relevant-code-from-apt-pkg-to-ease-packaging.patch
-
+Patch1:   0002-set_superuser.patch
 
 Requires: %{?scl_prefix}postgresql-server
 %{?scl:Requires: %{?scl_prefix}runtime}
@@ -81,5 +81,8 @@ rm -rf $RPM_BUILD_ROOT
 %license COPYING
 
 %changelog
+* Tue Jun 09 2020 Justin Sherrill <jsherril@redhat.com> 1.1.1-2
+- add patch to allow nonsuperuser access
+
 * Fri Jan 03 2020 Matthias Dellweg <dellweg@atix.de> - 1.1.1-1
 - new package


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
