### PR TITLE
Fix mv-error if non-empty dir is in rex-ssh dir

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
+++ b/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.3.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Ssh remote execution provider for Foreman Smart-Proxy
 Group: Applications/Internet
 License: GPLv3
@@ -91,6 +91,9 @@ gem build %{gem_name}.gemspec
 
 %pre
 if [ -d %{foreman_proxy_dir}/.ssh ] && [ ! -L %{foreman_proxy_dir}/.ssh ] ; then
+  if [ -d %{foreman_proxy_statedir}/ssh ] ; then
+    mv %{foreman_proxy_statedir}/ssh %{foreman_proxy_statedir}/ssh.save$(date '+%%y%%m%%d%%H%%M')
+  fi
   mv %{foreman_proxy_dir}/.ssh %{foreman_proxy_statedir}/ssh
 fi
 
@@ -135,6 +138,9 @@ EOF
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Thu Nov 26 2020 Markus Bucher <bucher@atix.de> 0.3.1-2
+- Fix remove files and dirs from ssh-dir before move
+
 * Mon Nov 09 2020 Adam Ruzicka <aruzicka@redhat.com> 0.3.1-1
 - Update to 0.3.1
 


### PR DESCRIPTION
Not yet sure if this makes sense, but we had people experiencing the following error during upgrade of `tfm-rubygem-smart_proxy_remote_execution_ssh`:
```
mv: inter-device move failed: ‘/usr/share/foreman-proxy/.ssh’ to ‘/var/lib/foreman-proxy/ssh/.ssh’; unable to remove target: Directory not empty
error: %pre(tfm-rubygem-smart_proxy_remote_execution_ssh-0.3.0-4.fm2_1.el7.noarch) scriptlet failed, exit status 1
```
Reason was there was a non-empty `.ssh`-directory existing in `/var/lib/foreman-proxy/ssh`
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
