### PR TITLE
Fixes #31870 - Update katello-debug with correct qpid commands

### DIFF
--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,7 +5,7 @@
 %global confdir common
 %global prereleasesource master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 1
+%global release 2
 
 Name:       katello
 Version:    4.1.0
@@ -144,6 +144,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Fri Mar 05 2021 Chris Roberts <chrobert@redhat.com> - 4.1.0-0.2.master
+- Update katello-debug with correct qpid commands
+
 * Wed Mar 03 2021 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 4.1.0-0.1.master
 - Bump to 4.1
 


### PR DESCRIPTION
Output of Qpid commands:

```bash
[root@devel ~]# qpid-stat -q --ssl-certificate=/etc/pki/katello/qpid_router_client.crt --ssl-key=/etc/pki/katello/qpid_router_client.key -b amqps://localhost:5671
Queues
  queue                                     dur  autoDel  excl  msg   msgIn  msgOut  bytes  bytesIn  bytesOut  cons  bind
  =========================================================================================================================
  aaa39fa4-d65a-47ae-8d8c-ca4836ad107b:0.0       Y        Y        0     0      0       0      0        0         1     2
  katello.agent                             Y                      0     0      0       0      0        0         0     1
[root@devel ~]# qpid-stat -u --ssl-certificate=/etc/pki/katello/qpid_router_client.crt --ssl-key=/etc/pki/katello/qpid_router_client.key -b amqps://localhost:5671
Subscriptions
  subscr  queue                                     conn                         procName   procId  browse  acked  excl  creditMode  delivered  sessUnacked
  ===========================================================================================================================================================
  0       7eb70367-1fde-41b8-a20a-02f55f2a3a38:0.0  qpid.[::1]:5671-[::1]:58080  qpid-stat  2161                         CREDIT      0          0
[root@devel ~]# qpid-stat -c --ssl-certificate=/etc/pki/katello/qpid_router_client.crt --ssl-key=/etc/pki/katello/qpid_router_client.key -b amqps://localhost:5671
Connections
  connection                   cproc      cpid  mech       auth                            connected  idle    msgIn  msgOut
  ===========================================================================================================================
  qpid.[::1]:5671-[::1]:57982  -                EXTERNAL   qpid_router_katello_agent@QPID  4m 25s     4m 21s     0      0
  qpid.[::1]:5671-[::1]:58082  qpid-stat  2167  ANONYMOUS  anonymous@QPID                  0s         0s         1      0
```

Removed `/var/log/qdrouterd/qdrouterd.log` since the log config goes to syslog now and there is nothing in `/var/log with that directory name now`

```bash
log {
    module: DEFAULT
    enable: info+
    timestamp: true
    output: syslog
}
```
Removed `/etc/qpidd.conf` because it is now in /etc/qpid` which line #71 will pick up

```bash
[root@qpid ~]# ll /etc/qpid/qpid
qpid.acl    qpidc.conf  qpidd.conf
```