### PR TITLE
Fixes #31598 - Don't recreate AAAA record as A

### DIFF
--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -334,7 +334,7 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
       begin
         aaaa_record = resolver.getresource(@old_hostname, Resolv::DNS::Resource::IN::AAAA)
         commands << "update delete #{@old_hostname} AAAA"
-        commands << "update add #{@new_hostname} #{aaaa_record.ttl} A #{aaaa_record.address}"
+        commands << "update add #{@new_hostname} #{aaaa_record.ttl} AAAA #{aaaa_record.address}"
       rescue Resolv::ResolvError => e
         # This is fine
       end


### PR DESCRIPTION
Evidently we aren't managing IPv6 downstream (see bugzilla), so I've made that the case here.