### PR TITLE
don't try to build scl-only gems for non-scl

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -182,6 +182,7 @@ foreman_scl_packages:
         - "jenkins_job=hammer-cli-foreman-master-source-release"
         - "jenkins_url=https://ci.theforeman.org"
       build_package_tito_builder: "tito.builder.FetchBuilder"
+    rubygem-hashie: {}
     rubygem-hirb-unicode-steakknife: {}
     rubygem-hirb: {}
     rubygem-hoe: {}
@@ -194,7 +195,9 @@ foreman_scl_packages:
     rubygem-jquery-ui-rails: {}
     rubygem-jwt: {}
     rubygem-ldap_fluff: {}
+    rubygem-little-plugger: {}
     rubygem-locale: {}
+    rubygem-logging: {}
     rubygem-logging-journald: {}
     rubygem-loofah: {}
     rubygem-mail: {}
@@ -236,6 +239,7 @@ foreman_scl_packages:
           dist: '.el7'
     rubygem-patternfly-sass: {}
     rubygem-pg: {}
+    rubygem-powerbar: {}
     rubygem-po_to_json: {}
     rubygem-prometheus-client: {}
     rubygem-promise.rb: {}

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -30,12 +30,7 @@ whitelist = foreman-bootloaders-redhat
   puppet-agent-yard
   rubygem-clamp
   rubygem-foreman_maintain
-  rubygem-hashie
   rubygem-highline
-  rubygem-little-plugger
-  rubygem-logging
-  rubygem-multi_json
-  rubygem-powerbar
 
 [foreman-nightly-rhel7]
 disttag = .el7


### PR DESCRIPTION
2c624dcdbe4f91b7a59142db1d4b07043f184eed removed those from the comps
and the package_manifest, but they were still in tito.props

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
