### PR TITLE
Require container-selinux by Katello

### DIFF
--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,7 +5,7 @@
 %global confdir common
 %global prereleasesource master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 4
+%global release 5
 
 Name:       katello
 Version:    4.0.0
@@ -115,6 +115,9 @@ Summary:    Common runtime components of %{name}
 
 Requires:       rubygem-highline
 Requires:       %{name}-debug
+%if 0%{?rhel} == 8
+Requires:       container-selinux
+%endif
 
 %description common
 Common runtime components of %{name}
@@ -170,6 +173,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Mon Feb 01 2021 Eric D. Helms <ericdhelms@gmail.com> - 4.0.0-0.5.master
+- Require container-selinux on EL8 until https://github.com/pulp/pulpcore-selinux/pull/33 is released
+
 * Mon Feb 01 2021 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 4.0.0-0.4.master
 - Drop katello-{backup,restore} stubs
 


### PR DESCRIPTION
Temporary until https://github.com/pulp/pulpcore-selinux/pull/33 is
released in a Pulp 3 release. Otherwise pulpcore-api.socket cannot
be accessed by Apache.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
