### PR TITLE
Add wrapper-script to select python-exe for salt

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
+++ b/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
@@ -104,9 +104,6 @@ sed -i -e '1s|^#!.*$|#!%{_root_bindir}/salt_python_wrapper|' sbin/upload-salt-re
 gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
 %{?scl:EOF}
 
-cp %{SOURCE1} .%{_bindir}/salt_python_wrapper
-chmod a+x .%{_bindir}/salt_python_wrapper
-
 %build
 # Create the gem as gem install only works on a gem file
 %{?scl:scl enable %{scl} - << \EOF}
@@ -118,6 +115,9 @@ gem build %{gem_name}.gemspec
 %{?scl:scl enable %{scl} - << \EOF}
 %gem_install
 %{?scl:EOF}
+
+cp %{SOURCE1} .%{_bindir}/salt_python_wrapper
+chmod a+x .%{_bindir}/salt_python_wrapper
 
 %install
 mkdir -p %{buildroot}%{_root_sysconfdir}/cron.d

--- a/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
+++ b/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
@@ -40,6 +40,7 @@ Group: Applications/System
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_salt
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
+Source1: salt_python_wrapper
 
 Requires: salt-master
 %if %{with python2}
@@ -103,6 +104,9 @@ sed -i -e '1s|^#!.*$|#!%{_root_bindir}/salt_python_wrapper|' sbin/upload-salt-re
 gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
 %{?scl:EOF}
 
+cp %{SOURCE1} .%{_bindir}/salt_python_wrapper
+chmod a+x .%{_bindir}/salt_python_wrapper
+
 %build
 # Create the gem as gem install only works on a gem file
 %{?scl:scl enable %{scl} - << \EOF}
@@ -114,26 +118,6 @@ gem build %{gem_name}.gemspec
 %{?scl:scl enable %{scl} - << \EOF}
 %gem_install
 %{?scl:EOF}
-
-cat <<EOF >.%{_bindir}/salt_python_wrapper
-#!/bin/sh
-
-set -eu
-
-for py in 'python3' 'python'; do
-  exe=\$(type -p \${py})
-  if [ -n "\${exe}" ]; then
-    if \${exe} -c 'import salt.config'; then
-      \${exe} "\$@"
-      exit \$?
-    fi
-  fi
-done
-
-echo "No usable python version found, check if python-salt-library is installed!" 1>&2
-exit 1
-EOF
-chmod a+x .%{_bindir}/salt_python_wrapper
 
 %install
 mkdir -p %{buildroot}%{_root_sysconfdir}/cron.d

--- a/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
+++ b/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
@@ -35,7 +35,7 @@
 Summary: SaltStack support for Foreman Smart-Proxy
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.1.2
-Release: 6%{?foremandist}%{?dist}
+Release: 7%{?foremandist}%{?dist}
 Group: Applications/System
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_salt
@@ -97,13 +97,7 @@ gem unpack %{SOURCE0}
 
 %setup -q -D -T -n  %{gem_name}-%{version}
 
-%if %{with python2} && 0%{?rhel} >= 8
-sed -i -e '1s|^#!.*$|#!%{__python2}|' sbin/upload-salt-reports
-%endif
-
-%if %{with python3} && 0%{?rhel} >= 8
-sed -i -e '1s|^#!.*$|#!%{__python3}|' sbin/upload-salt-reports
-%endif
+sed -i -e '1s|^#!.*$|#!%{_root_bindir}/salt_python_wrapper|' sbin/upload-salt-reports
 
 %{?scl:scl enable %{scl} - << \EOF}
 gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
@@ -120,6 +114,26 @@ gem build %{gem_name}.gemspec
 %{?scl:scl enable %{scl} - << \EOF}
 %gem_install
 %{?scl:EOF}
+
+cat <<EOF >.%{_bindir}/salt_python_wrapper
+#!/bin/sh
+
+set -eu
+
+for py in 'python3' 'python'; do
+  exe=\$(type -p \${py})
+  if [ -n "\${exe}" ]; then
+    if \${exe} -c 'import salt.config'; then
+      \${exe} "\$@"
+      exit \$?
+    fi
+  fi
+done
+
+echo "No usable python version found, check if python-salt-library is installed!" 1>&2
+exit 1
+EOF
+chmod a+x .%{_bindir}/salt_python_wrapper
 
 %install
 mkdir -p %{buildroot}%{_root_sysconfdir}/cron.d
@@ -162,6 +176,7 @@ EOF
 %files
 %dir %{gem_instdir}
 %{_root_bindir}/foreman-node
+%{_root_bindir}/salt_python_wrapper
 %{_root_sbindir}/upload-salt-reports
 %config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/salt.saltfile
 %config(noreplace) %attr(0640, root, foreman-proxy) %{foreman_proxy_settingsd_dir}/salt.yml
@@ -186,6 +201,10 @@ EOF
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Thu Dec 10 2020 Markus Bucher <bucher@atix.de> - 3.1.2-7
+- Add salt_python_wrapper to select correct
+  python-exe for upload-salt-reports
+
 * Thu Jul 09 2020 Bernhard Suttner <suttner@atix.de> - 3.1.2-6
 - Fix upload-salt-report path
 - Fix hashbang for foreman-node helper script

--- a/packages/plugins/rubygem-smart_proxy_salt/salt_python_wrapper
+++ b/packages/plugins/rubygem-smart_proxy_salt/salt_python_wrapper
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -eu
+
+for py in 'python3' 'python'; do
+  exe=$(type -p ${py})
+  if [ -n "${exe}" ]; then
+    if ${exe} -c 'import salt.config'; then
+      ${exe} "$@"
+      exit $?
+    fi
+  fi
+done
+
+echo "No usable python version found, check if python-salt-library is installed!" 1>&2
+exit 1


### PR DESCRIPTION
Since the python-version that needs to be used for `upload-salt-reports` does primarily depend on whether the python2 or python3 version of the Saltstack python-lib is installed, it might be better to have a wrapper script to dynamically decide, which python needs to be used.
The script prefers python3.

It might be better placed in https://github.com/theforeman/smart_proxy_salt repository instead of Adding it through the spec-file, but this was the fastest solution to test this :grin: 
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
