### PR TITLE
Remove trends counter cron job

### DIFF
--- a/packages/foreman/foreman/foreman.cron.d
+++ b/packages/foreman/foreman/foreman.cron.d
@@ -15,23 +15,8 @@ FOREMAN_HOME=/usr/share/foreman
 # Expire old reports
 30 7 * * *      foreman    /usr/sbin/foreman-rake reports:expire >>/var/log/foreman/cron.log 2>&1
 
-# Collects trends data
-*/30 * * * *    foreman    /usr/sbin/foreman-rake trends:counter >>/var/log/foreman/cron.log 2>&1
-
 # Refreshes ldap usergroups. Can be disabled if you're not using LDAP authentication.
 */30 * * * *    foreman    /usr/sbin/foreman-rake ldap:refresh_usergroups >>/var/log/foreman/cron.log 2>&1
 
 # Clean expired notifications
 0 6 * * 0       foreman    /usr/sbin/foreman-rake notifications:clean >>/var/log/foreman/cron.log 2>&1
-
-# Only use the following cronjob if you're not using the ENC or ActiveRecord-based storeconfigs
-# Get the node.rb / ENC script and store at /etc/puppet/node.rb:
-#   https://github.com/theforeman/puppet-foreman/blob/master/templates/external_node.rb.erb
-# Send facts to Foreman, using the ENC script in a fact pushing only mode
-#*/2 * * * *     puppet    /usr/bin/tfm-ruby /etc/puppet/node.rb --push-facts >>/var/log/foreman/cron.log 2>&1
-
-# Warning: ActiveRecord-based storeconfigs is deprecated from Foreman 1.1 and Puppet 3.0
-#   see http://projects.theforeman.org/wiki/foreman/ReleaseNotes#11-stable
-# Only use the following cronjob if you're using ActiveRecord storeconfigs!
-#*/30 * * * *    foreman    /usr/sbin/foreman-rake puppet:migrate:populate_hosts >>/var/log/foreman/cron.log 2>&1
-

--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -9,7 +9,7 @@
 %global scl_ruby_bin /usr/bin/%{?scl:%{scl_prefix}}ruby
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 31
+%global release 32
 %global prereleasesource rc3
 %global prerelease %{?prereleasesource}
 
@@ -1018,6 +1018,9 @@ exit 0
 %systemd_postun %{name}.socket
 
 %changelog
+* Tue Sep 29 2020 Ondrej Ezr <ezrik12@gmail.com> - 2.2.0-0.32.rc3
+- Clean up cron file
+
 * Mon Sep 14 2020 Evgeni Golov - 2.2.0-0.31.rc3
 - Release foreman 2.2.0
 


### PR DESCRIPTION
The cron job is being obsolete as of https://github.com/theforeman/foreman_statistics/pull/19
This is released in foreman_statistics 1.0

(cherry picked from commit 13f0e7af7c99bc90aeb1b95e0e2e15623ef2bcfd)