### PR TITLE
Bump foreman-maintain to 0.6.10 and add yum-utils as dependency

### DIFF
--- a/packages/foreman/rubygem-foreman_maintain/foreman_maintain-0.6.10.gem
+++ b/packages/foreman/rubygem-foreman_maintain/foreman_maintain-0.6.10.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/4m/Jm/SHA256E-s122880--428ee0e6e3f25c4fa3bc51415e14aba3ff7c3023aed6ab236caf62862d3c7eda.10.gem/SHA256E-s122880--428ee0e6e3f25c4fa3bc51415e14aba3ff7c3023aed6ab236caf62862d3c7eda.10.gem

--- a/packages/foreman/rubygem-foreman_maintain/foreman_maintain-0.6.9.gem
+++ b/packages/foreman/rubygem-foreman_maintain/foreman_maintain-0.6.9.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/JM/MQ/SHA256E-s121856--12f26ffd165bde93bfdd3917a47b0dce7d14c69d39d775b56b62e49a5d1a939a.9.gem/SHA256E-s121856--12f26ffd165bde93bfdd3917a47b0dce7d14c69d39d775b56b62e49a5d1a939a.9.gem

--- a/packages/foreman/rubygem-foreman_maintain/rubygem-foreman_maintain.spec
+++ b/packages/foreman/rubygem-foreman_maintain/rubygem-foreman_maintain.spec
@@ -9,7 +9,7 @@
 
 Summary: The Foreman/Satellite maintenance tool
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 0.6.9
+Version: 0.6.10
 Release: 1%{?dist}
 Epoch: 1
 Group: Development/Languages
@@ -21,6 +21,7 @@ Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
 Requires: %{?scl_prefix}rubygem(clamp) >= 0.6.2
 Requires: %{?scl_prefix}rubygem(highline)
+Requires: yum-utils
 %if 0%{?rhel} < 8
 BuildRequires: python2-devel
 %else
@@ -122,6 +123,9 @@ install -D -m0640 %{buildroot}%{gem_instdir}/extras/foreman_protector/foreman-pr
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Fri Sep 04 2020 Amit Upadhye <upadhyeammit@gmail.com> 1:0.6.10-1
+- Update to 0.6.10
+
 * Mon Aug 03 2020 Amit Upadhye <upadhyeammit@gmail.com> 1:0.6.9-1
 - Update to 0.6.9
 


### PR DESCRIPTION
Bumping foreman-maintain which is required for 2.1-stable. With this adding yum-utils as dependency for foreman-maintain as per issue : 30414