### PR TITLE
Require python-setuptools on EL7 for k-certs-tools

### DIFF
--- a/packages/foreman/katello-certs-tools/katello-certs-tools.spec
+++ b/packages/foreman/katello-certs-tools/katello-certs-tools.spec
@@ -3,7 +3,7 @@ Summary:   Katello SSL Key/Cert Tool
 Group:     Applications/Internet
 License:   GPLv2
 Version:   2.7.1
-Release:   1%{?dist}
+Release:   2%{?dist}
 URL:       https://github.com/katello/katello-certs-tools
 Source0:   https://codeload.github.com/Katello/%{name}/tar.gz/%{version}#/%{name}-%{version}.tar.gz
 BuildArch: noarch
@@ -15,6 +15,7 @@ BuildRequires: docbook-utils
 %if 0%{?rhel} == 7
 BuildRequires: python-devel >= 2.6
 BuildRequires: python-setuptools
+Requires: python-setuptools
 %else
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
@@ -63,6 +64,9 @@ mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/pki/%{name}/private
 %license LICENSE
 
 %changelog
+* Mon Jun 22 2020 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 2.7.1-2
+- Require python-setuptools on EL7
+
 * Tue Jun 09 2020 Eric D. Helms <ericdhelms@gmail.com> - 2.7.1-1
 - Release katello-certs-tools 2.7.1
 


### PR DESCRIPTION
Since 2.7.1 setuptools is used to create /usr/bin/katello-ssl-tool by generating a wrapper. This needs pkg_resources which on EL8 is included in Python, but isn't on EL7. This is provided by python-setuptools.