### PR TITLE
Update foreman-monitoring to 2.1.0

### DIFF
--- a/plugins/ruby-foreman-monitoring/debian/changelog
+++ b/plugins/ruby-foreman-monitoring/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-monitoring (2.1.0-1) stable; urgency=low
+
+  * 2.1.0 released
+
+ -- Dirk Goetz <dirk.goetz@netways.de>  Tue, 01 Dec 2020 15:37:35 +0100
+
 ruby-foreman-monitoring (1.0.1-1) stable; urgency=low
 
   * 1.0.1 released

--- a/plugins/ruby-foreman-monitoring/debian/gem.list
+++ b/plugins/ruby-foreman-monitoring/debian/gem.list
@@ -1,2 +1,2 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_monitoring-1.0.1.gem"
+GEMS="https://rubygems.org/downloads/foreman_monitoring-2.1.0.gem"

--- a/plugins/ruby-foreman-monitoring/foreman_monitoring.rb
+++ b/plugins/ruby-foreman-monitoring/foreman_monitoring.rb
@@ -1,1 +1,1 @@
-gem 'foreman_monitoring', '1.0.1'
+gem 'foreman_monitoring', '2.1.0'


### PR DESCRIPTION
And here is it for Debian, hope this is correct, too. If yes, I will do cherry picks here also for 2.2 and 2.3.