### PR TITLE
bump supported openscap version

### DIFF
--- a/packages/plugins/rubygem-openscap/rubygem-openscap.spec
+++ b/packages/plugins/rubygem-openscap/rubygem-openscap.spec
@@ -3,10 +3,12 @@
 %{!?scl:%global pkg_name %{name}}
 
 %global gem_name openscap
+%global min_openscap_version 1.2.9
+%global max_openscap_version 1.3.4
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.4.9
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: A FFI wrapper around the OpenSCAP library
 Group: Development/Languages
 License: GPLv2+
@@ -14,11 +16,11 @@ URL: https://github.com/OpenSCAP/ruby-openscap
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
 # require libopenscap.so.8 in an arch neutral way
-Requires: openscap >= 1.2.9
-Requires: openscap < 1.3.2
+Requires: openscap >= %{min_openscap_version}
+Requires: openscap < %{max_openscap_version}
 
-BuildRequires: openscap >= 1.2.9
-BuildRequires: openscap < 1.3.2
+BuildRequires: openscap >= %{min_openscap_version}
+BuildRequires: openscap < %{max_openscap_version}
 BuildRequires: openscap-devel
 BuildRequires: bzip2
 
@@ -90,6 +92,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Tue Jun 16 2020 Evgeni Golov - 0.4.9-3
+- Bump supported openscap version
+
 * Tue May 05 2020 Evgeni Golov - 0.4.9-2
 - Update openscap dependency to match EL8
 


### PR DESCRIPTION
CentOS 8.2 contains openscap 1.3.2 which still has soname 25
1.3.3 (latest upstream) also has 25
so lets break on 1.3.4 now

(cherry picked from commit c7554323c7814cb80cac1c6e74954928d79226ec)

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
