### PR TITLE
Ensure foreman.socket is removed on package removal

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -9,7 +9,7 @@
 %global scl_ruby_bin /usr/bin/%{?scl:%{scl_prefix}}ruby
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 28
+%global release 29
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -1005,18 +1005,19 @@ fi
 exit 0
 
 %post service
-%systemd_post %{name}.socket
-%systemd_post %{name}.service
+%systemd_post %{name}.socket %{name}.service
 
 %preun service
-%systemd_preun %{name}.socket
-%systemd_preun %{name}.service
+%systemd_preun %{name}.socket %{name}.service
 
 %postun service
-%systemd_postun_with_restart %{name}.socket
 %systemd_postun_with_restart %{name}.service
+%systemd_postun %{name}.socket
 
 %changelog
+* Wed Jul 29 2020 Eric D. Helms <ericdhelms@gmail.com> - 2.2.0-0.29.develop
+- Ensure foreman.socket is removed on package removal
+
 * Mon Jul 20 2020 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 2.2.0-0.28.develop
 - Update Gem and NPM dependencies
 


### PR DESCRIPTION
This reverts commit 5c83debb7411b8f42bd53d197c4febb47533cea5.

Cleanup from broken upgrades that were the result of needing to backport SELinux changes. This change is not present in 2.1 from my investigation so just needs this revert in nightly branch.