### PR TITLE
Refs #31324 - Katello 3.17 should use Pulpcore 3.7

### DIFF
--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -7,7 +7,7 @@
 %define repo_dir %{_sysconfdir}/yum.repos.d
 %define repo_dist %{dist}
 
-%global release 1
+%global release 2
 
 Name:           katello-repos
 Version:        3.17.0
@@ -81,6 +81,9 @@ rm -rf %{buildroot}
 %config %{repo_dir}/*.repo
 
 %changelog
+* Wed Nov 18 2020 Ian Ballou <ianballou67@gmail.com> - 3.17.0-2
+- Add pulpcore 3.7 repos
+
 * Mon Nov 09 2020 Patrick Creech <pcreech@redhat.com> - 3.17.0-1
 - Release katello-repos 3.17.0
 


### PR DESCRIPTION
[This PR](https://github.com/theforeman/foreman-packaging/pull/5995) was missing the changelog entry and release version bump.