### PR TITLE
Support more version specifiers in update-requirements

### DIFF
--- a/update-requirements
+++ b/update-requirements
@@ -72,6 +72,9 @@ def get_requirement(version):
 
         return ['>= {}'.format(min_version), '< {}'.format(max_version)]
 
+    if version.startswith('>=') or version.startswith('<'):
+        return [version]
+
     raise ValueError('Unable to handle version {}'.format(version))
 
 


### PR DESCRIPTION
>= is used for the NPM package @theforeman/builder by some packages.