### PR TITLE
Add generated bundled information for f-installer

### DIFF
--- a/packages/foreman/foreman-installer/foreman-installer.prov
+++ b/packages/foreman/foreman-installer/foreman-installer.prov
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import sys
+import json
+
+
+for path in sorted(sys.argv[1:]):
+    with open(path, 'rb') as fp:
+        metadata = json.load(fp)
+
+    name = metadata['name'].replace('/', '-').split('-', 1)[1]
+    version = metadata['version']
+    print('bundled(puppet-module(%s)) = %s' % (name, version))

--- a/packages/foreman/foreman-installer/foreman-installer.spec
+++ b/packages/foreman/foreman-installer/foreman-installer.spec
@@ -1,7 +1,7 @@
 %{?scl:%global scl_prefix %{scl}-}
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 1
+%global release 2
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -14,6 +14,10 @@ Group:      Applications/System
 License:    GPLv3+ and ASL 2.0
 URL:        https://theforeman.org
 Source0:    https://downloads.theforeman.org/%{name}/%{name}-%{version}%{?prerelease:-}%{?prerelease}.tar.bz2
+Source1:    %{name}.prov
+
+%global __foreman_installer_provides %{SOURCE1}
+%global __foreman_installer_path ^%{_datadir}/%{name}/modules/*/metadata.json
 
 BuildArch:  noarch
 
@@ -146,6 +150,9 @@ done
 %{_sbindir}/foreman-proxy-certs-generate
 
 %changelog
+* Tue Jan 05 2021 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1:2.4.0-0.2.develop
+- Add generated info about bundled modules
+
 * Mon Nov 02 2020 Patrick Creech <pcreech@redhat.com> - 1:2.4.0-0.1.develop
 - Bump version to 2.4-develop
 


### PR DESCRIPTION
It's very useful to know which versions of modules are shipped by the installer. It's tedious to maintain this by hand so the dependency generator is used to generate it on the fly.

It's a draft since I don't even know if this is valid. https://rpm.org/user_doc/dependency_generators.html only describes the case where it's common, but for this use case it's mostly just painful to ship a macros package as a build dependency. This first tries out if it can directly use a Source.