### PR TITLE
Fixes #31324 - Katello 3.17 should use Pulpcore 3.7

### DIFF
--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -2,7 +2,7 @@
 %global pulp_version 2.21
 %global use_pulp_nightly false
 
-%global pulpcore_version 3.6
+%global pulpcore_version 3.7
 
 %define repo_dir %{_sysconfdir}/yum.repos.d
 %define repo_dist %{dist}


### PR DESCRIPTION
Katello 3.17 should use Pulpcore 3.7.