### PR TITLE
Fixes #30584: fix NoMethodError in change-hostname after foreman-installer fails

### DIFF
--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -15,8 +15,6 @@ module KatelloUtilities
   class HostnameChange
     include ::KatelloUtilities::Helper
 
-    attr_accessor :temp_last_scenario_yaml
-
     def initialize(init_options)
       @default_program = self.get_default_program
       @proxy = init_options.fetch(:proxy)
@@ -375,11 +373,11 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
     def restore_last_scenario_yaml
       STDOUT.puts 'restoring last_scenario.yaml'
       if File.exist?(last_scenario_yaml)
-        run_cmd("cp #{temp_last_scenario_yaml.path} #{last_scenario_yaml}")
+        run_cmd("cp #{@temp_last_scenario_yaml.path} #{last_scenario_yaml}")
       else
         # if the installer failed early the last_scenario symlink won't exist
         scenario_path = "#{scenarios_path}/#{@options[:scenario]}.yaml"
-        run_cmd("cp #{temp_last_scenario_yaml.path} #{scenario_path}")
+        run_cmd("cp #{@temp_last_scenario_yaml.path} #{scenario_path}")
         File.symlink(scenario_path, last_scenario_yaml)
       end
     end
@@ -500,11 +498,11 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
 
       if File.exist?(last_scenario_yaml)
         STDOUT.puts 'backing up last_scenario.yaml'
-        temp_last_scenario_yaml = Tempfile.new('last_scenario')
+        @temp_last_scenario_yaml = Tempfile.new('last_scenario')
         begin
-          temp_last_scenario_yaml << File.read(last_scenario_yaml)
+          @temp_last_scenario_yaml << File.read(last_scenario_yaml)
         ensure
-          temp_last_scenario_yaml.close
+          @temp_last_scenario_yaml.close
         end
 
         STDOUT.puts 'removing last_scenario.yaml'
@@ -528,12 +526,12 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
 
       STDOUT.puts installer
       run_cmd(installer, [0], installer_failure_message) do |result, success|
-        if temp_last_scenario_yaml && temp_last_scenario_yaml.path
+        if @temp_last_scenario_yaml && @temp_last_scenario_yaml.path
           unless success
             restore_last_scenario_yaml
           end
           STDOUT.puts 'cleaning up temporary files'
-          temp_last_scenario_yaml.unlink
+          @temp_last_scenario_yaml.unlink
         end
 
         if success

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,7 +5,7 @@
 %global confdir common
 %global prereleasesource master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 1
+%global release 2
 
 Name:       katello
 Version:    3.18.0
@@ -180,6 +180,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Tue Aug 11 2020 Jeremy Lenz <jlenz@redhat.com> - 3.18.0-0.2.master
+- Fixes #30584: fix NoMethodError in change-hostname after foreman-installer fails
+
 * Tue Aug 11 2020 Eric D. Helms <ericdhelms@gmail.com> - 3.18.0-0.1.master
 - Bump to 3.18.0
 


### PR DESCRIPTION
### To see the issue:

1. Take a snapshot of your satellite
2. In `/sbin/foreman-installer`, comment out the line
```
@result = Kafo::KafoConfigure.run
```
and add the following below it:
```
exit(1)
```
3. Run change-hostname:
```
[root@sat-6-8-qa-rhel7 vagrant]# satellite-change-hostname sat2.example.com -u admin -p changeme
```
4.  See the error:
```
foreman-installer --scenario satellite -v --disable-system-checks --certs-regenerate=true --foreman-proxy-register-in-foreman true
restoring last_scenario.yaml
/usr/share/katello/hostname-change.rb:382:in `restore_last_scenario_yaml': undefined method `path' for nil:NilClass (NoMethodError)
	from /usr/share/katello/hostname-change.rb:533:in `block in run'
	from /usr/share/katello/helper.rb:59:in `run_cmd'
	from /usr/share/katello/hostname-change.rb:530:in `run'
	from /sbin/satellite-change-hostname:23:in `<main>'
```

### To test:

1. Revert/restore your snapshot
2. Repeat step 2 above
3. Apply this patch to `/usr/share/katello/hostname-change.rb`
4. Run change-hostname again
5. Verify that the error does not appear.  You should now be free to fix the issue with foreman-installer and run it again.