### PR TITLE
fix python-dateutil obsoletes by placing them to the binary package

### DIFF
--- a/packages/pulpcore/python-dateutil/python-dateutil.spec
+++ b/packages/pulpcore/python-dateutil/python-dateutil.spec
@@ -4,7 +4,7 @@
 
 Name:           python-%{srcname}
 Version:        2.8.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Extensions to the standard Python datetime module
 
 License:        Dual License
@@ -17,8 +17,6 @@ BuildRequires:  python3-setuptools
 BuildRequires:  python3-setuptools-scm
 BuildRequires:  python3-six >= 1.5
 
-Obsoletes: python36-dateutil
-
 %description
 %{summary}
 
@@ -26,6 +24,7 @@ Obsoletes: python36-dateutil
 Summary:        %{summary}
 %{?python_provide:%python_provide python3-%{srcname}}
 Requires:       python3-six >= 1.5
+Obsoletes:      python36-dateutil
 
 %description -n python3-%{srcname}
 %{summary}
@@ -48,6 +47,9 @@ rm -rf %{pypi_name}.egg-info
 %{python3_sitelib}/python_dateutil-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Mon Aug 24 2020 Evgeni Golov - 2.8.1-3
+- Fix Obsoletes
+
 * Thu Aug 20 2020 Eric D. Helms <ericdhelms@gmail.com> - 2.8.1-2
 - Obsolete python36-dateutil
 


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
