### PR TITLE
do not change hashbang on centos < 8

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
+++ b/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
@@ -34,7 +34,7 @@
 Summary: SaltStack support for Foreman Smart-Proxy
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.1.2
-Release: 4%{?foremandist}%{?dist}
+Release: 5%{?foremandist}%{?dist}
 Group: Applications/System
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_salt

--- a/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
+++ b/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
@@ -96,11 +96,11 @@ gem unpack %{SOURCE0}
 
 %setup -q -D -T -n  %{gem_name}-%{version}
 
-%if %{with python2}
+%if %{with python2} && 0%{?rhel} >= 8
 sed -i -e '1s|^#!.*$|#!%{__python2}|' sbin/upload-salt-reports
 %endif
 
-%if %{with python3}
+%if %{with python3} && 0%{?rhel} >= 8
 sed -i -e '1s|^#!.*$|#!%{__python3}|' sbin/upload-salt-reports
 %endif
 

--- a/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
+++ b/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
@@ -186,6 +186,9 @@ EOF
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Fri Jul 03 2020 Stefan Bogner <bogner@b1-systems.de> - 3.1.2-5
+- Do not change hashbang on RHEL < 8
+
 * Tue Jun 23 2020 Markus Bucher <bucher@atix.de> - 3.1.2-4
 - Fix hashbang in upload-salt-reports
 


### PR DESCRIPTION
This will fix the hashbang for CentOS7.
On CentOS7, /usr/bin/env python exists which will make the script work for python2 and python3. 
Please note that with Salt 3001 python2 support was deprecated, so a script with /usr/bin/python2 is pretty much useless.