### PR TITLE
Add the candlepin artemis broker.xml to foreman-debug

### DIFF
--- a/packages/katello/katello/katello-debug.sh
+++ b/packages/katello/katello/katello-debug.sh
@@ -52,7 +52,11 @@ add_files /var/log/tomcat*/host-manager*.log*
 add_files /var/log/tomcat*/localhost*.log*
 add_files /var/log/tomcat*/manager*.log*
 add_files /etc/candlepin/candlepin.conf
+add_files /etc/candlepin/broker.xml
 add_files /etc/tomcat*/server.xml
+add_files /etc/tomcat/cert-roles.properties
+add_files /etc/tomcat/cert-users.properties
+add_files /etc/tomcat/login.config
 
 # RHSM
 add_files /var/log/rhsm/*

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,7 +5,7 @@
 %global confdir common
 %global prereleasesource master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 2
+%global release 3
 
 Name:       katello
 Version:    4.0.0
@@ -180,6 +180,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Thu Jun 18 2020 Barnaby Court <bcourt@redhat.com> - 4.0.0-0.3.master
+- Add artemis broker.xml and tomcat config files to debug collection
+
 * Wed Jun 17 2020 Justin Sherrill <jsherril@redhat.com> 4.0.0-0.2.master
 - move pulp-selinux requires to -common for foreman proxy install
 


### PR DESCRIPTION
Add the broker.xml that is used for configuring the Artemis instance that is embedded inside candlepin to the list of files collected during foreman-debug. 