### PR TITLE
call scripts with an absolute path

### DIFF
--- a/add_pypi_package.sh
+++ b/add_pypi_package.sh
@@ -21,6 +21,8 @@ PACKAGE_DIR=packages/$BASE_DIR/$PACKAGE_NAME
 
 ROOT=$(git rev-parse --show-toplevel)
 
+SCRIPT_ROOT=$(readlink -f $0)
+
 program_exists() {
   which "$@" &> /dev/null
 }
@@ -97,10 +99,10 @@ add_pypi_to_comps() {
 
   for comps_package in ${comps_packages}; do
     if [[ $comps_package != *-debuginfo ]] && [[ $comps_package != *-debugsource ]] ; then
-      ./add_to_comps.rb comps/comps-${comps_file}-${DISTRO}.xml $comps_package $comps_scl
+      ${SCRIPT_ROOT}/add_to_comps.rb comps/comps-${comps_file}-${DISTRO}.xml $comps_package $comps_scl
     fi
   done
-  ./comps_doc.sh
+  ${SCRIPT_ROOT}/comps_doc.sh
   git add comps/
 }
 
@@ -119,11 +121,11 @@ add_pypi_to_manifest() {
 	fi
 
 	if [[ -n $section ]] ; then
-		./add_host.py "$section" "$PACKAGE_NAME"
+		${SCRIPT_ROOT}/add_host.py "$section" "$PACKAGE_NAME"
 		git add package_manifest.yaml
 	else
 		echo "TODO: Add the package into the right section"
-		echo "./add_host.py SECTION '$PACKAGE_NAME'"
+		echo "${SCRIPT_ROOT}/add_host.py SECTION '$PACKAGE_NAME'"
 		echo "git add package_manifest.yaml"
 		echo "git commit --amend --no-edit"
 	fi


### PR DESCRIPTION
this allows to run add_pypi_package in a different directory than the
script itself lives

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
