### PR TITLE
Update rubygem-katello to 3.16.1.2

### DIFF
--- a/packages/katello/rubygem-katello/katello-3.16.1.1.gem
+++ b/packages/katello/rubygem-katello/katello-3.16.1.1.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/9W/xM/SHA256E-s3674624--8e6d84fe9b4d151fa3fa82f7ebd78d3e914581963dcd5b75f825a7e3198dc9ce.1.gem/SHA256E-s3674624--8e6d84fe9b4d151fa3fa82f7ebd78d3e914581963dcd5b75f825a7e3198dc9ce.1.gem

--- a/packages/katello/rubygem-katello/katello-3.16.1.2.gem
+++ b/packages/katello/rubygem-katello/katello-3.16.1.2.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/fq/Kv/SHA256E-s3675136--a221cead0ecc464ea5b3f7b84cabb4e3d7fcffb55f86d10624fb1723b97e1cc4.2.gem/SHA256E-s3675136--a221cead0ecc464ea5b3f7b84cabb4e3d7fcffb55f86d10624fb1723b97e1cc4.2.gem

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -6,7 +6,7 @@
 %global foreman_max_version 2.2
 %global plugin_name katello
 %global gem_name katello
-%global mainver 3.16.1.1
+%global mainver 3.16.1.2
 %global release 1
 
 Name:    %{?scl_prefix}rubygem-%{gem_name}
@@ -245,6 +245,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/webpack
 
 %changelog
+* Mon Oct 05 2020 ianballou <ianballou67@gmail.com> 3.16.1.2-1
+- Update to 3.16.1.2
+
 * Thu Oct 01 2020 Evgeni Golov - 3.16.1.1-1
 - Release rubygem-katello 3.16.1.1
 


### PR DESCRIPTION
I noticed the 3.16.1.1 version bump didn't contain any other gem version updates in the spec file, should those have stayed the same?  They match what I have in katello.gemspec now.