### PR TITLE
Update rubygem-hammer_cli_foreman_remote_execution to 0.2.0

### DIFF
--- a/dependencies/bionic/hammer_cli_foreman_remote_execution/changelog
+++ b/dependencies/bionic/hammer_cli_foreman_remote_execution/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-remote-execution (0.2.0-1) stable; urgency=low
+
+  * 0.2.0 released
+
+ -- Adam Růžička <aruzicka@redhat.com>  Mon, 09 Nov 2020 12:17:00 +0100
+
 ruby-hammer-cli-foreman-remote-execution (0.1.2-1) stable; urgency=low
 
   * 0.1.2 released

--- a/dependencies/buster/hammer_cli_foreman_remote_execution/changelog
+++ b/dependencies/buster/hammer_cli_foreman_remote_execution/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-remote-execution (0.2.0-1) stable; urgency=low
+
+  * 0.2.0 released
+
+ -- Adam Růžička <aruzicka@redhat.com>  Mon, 09 Nov 2020 12:17:00 +0100
+
 ruby-hammer-cli-foreman-remote-execution (0.1.2-1) stable; urgency=low
 
   * 0.1.2 released

--- a/dependencies/focal/hammer_cli_foreman_remote_execution/changelog
+++ b/dependencies/focal/hammer_cli_foreman_remote_execution/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-remote-execution (0.2.0-1) stable; urgency=low
+
+  * 0.2.0 released
+
+ -- Adam Růžička <aruzicka@redhat.com>  Mon, 09 Nov 2020 12:17:00 +0100
+
 ruby-hammer-cli-foreman-remote-execution (0.1.2-1) stable; urgency=low
 
   * 0.1.2 released


### PR DESCRIPTION
(cherry picked from commit 79f102eab8f6cfae253bec3540c0d1c640ff3639)
