### PR TITLE
Remove fedora 29 from rpm/2.3

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -722,8 +722,6 @@ foreman_client_packages:
         dist: '.el7'
       - name: "foreman-client-{{ foreman_version }}-rhel6"
         dist: '.el6'
-      - name: "foreman-client-{{ foreman_version }}-fedora29"
-        dist: '.fc29'
     repoclosure_target_repos:
       el8:
         - "el8-foreman-client-{{ foreman_version }}"
@@ -731,8 +729,6 @@ foreman_client_packages:
         - "el7-foreman-client-{{ foreman_version }}"
       rhel6:
         - "el6-foreman-client-{{ foreman_version }}"
-      fedora29:
-        - "f29-foreman-client-{{ foreman_version }}"
     repoclosure_lookaside_repos:
       el8:
         - el8-baseos
@@ -756,10 +752,6 @@ foreman_client_packages:
         - el6-qpid
         - el6-subscription-manager
         - el6-pulp
-      fedora29:
-        - f29-base
-        - f29-updates
-        - f29-puppet-6
   hosts:
     ansible-collection-theforeman-foreman: {}
     katello-host-tools: {}
@@ -1191,16 +1183,6 @@ repoclosures:
           - el6-qpid
           - el6-pulp
           - el6-subscription-manager
-    foreman-client-repoclosure-f29:
-      repoclosure_target_repos:
-        fedora29:
-          - "f29-foreman-client-{{ foreman_version }}"
-      repoclosure_target_dist: fedora29
-      repoclosure_lookaside_repos:
-        fedora29:
-          - f29-base
-          - f29-updates
-          - f29-puppet-6
 
 
 foreman_release_packages:
@@ -1216,8 +1198,6 @@ foreman_release_packages:
         dist: '.el7'
       - name: "foreman-client-{{ foreman_version }}-rhel6"
         dist: '.el6'
-      - name: "foreman-client-{{ foreman_version }}-fedora29"
-        dist: '.fc29'
     releasers:
       - koji-foreman
       - koji-foreman-client
@@ -1229,8 +1209,6 @@ foreman_release_packages:
         - "el7-foreman-client-{{ foreman_version }}"
       rhel6:
         - "el6-foreman-client-{{ foreman_version }}"
-      fedora29:
-        - "f29-foreman-client-{{ foreman_version }}"
     repoclosure_lookaside_repos:
       el8:
         - el8-baseos
@@ -1254,9 +1232,5 @@ foreman_release_packages:
         - el6-qpid
         - el6-subscription-manager
         - el6-pulp
-      fedora29:
-        - f29-base
-        - f29-updates
-        - f29-puppet-6
   hosts:
     foreman-release: {}

--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -24,11 +24,11 @@ builder.rpmbuild_options = --define "foremandist .fm2_3"
 
 [koji-foreman-client]
 releaser = tito.release.KojiReleaser
-autobuild_tags = foreman-client-2.3-rhel6 foreman-client-2.3-rhel7 foreman-client-2.3-el8 foreman-client-2.3-fedora29
+autobuild_tags = foreman-client-2.3-rhel6 foreman-client-2.3-rhel7 foreman-client-2.3-el8
 
 [koji-foreman-client-jenkins]
 releaser = tito.release.KojiReleaser
-autobuild_tags = foreman-client-2.3-rhel6 foreman-client-2.3-rhel7 foreman-client-2.3-el8 foreman-client-2.3-fedora29
+autobuild_tags = foreman-client-2.3-rhel6 foreman-client-2.3-rhel7 foreman-client-2.3-el8
 builder = tito.builder.FetchBuilder
 
 # Katello Releasers

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1052,16 +1052,6 @@ whitelist = foreman-release
   katello-host-tools
   rubygem-foreman_scap_client
 
-[foreman-client-2.3-fedora29]
-disttag = .fc29
-whitelist =
-  ansible-collection-theforeman-foreman
-  foreman-release
-  katello-host-tools
-  python-apypie
-  rubygem-foreman_scap_client
-  tracer
-
 [katello-2.3-rhel7]
 disttag = .el7
 scl = tfm


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
