### PR TITLE
Fixes #30367 - Add Infoblox dependency to sp_dns_infoblox

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_dns_infoblox/rubygem-smart_proxy_dns_infoblox.spec
+++ b/packages/plugins/rubygem-smart_proxy_dns_infoblox/rubygem-smart_proxy_dns_infoblox.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.1.0
-Release: 3%{?foremandist}%{?dist}
+Release: 4%{?foremandist}%{?dist}
 Summary: Infoblox DNS provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -30,6 +30,8 @@ Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
+Requires: %{?scl_prefix}rubygem(infoblox) >= 3.0
+Requires: %{?scl_prefix}rubygem(infoblox) < 4
 BuildRequires: %{?scl_prefix_ruby}ruby(release)
 BuildRequires: %{?scl_prefix_ruby}ruby
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
@@ -109,6 +111,9 @@ mv %{buildroot}%{gem_instdir}/config/dns_infoblox.yml.example \
 %{gem_instdir}/test
 
 %changelog
+* Fri Jul 10 2020 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 1.1.0-4
+- Add infoblox dependency back (#30367)
+
 * Mon Jun 22 2020 Evgeni Golov - 1.1.0-3
 - Fix bundler.d location on EL8
 


### PR DESCRIPTION
f825335074aacaf60b97ff99aa72e8b2bc0c8279 dropped this dependency, but it should really be there.