### PR TITLE
foreman-bootloaders-redhat: Set prefix "grub2" in generated Grub2.

### DIFF
--- a/packages/foreman/foreman-bootloaders-redhat/foreman-generate-bootloaders
+++ b/packages/foreman/foreman-bootloaders-redhat/foreman-generate-bootloaders
@@ -13,7 +13,7 @@ MODULES="all_video boot btrfs cat configfile echo ext2 fat font gfxmenu gfxterm 
 
 generate() {
   grub2-mknetdir --net-directory=/var/lib/tftpboot/ --locales="" --fonts="" -d /usr/lib/grub/$1/ --subdir=grub2 >/dev/null
-  grub2-mkimage -d /usr/lib/grub/$1/ -O $1 -o /var/lib/tftpboot/$2 -p "" $MODULES
+  grub2-mkimage -d /usr/lib/grub/$1/ -O $1 -o /var/lib/tftpboot/$2 -p "grub2" $MODULES
 }
 
 check_pkg() {


### PR DESCRIPTION
This is the actual prefix used in the tftpboot layout,
and embedding it into the image increases compatibility.

An example case are DHCP servers sending the boot_file in
DHCP option 67 instead of using the classic BOOTP field
to conserve space.
This is not yet handled in Grub2 < 2.0.4, which then fails
to find its configuration unless the prefix is known.
