### PR TITLE
Patch rubygem-safemode to allow to_sentence for array

### DIFF
--- a/packages/foreman/rubygem-safemode/32.patch
+++ b/packages/foreman/rubygem-safemode/32.patch
@@ -1,0 +1,24 @@
+From 719986c444f6cd9d2a9dc4109b95d036a6494c38 Mon Sep 17 00:00:00 2001
+From: Dirk Goetz <dirk.goetz@netways.de>
+Date: Thu, 30 Apr 2020 14:26:32 +0200
+Subject: [PATCH] allow to_sentence for array
+
+---
+ lib/safemode/core_jails.rb | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lib/safemode/core_jails.rb b/lib/safemode/core_jails.rb
+index ec875fe..bf8e395 100644
+--- a/lib/safemode/core_jails.rb
++++ b/lib/safemode/core_jails.rb
+@@ -51,8 +51,8 @@ def core_jail_class_methods(klass)
+                     indexes indices inject insert join last length map map!
+                     nitems pop push present? rassoc reject reject! reverse
+                     reverse! reverse_each rindex select shift size slice
+-                    slice! sort sort! transpose uniq uniq! unshift values_at
+-                    zip),
++                    slice! sort sort! transpose to_sentence uniq uniq! unshift
++                    values_at zip),
+ 
+     'Bignum'     => %w(abs blank? ceil chr coerce div divmod downto floor hash
+                     integer? modulo next nonzero? present? quo remainder round

--- a/packages/foreman/rubygem-safemode/rubygem-safemode.spec
+++ b/packages/foreman/rubygem-safemode/rubygem-safemode.spec
@@ -7,11 +7,13 @@ Summary: A library for safe evaluation of Ruby code
 Name: %{?scl_prefix}rubygem-%{gem_name}
 
 Version: 1.3.5
-Release: 3%{?dist}
+Release: 4%{?dist}
 Group: Development/Ruby
 License: MIT
 URL: https://github.com/svenfuchs/safemode
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
+# Patch safemode to allow to_sentence for array
+Patch0: https://patch-diff.githubusercontent.com/raw/svenfuchs/safemode/pull/32.patch
 Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}rubygems
 Requires: %{?scl_prefix}rubygem(ruby2ruby) >= 2.4.0
@@ -45,6 +47,7 @@ This package contains documentation for rubygem-%{gem_name}.
 gem unpack %{SOURCE0}
 %{?scl:"}
 %setup -q -D -T -n  %{gem_name}-%{version}
+%patch0 -p1
 
 %{?scl:scl enable %{scl} "}
 gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
@@ -86,6 +89,9 @@ rm %{buildroot}%{gem_instdir}/{VERSION,.travis.yml}
 %{gem_docdir}
 
 %changelog
+* Tue Jul 14 2020 Dirk Goetz <dirk.goetz@netways.de> - 1.3.5-4
+- Add patch to allow to_sentence for array
+
 * Wed Apr 08 2020 Zach Huntington-Meath <zhunting@redhat.com> - 1.3.5-3
 - Bump to release for EL8
 


### PR DESCRIPTION
Safemode has not been released in a while but now includes a fix I need, so I opted for bumping to snapshot version.
