### PR TITLE
Remove trends counter cron job

### DIFF
--- a/debian/bionic/foreman/foreman.cron.d
+++ b/debian/bionic/foreman/foreman.cron.d
@@ -15,9 +15,6 @@ FOREMAN_HOME=/usr/share/foreman
 # Expire old reports
 30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake reports:expire >>/var/log/foreman/cron.log 2>&1
 
-# Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake trends:counter >>/var/log/foreman/cron.log 2>&1
-
 # Refreshes ldap usergroups. Can be disabled if you're not using LDAP authentication.
 */30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake ldap:refresh_usergroups >>/var/log/foreman/cron.log 2>&1
 

--- a/debian/buster/foreman/foreman.cron.d
+++ b/debian/buster/foreman/foreman.cron.d
@@ -15,9 +15,6 @@ FOREMAN_HOME=/usr/share/foreman
 # Expire old reports
 30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake reports:expire >>/var/log/foreman/cron.log 2>&1
 
-# Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake trends:counter >>/var/log/foreman/cron.log 2>&1
-
 # Refreshes ldap usergroups. Can be disabled if you're not using LDAP authentication.
 */30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake ldap:refresh_usergroups >>/var/log/foreman/cron.log 2>&1
 


### PR DESCRIPTION
The cron job is being obsolete as of theforeman/foreman_statistics#19
This is released in foreman_statistics 1.0
