### PR TITLE
Fix deployment of bundler.d files for ansible-core

### DIFF
--- a/dependencies/bionic/foreman_ansible_core/changelog
+++ b/dependencies/bionic/foreman_ansible_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-ansible-core (4.0.0-1) stable; urgency=low
+
+  * 4.0.0 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Mon, 18 Jan 2021 14:18:49 +0100
+
 ruby-foreman-ansible-core (3.0.4-1) stable; urgency=low
 
   * 3.0.4 released

--- a/dependencies/bionic/foreman_ansible_core/foreman_ansible_core.rb
+++ b/dependencies/bionic/foreman_ansible_core/foreman_ansible_core.rb
@@ -1,0 +1,1 @@
+gem 'foreman_ansible_core'

--- a/dependencies/bionic/foreman_ansible_core/install
+++ b/dependencies/bionic/foreman_ansible_core/install
@@ -1,0 +1,1 @@
+debian/foreman_ansible_core.rb usr/share/foreman-proxy/bundler.d

--- a/dependencies/buster/foreman_ansible_core/changelog
+++ b/dependencies/buster/foreman_ansible_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-ansible-core (4.0.0-1) stable; urgency=low
+
+  * 4.0.0 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Mon, 18 Jan 2021 14:18:49 +0100
+
 ruby-foreman-ansible-core (3.0.4-1) stable; urgency=low
 
   * 3.0.4 released

--- a/dependencies/buster/foreman_ansible_core/foreman_ansible_core.rb
+++ b/dependencies/buster/foreman_ansible_core/foreman_ansible_core.rb
@@ -1,0 +1,1 @@
+gem 'foreman_ansible_core'

--- a/dependencies/buster/foreman_ansible_core/install
+++ b/dependencies/buster/foreman_ansible_core/install
@@ -1,0 +1,1 @@
+debian/foreman_ansible_core.rb usr/share/foreman-proxy/bundler.d

--- a/dependencies/focal/foreman_ansible_core/changelog
+++ b/dependencies/focal/foreman_ansible_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-ansible-core (4.0.0-1) stable; urgency=low
+
+  * 4.0.0 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Mon, 18 Jan 2021 14:18:49 +0100
+
 ruby-foreman-ansible-core (3.0.4-1) stable; urgency=low
 
   * 3.0.4 released

--- a/dependencies/focal/foreman_ansible_core/foreman_ansible_core.rb
+++ b/dependencies/focal/foreman_ansible_core/foreman_ansible_core.rb
@@ -1,0 +1,1 @@
+gem 'foreman_ansible_core'

--- a/dependencies/focal/foreman_ansible_core/install
+++ b/dependencies/focal/foreman_ansible_core/install
@@ -1,0 +1,1 @@
+debian/foreman_ansible_core.rb usr/share/foreman-proxy/bundler.d


### PR DESCRIPTION
For remote execution the `gem 'foreman_remote_execution_core'` gets deployed when installing `ruby-smart-proxy-remote-execution-ssh`, which feels less clean than this approach.

CPs:
- [ ] 2.3
- [ ] 2.2