### PR TITLE
Bump Katello to 4.1 + drop Pulp 2 & qpid repos + Pulpcore GPG check

### DIFF
--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -1,12 +1,3 @@
-%global pulp_release stable
-%global pulp_version 2.21
-%global use_pulp_nightly false
-%if 0%{?rhel} == 7
-%global pulp_enabled 1
-%else
-%global pulp_enabled 0
-%endif
-
 %global pulpcore_version 3.9
 
 %define repo_dir %{_sysconfdir}/yum.repos.d
@@ -14,7 +5,7 @@
 
 %global prereleasesource nightly
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 3
+%global release 4
 
 Name:           katello-repos
 Version:        4.0
@@ -66,19 +57,7 @@ for repofile in %{buildroot}%{repo_dir}/*.repo; do
     sed -i "s/@REPO_VERSION@/${REPO_VERSION}/" $repofile
     sed -i "s/@REPO_NAME@/${REPO_NAME}/" $repofile
     sed -i "s/@REPO_GPGCHECK@/${REPO_GPGCHECK}/" $repofile
-    sed -i "s/@PULP_RELEASE@/%pulp_release/" $repofile
-    sed -i "s/@PULP_VERSION@/%pulp_version/" $repofile
-    sed -i "s/@PULP_ENABLED@/%pulp_enabled/" $repofile
     sed -i "s/@PULPCORE_VERSION@/%pulpcore_version/" $repofile
-    if [ "%{use_pulp_nightly}" = true ] ; then
-        PULP_URL_MIDDLE="testing\/automation\/2-master\/stage"
-        PULP_GPG_CHECK=0
-    else
-        PULP_URL_MIDDLE="%{pulp_release}\/%{pulp_version}"
-        PULP_GPG_CHECK=1
-    fi
-    sed -i "s/@PULP_URL_MIDDLE@/${PULP_URL_MIDDLE}/" $repofile
-    sed -i "s/@PULP_GPG_CHECK@/${PULP_GPG_CHECK}/" $repofile
 done
 
 %clean
@@ -89,6 +68,10 @@ rm -rf %{buildroot}
 %config %{repo_dir}/*.repo
 
 %changelog
+* Wed Mar 03 2021 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 4.0-0.4.nightly
+- Remove Pulp 2 and qpid copr repository definitions
+- Always GPG check pulpcore repositories
+
 * Mon Jan 11 2021 Ian Ballou <ianballou67@gmail.com> - 4.0-0.3.nightly
 - use pulpcore 3.9 repos
 

--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -5,10 +5,10 @@
 
 %global prereleasesource nightly
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 4
+%global release 1
 
 Name:           katello-repos
-Version:        4.0
+Version:        4.1
 Release:        %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:        Definition of yum repositories for Katello
 
@@ -68,7 +68,8 @@ rm -rf %{buildroot}
 %config %{repo_dir}/*.repo
 
 %changelog
-* Wed Mar 03 2021 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 4.0-0.4.nightly
+* Wed Mar 03 2021 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 4.1-0.1.nightly
+- Bump to 4.1
 - Remove Pulp 2 and qpid copr repository definitions
 - Always GPG check pulpcore repositories
 

--- a/packages/katello/katello-repos/katello.repo
+++ b/packages/katello/katello-repos/katello.repo
@@ -8,21 +8,6 @@ enabled=1
 gpgcheck=@REPO_GPGCHECK@
 module_hotfixes=1
 
-[pulp]
-name=Pulp Community Release
-baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/@PULP_URL_MIDDLE@/$releasever/$basearch
-gpgkey=https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2
-enabled=@PULP_ENABLED@
-gpgcheck=@PULP_GPG_CHECK@
-module_hotfixes=1
-
-[qpid]
-name=Copr repo for qpid owned by @qpid
-baseurl=https://download.copr.fedorainfracloud.org/results/@qpid/qpid/epel-7-$basearch/
-gpgcheck=@REPO_GPGCHECK@
-gpgkey=https://download.copr.fedorainfracloud.org/results/@qpid/qpid/pubkey.gpg
-enabled=@PULP_ENABLED@
-
 # Candlepin RPMs as supported by Katello - This is a coordinated
 # copy of Candlepin's packages in order to ensure compatibility
 
@@ -39,7 +24,7 @@ name=pulpcore: Fetch, Upload, Organize, and Distribute Software Packages.
 baseurl=https://yum.theforeman.org/pulpcore/@PULPCORE_VERSION@/@DIST@/$basearch/
 gpgkey=https://yum.theforeman.org/pulpcore/@PULPCORE_VERSION@/GPG-RPM-KEY-pulpcore
 enabled=1
-gpgcheck=@REPO_GPGCHECK@
+gpgcheck=1
 module_hotfixes=1
 
 # source repositories
@@ -50,13 +35,6 @@ baseurl=https://fedorapeople.org/groups/katello/releases/source/srpm/@REPO_VERSI
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=0
 gpgcheck=@REPO_GPGCHECK@
-
-[pulp-source]
-name=Pulp Community Release Source
-baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/@PULP_URL_MIDDLE@/$releasever/src/
-gpgkey=https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2
-enabled=0
-gpgcheck=@PULP_GPG_CHECK@
 
 [katello-candlepin-source]
 name=Katello Candlepin source
@@ -70,4 +48,4 @@ name=pulpcore source
 baseurl=https://yum.theforeman.org/pulpcore/@PULPCORE_VERSION@/@DIST@/source/
 gpgkey=https://yum.theforeman.org/pulpcore/@PULPCORE_VERSION@/GPG-RPM-KEY-pulpcore
 enabled=0
-gpgcheck=@REPO_GPGCHECK@
+gpgcheck=1

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,10 +5,10 @@
 %global confdir common
 %global prereleasesource master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 10
+%global release 1
 
 Name:       katello
-Version:    4.0.0
+Version:    4.1.0
 Release:    %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:    A package for managing application life-cycle for Linux systems
 BuildArch:  noarch
@@ -144,6 +144,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Wed Mar 03 2021 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 4.1.0-0.1.master
+- Bump to 4.1
+
 * Mon Feb 15 2021 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 4.0.0-0.10.master
 - Drop Pulp 2 from katello-debug
 


### PR DESCRIPTION
9198ac1c490ecf5a7b53cc21791dddf8e65cc6f0 bumped rubygem-katello to 4.1 but forgot the other packages.

Now that Pulp 2 is removed, there's no reason to ship the repos anymore.

qpid's copr repository is also no longer needed. In 49694ccac9bc3bf8fc5a70d4d2eff748dd04c446 it was added since the packages were removed from EPEL-7 but they have been readded.

Pulpcore repositories are always GPG signed, unlike Katello nightly. This means that it should also always be checked.

This PR replaces https://github.com/theforeman/foreman-packaging/pull/6369. It's a separate commit to make cherry picking easier.