### PR TITLE
foreman-bootloaders-redhat: Add efinet module to Grub2 modules.

### DIFF
--- a/packages/foreman/foreman-bootloaders-redhat/foreman-bootloaders-redhat.spec
+++ b/packages/foreman/foreman-bootloaders-redhat/foreman-bootloaders-redhat.spec
@@ -1,5 +1,5 @@
 Name: foreman-bootloaders-redhat
-Version: 202005201200
+Version: 202102211600
 Release: 1%{?dist}
 Summary: Metapackage with Grub2 and Shim TFTP bootloaders
 
@@ -69,6 +69,10 @@ install -Dp -m0755 %{SOURCE0} %{buildroot}%{_bindir}/foreman-generate-bootloader
 
 
 %changelog
+* Mon Jan 25 2021 Oliver Freyermuth <o.freyermuth@googlemail.com> 202102211600-1
+- Add efinet module to Grub2 modules.
+- Set prefix "grub2" in generated Grub2.
+
 * Fri Apr 17 2020 Lukas Zapletal <lzap+rpm@redhat.com> 202005201200-1
 - BZ#1702434 - unmanaged files and permissions
 

--- a/packages/foreman/foreman-bootloaders-redhat/foreman-generate-bootloaders
+++ b/packages/foreman/foreman-bootloaders-redhat/foreman-generate-bootloaders
@@ -13,7 +13,7 @@ MODULES="all_video boot btrfs cat configfile echo efinet ext2 fat font gfxmenu g
 
 generate() {
   grub2-mknetdir --net-directory=/var/lib/tftpboot/ --locales="" --fonts="" -d /usr/lib/grub/$1/ --subdir=grub2 >/dev/null
-  grub2-mkimage -d /usr/lib/grub/$1/ -O $1 -o /var/lib/tftpboot/$2 -p "" $MODULES
+  grub2-mkimage -d /usr/lib/grub/$1/ -O $1 -o /var/lib/tftpboot/$2 -p "grub2" $MODULES
 }
 
 check_pkg() {

--- a/packages/foreman/foreman-bootloaders-redhat/foreman-generate-bootloaders
+++ b/packages/foreman/foreman-bootloaders-redhat/foreman-generate-bootloaders
@@ -9,7 +9,7 @@
 #   foreman-generate-boot [x86|aa64|ppc|ppc64|ppc64le]
 
 ARCH=${1:-x86_64}
-MODULES="all_video boot btrfs cat configfile echo ext2 fat font gfxmenu gfxterm gzio halt hfsplus iso9660 jpeg loadenv loopback lvm mdraid09 mdraid1x minicmd normal part_apple part_msdos part_gpt password_pbkdf2 png reboot search search_fs_uuid search_fs_file search_label serial sleep syslinuxcfg test tftp video xfs linux"
+MODULES="all_video boot btrfs cat configfile echo efinet ext2 fat font gfxmenu gfxterm gzio halt hfsplus iso9660 jpeg loadenv loopback lvm mdraid09 mdraid1x minicmd normal part_apple part_msdos part_gpt password_pbkdf2 png reboot search search_fs_uuid search_fs_file search_label serial sleep syslinuxcfg test tftp video xfs linux"
 
 generate() {
   grub2-mknetdir --net-directory=/var/lib/tftpboot/ --locales="" --fonts="" -d /usr/lib/grub/$1/ --subdir=grub2 >/dev/null


### PR DESCRIPTION
This module is needed for network connectivity on UEFI systems,
and used e.g. for loading the grub.cfg and additional Grub2 modules
when booting via UEFI PXE.
