### PR TITLE
Patch out Ansible and ansible-lint dependencies from galaxy importer

### DIFF
--- a/packages/pulpcore/python-galaxy-importer/python-galaxy-importer.spec
+++ b/packages/pulpcore/python-galaxy-importer/python-galaxy-importer.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.2.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Galaxy content importer
 
 License:        Apache-2.0
@@ -52,6 +52,8 @@ Requires:       python3-semantic-version >= 2.8.4
 # Remove bundled egg-info
 rm -rf %{pypi_name}.egg-info
 
+sed -i -E '/\s+ansible($|-lint)/d' setup.cfg
+
 %build
 %py3_build
 
@@ -66,5 +68,8 @@ rm -rf %{pypi_name}.egg-info
 %{python3_sitelib}/galaxy_importer-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Mon Jul 27 2020 Evgeni Golov - 0.2.5-2
+- Patch out Ansible and ansible-lint dependencies from the Python egg
+
 * Tue Jun 23 2020 Evgeni Golov - 0.2.5-1
 - Initial package.


### PR DESCRIPTION
We use system Ansible, which uses on EL7 Python2 and thus the
requirement is never met.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
