### PR TITLE
Bump foreman_statistics to 1.0.0

### DIFF
--- a/debian/bionic/foreman/foreman.cron.d
+++ b/debian/bionic/foreman/foreman.cron.d
@@ -15,9 +15,6 @@ FOREMAN_HOME=/usr/share/foreman
 # Expire old reports
 30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake reports:expire >>/var/log/foreman/cron.log 2>&1
 
-# Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake trends:counter >>/var/log/foreman/cron.log 2>&1
-
 # Refreshes ldap usergroups. Can be disabled if you're not using LDAP authentication.
 */30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake ldap:refresh_usergroups >>/var/log/foreman/cron.log 2>&1
 

--- a/debian/buster/foreman/foreman.cron.d
+++ b/debian/buster/foreman/foreman.cron.d
@@ -15,9 +15,6 @@ FOREMAN_HOME=/usr/share/foreman
 # Expire old reports
 30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake reports:expire >>/var/log/foreman/cron.log 2>&1
 
-# Collects trends data
-*/30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake trends:counter >>/var/log/foreman/cron.log 2>&1
-
 # Refreshes ldap usergroups. Can be disabled if you're not using LDAP authentication.
 */30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake ldap:refresh_usergroups >>/var/log/foreman/cron.log 2>&1
 

--- a/plugins/ruby-foreman-statistics/debian/changelog
+++ b/plugins/ruby-foreman-statistics/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-statistics (1.0.0-1) stable; urgency=low
+
+  * 1.0.0 released
+
+ -- Ondřej Ezr <oezr@redhat.com>  Mon, 10 Aug 2020 01:38:10 +0200
+
 ruby-foreman-statistics (0.1.3-1) stable; urgency=low
 
   * 0.1.3 released

--- a/plugins/ruby-foreman-statistics/debian/gem.list
+++ b/plugins/ruby-foreman-statistics/debian/gem.list
@@ -1,2 +1,2 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_statistics-0.1.3.gem"
+GEMS="https://rubygems.org/downloads/foreman_statistics-1.0.0.gem"

--- a/plugins/ruby-foreman-statistics/foreman_statistics.rb
+++ b/plugins/ruby-foreman-statistics/foreman_statistics.rb
@@ -1,1 +1,1 @@
-gem 'foreman_statistics', '0.1.3'
+gem 'foreman_statistics', '1.0.0'


### PR DESCRIPTION
(cherry picked from commit b86d6e8)

AND

The cron job is being obsolete as of theforeman/foreman_statistics#19
This is released in foreman_statistics 1.0

(cherry picked from commit 1c3ce37)