### PR TITLE
Clean up tito.props and comps

### DIFF
--- a/comps/comps-foreman-el8.xml
+++ b/comps/comps-foreman-el8.xml
@@ -123,13 +123,11 @@
       <packagereq type="default">rubygem-actionview</packagereq>
       <packagereq type="default">rubygem-activejob</packagereq>
       <packagereq type="default">rubygem-activemodel</packagereq>
-      <packagereq type="default">rubygem-activepack</packagereq>
       <packagereq type="default">rubygem-activerecord</packagereq>
       <packagereq type="default">rubygem-activerecord-nulldb-adapter</packagereq>
       <packagereq type="default">rubygem-activerecord-session_store</packagereq>
       <packagereq type="default">rubygem-activestorage</packagereq>
       <packagereq type="default">rubygem-activesupport</packagereq>
-      <packagereq type="default">rubygem-activeview</packagereq>
       <packagereq type="default">rubygem-addressable</packagereq>
       <packagereq type="default">rubygem-algebrick</packagereq>
       <packagereq type="default">rubygem-amazing_print</packagereq>
@@ -249,7 +247,6 @@
       <packagereq type="default">rubygem-ovirt-engine-sdk</packagereq>
       <packagereq type="default">rubygem-paint</packagereq>
       <packagereq type="default">rubygem-parallel</packagereq>
-      <packagereq type="default">rubygem-passenger</packagereq>
       <packagereq type="default">rubygem-patternfly-sass</packagereq>
       <packagereq type="default">rubygem-pg</packagereq>
       <packagereq type="default">rubygem-po_to_json</packagereq>
@@ -317,7 +314,6 @@
       <packagereq type="default">rubygem-thor</packagereq>
       <packagereq type="default">rubygem-thread_safe</packagereq>
       <packagereq type="default">rubygem-tilt</packagereq>
-      <packagereq type="default">rubygem-turbolinks</packagereq>
       <packagereq type="default">rubygem-tzinfo</packagereq>
       <packagereq type="default">rubygem-uber</packagereq>
       <packagereq type="default">rubygem-uglifier</packagereq>
@@ -470,7 +466,6 @@
       <packagereq type="default">rubygem-ovirt-engine-sdk-doc</packagereq>
       <packagereq type="default">rubygem-paint-doc</packagereq>
       <packagereq type="default">rubygem-parallel-doc</packagereq>
-      <packagereq type="default">rubygem-passenger-doc</packagereq>
       <packagereq type="default">rubygem-patternfly-sass-doc</packagereq>
       <packagereq type="default">rubygem-pg-doc</packagereq>
       <packagereq type="default">rubygem-po_to_json-doc</packagereq>

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -22,7 +22,6 @@ whitelist = foreman-bootloaders-redhat
   foreman-selinux
   katello-certs-tools
   keycloak-httpd-client-install
-  nodejs-node-gyp
   pcp-mmvstatsd
   puppet-agent-oauth
   puppet-agent-puppet-strings
@@ -55,7 +54,6 @@ whitelist = foreman
   nodejs-c3
   nodejs-compression-webpack-plugin
   nodejs-core-js
-  nodejs-css-element-queries
   nodejs-css-loader
   nodejs-d3
   nodejs-dotenv
@@ -115,7 +113,6 @@ whitelist = foreman
   rubygem-actionview
   rubygem-activejob
   rubygem-activemodel
-  rubygem-activepack
   rubygem-activerecord
   rubygem-activerecord-nulldb-adapter
   rubygem-activerecord-session_store
@@ -307,7 +304,6 @@ whitelist = foreman
   rubygem-thor
   rubygem-thread_safe
   rubygem-tilt
-  rubygem-turbolinks
   rubygem-tzinfo
   rubygem-uber
   rubygem-uglifier
@@ -420,13 +416,11 @@ whitelist = foreman
   rubygem-actionview
   rubygem-activejob
   rubygem-activemodel
-  rubygem-activepack
   rubygem-activerecord
   rubygem-activerecord-nulldb-adapter
   rubygem-activerecord-session_store
   rubygem-activestorage
   rubygem-activesupport
-  rubygem-activeview
   rubygem-addressable
   rubygem-algebrick
   rubygem-amazing_print
@@ -614,7 +608,6 @@ whitelist = foreman
   rubygem-thor
   rubygem-thread_safe
   rubygem-tilt
-  rubygem-turbolinks
   rubygem-tzinfo
   rubygem-uber
   rubygem-uglifier


### PR DESCRIPTION
2c624dcdbe4f91b7a59142db1d4b07043f184eed removed nodejs-node-gyp from non-SCL, but left one entry in.

162257c13fb80076465f01c055c55a762e032412 removed nodejs-css-element-queries but left a tito entry.

eb6690230abb3ca5bae80d67a2936b20c2a5601d added an entry for rubygem-activepack, rubygem-activeview and rubygem-turbolinks but the actual packages don't exist.