### PR TITLE
foreman-bootloaders-redhat: Add efinet only on *-efi platforms.

### DIFF
--- a/packages/foreman/foreman-bootloaders-redhat/foreman-bootloaders-redhat.spec
+++ b/packages/foreman/foreman-bootloaders-redhat/foreman-bootloaders-redhat.spec
@@ -1,5 +1,5 @@
 Name: foreman-bootloaders-redhat
-Version: 202102211600
+Version: 202102220000
 Release: 1%{?dist}
 Summary: Metapackage with Grub2 and Shim TFTP bootloaders
 
@@ -69,6 +69,9 @@ install -Dp -m0755 %{SOURCE0} %{buildroot}%{_bindir}/foreman-generate-bootloader
 
 
 %changelog
+* Fri Feb 19 2021 Oliver Freyermuth <o.freyermuth@googlemail.com> 202102220000-1
+- Add efinet module only on *-efi platforms.
+
 * Mon Jan 25 2021 Oliver Freyermuth <o.freyermuth@googlemail.com> 202102211600-1
 - Add efinet module to Grub2 modules.
 - Set prefix "grub2" in generated Grub2.

--- a/packages/foreman/foreman-bootloaders-redhat/foreman-generate-bootloaders
+++ b/packages/foreman/foreman-bootloaders-redhat/foreman-generate-bootloaders
@@ -9,11 +9,12 @@
 #   foreman-generate-boot [x86|aa64|ppc|ppc64|ppc64le]
 
 ARCH=${1:-x86_64}
-MODULES="all_video boot btrfs cat configfile echo efinet ext2 fat font gfxmenu gfxterm gzio halt hfsplus iso9660 jpeg loadenv loopback lvm mdraid09 mdraid1x minicmd normal part_apple part_msdos part_gpt password_pbkdf2 png reboot search search_fs_uuid search_fs_file search_label serial sleep syslinuxcfg test tftp video xfs linux"
+MODULES="all_video boot btrfs cat configfile echo ext2 fat font gfxmenu gfxterm gzio halt hfsplus iso9660 jpeg loadenv loopback lvm mdraid09 mdraid1x minicmd normal part_apple part_msdos part_gpt password_pbkdf2 png reboot search search_fs_uuid search_fs_file search_label serial sleep syslinuxcfg test tftp video xfs linux"
 
 generate() {
   grub2-mknetdir --net-directory=/var/lib/tftpboot/ --locales="" --fonts="" -d /usr/lib/grub/$1/ --subdir=grub2 >/dev/null
-  grub2-mkimage -d /usr/lib/grub/$1/ -O $1 -o /var/lib/tftpboot/$2 -p "grub2" $MODULES
+  [[ $1 =~ -efi$ ]] && MODULES_EFI="efinet" || MODULES_EFI=""
+  grub2-mkimage -d /usr/lib/grub/$1/ -O $1 -o /var/lib/tftpboot/$2 -p "grub2" $MODULES $MODULES_EFI
 }
 
 check_pkg() {


### PR DESCRIPTION
This fixes an issue introduced in 311d91c98ae7b39088d1aaa90777e8751405705f,
since `efinet.mod` is only provided for `*-efi` platforms.

I introduced that bug in #6219 / version `202102211600-1`. While the generation works, it fails if generation is done for a non-efi platform, since `efinet.mod` does not exist there. 