### PR TITLE
disable building of el8 bits for katello 3.16

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -749,17 +749,11 @@ katello_packages:
         dist: '.el7'
         macros:
           foremandist: "{{ foremandist }}"
-      - name: katello-3.16-el8
-        dist: '.el8'
-        macros:
-          foremandist: "{{ foremandist }}"
     releasers:
       - koji-katello
     repoclosure_target_repos:
       rhel7:
         - el7-katello-3.16
-      el8:
-        - el8-katello-3.16
     repoclosure_lookaside_repos:
       rhel7:
         - el7-base
@@ -773,17 +767,6 @@ katello_packages:
         - el7-katello-pulp-3.16
         - el7-katello-pulpcore-3.16
         - el7-katello-candlepin-3.16
-      el8:
-        - el8-baseos
-        - el8-appstream
-        - el8-powertools
-        - el8-epel
-        - el8-extras
-        - el8-puppet-6
-        - el8-foreman-2.1
-        - el8-foreman-plugins-2.1
-        - el8-katello-pulpcore-3.16
-        - el8-katello-candlepin-3.16
   hosts:
     katello: {}
     katello-client-bootstrap: {}
@@ -1180,25 +1163,17 @@ pulpcore_packages:
     koji_tags:
       - name: katello-pulpcore-3.16-el7
         dist: '.el7'
-      - name: katello-pulpcore-3.16-el8
-        dist: '.el8'
     releasers:
       - koji-katello-pulpcore
     repoclosure_target_repos:
       el7:
         - el7-katello-pulpcore-3.16
-      el8:
-        - el8-katello-pulpcore-3.16
     repoclosure_lookaside_repos:
       el7:
         - el7-base
         - el7-updates
         - el7-scl
         - el7-epel
-      el8:
-        - el8-baseos
-        - el8-appstream
-        - el8-powertools
   hosts:
     createrepo_c: {}
     libcomps: {}

--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -34,16 +34,16 @@ builder = tito.builder.FetchBuilder
 # Katello Releasers
 [koji-katello]
 releaser = tito.release.KojiReleaser
-autobuild_tags = katello-3.16-rhel7 katello-3.16-el8
+autobuild_tags = katello-3.16-rhel7
 builder.rpmbuild_options = --define "foremandist .fm2_1"
 
 [koji-katello-jenkins]
 releaser = tito.release.KojiReleaser
-autobuild_tags = katello-3.16-rhel7 katello-3.16-el8
+autobuild_tags = katello-3.16-rhel7
 builder = tito.builder.FetchBuilder
 builder.jenkins_url = https://ci.theforeman.org
 builder.rpmbuild_options = --define "foremandist .fm2_1"
 
 [koji-katello-pulpcore]
 releaser = tito.release.KojiReleaser
-autobuild_tags = katello-pulpcore-3.16-el7 katello-pulpcore-3.16-el8
+autobuild_tags = katello-pulpcore-3.16-el7


### PR DESCRIPTION
it won't be supported anyways

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
