### PR TITLE
Let cockpit subpackage depend on exact version of the main package

### DIFF
--- a/packages/plugins/rubygem-foreman_remote_execution/rubygem-foreman_remote_execution.spec
+++ b/packages/plugins/rubygem-foreman_remote_execution/rubygem-foreman_remote_execution.spec
@@ -11,7 +11,7 @@
 Summary:    Plugin that brings remote execution capabilities to Foreman
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    4.1.0
-Release:    1%{?foremandist}%{?dist}
+Release:    2%{?foremandist}%{?dist}
 Group:      Applications/Systems
 License:    GPLv3
 URL:        https://github.com/theforeman/foreman_remote_execution
@@ -60,7 +60,8 @@ management functionality with remote management functionality.
 
 %package cockpit
 BuildArch:  noarch
-Requires:   cockpit
+Requires: cockpit
+Requires: %{?scl_prefix}%{pkg_name} = %{version}-%{release}
 Requires(post): systemd-units
 Requires(preun): systemd-units
 Summary:    Cockpit integration using remote execution connection
@@ -160,6 +161,9 @@ install -Dp -m0644 %{buildroot}%{gem_instdir}/extra/cockpit/settings.yml.example
 %{_unitdir}/foreman-cockpit.service
 
 %changelog
+* Thu Nov 12 2020 Evgeni Golov 4.1.0-2
+- Let cockpit subpackage depend on exact version of the main package
+
 * Tue Sep 01 2020 Adam Ruzicka <aruzicka@redhat.com> 4.1.0-1
 - Update to 4.1.0
 


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
