### PR TITLE
Update rubygem-foreman_maintain to 0.6.12

### DIFF
--- a/packages/foreman/rubygem-foreman_maintain/foreman_maintain-0.6.10.gem
+++ b/packages/foreman/rubygem-foreman_maintain/foreman_maintain-0.6.10.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/4m/Jm/SHA256E-s122880--428ee0e6e3f25c4fa3bc51415e14aba3ff7c3023aed6ab236caf62862d3c7eda.10.gem/SHA256E-s122880--428ee0e6e3f25c4fa3bc51415e14aba3ff7c3023aed6ab236caf62862d3c7eda.10.gem

--- a/packages/foreman/rubygem-foreman_maintain/foreman_maintain-0.6.12.gem
+++ b/packages/foreman/rubygem-foreman_maintain/foreman_maintain-0.6.12.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/xf/F7/SHA256E-s122880--d434d6cc11b455c373d0975d93a57f8c2aa90bba9c2e23ffcde3b607cfcf2d92.12.gem/SHA256E-s122880--d434d6cc11b455c373d0975d93a57f8c2aa90bba9c2e23ffcde3b607cfcf2d92.12.gem

--- a/packages/foreman/rubygem-foreman_maintain/rubygem-foreman_maintain.spec
+++ b/packages/foreman/rubygem-foreman_maintain/rubygem-foreman_maintain.spec
@@ -9,7 +9,7 @@
 
 Summary: The Foreman/Satellite maintenance tool
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 0.6.10
+Version: 0.6.12
 Release: 1%{?dist}
 Epoch: 1
 Group: Development/Languages
@@ -123,6 +123,12 @@ install -D -m0640 %{buildroot}%{gem_instdir}/extras/foreman_protector/foreman-pr
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Sep 21 2020 Amit Upadhye <upadhyeammit@gmail.com> 1:0.6.12-1
+- Update to 0.6.12
+
+* Thu Sep 10 2020 Amit Upadhye <upadhyeammit@gmail.com> 1:0.6.11-1
+- Update to 0.6.11
+
 * Fri Sep 04 2020 Amit Upadhye <upadhyeammit@gmail.com> 1:0.6.10-1
 - Update to 0.6.10
 


### PR DESCRIPTION
Bumping formain-maintain to 0.6.12 version to fix yum-utils dependency while doing self upgrade.