### PR TITLE
Revert "Add disable Autoreq to gem2rpm templates"

### DIFF
--- a/gem2rpm/foreman_plugin.spec.erb
+++ b/gem2rpm/foreman_plugin.spec.erb
@@ -52,8 +52,6 @@ URL: <%= spec.homepage %>
 <% end -%>
 Source0: <%= download_path %>%{gem_name}-%{version}.gem
 
-Autoreq: 0
-
 # start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)

--- a/gem2rpm/hammer_plugin.spec.erb
+++ b/gem2rpm/hammer_plugin.spec.erb
@@ -26,8 +26,6 @@ URL: <%= spec.homepage %>
 <% end -%>
 Source0: <%= download_path %>%{gem_name}-%{version}.gem
 
-Autoreq: 0
-
 # start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>

--- a/gem2rpm/nonscl.spec.erb
+++ b/gem2rpm/nonscl.spec.erb
@@ -18,8 +18,6 @@ URL: <%= spec.homepage %>
 <% end -%>
 Source0: <%= download_path %>%{gem_name}-%{version}.gem
 
-Autoreq: 0
-
 # start specfile generated dependencies
 Requires: ruby(release)
 <% for req in spec.required_ruby_version -%>

--- a/gem2rpm/scl.spec.erb
+++ b/gem2rpm/scl.spec.erb
@@ -29,8 +29,6 @@ URL: <%= spec.homepage %>
 <% end -%>
 Source0: <%= download_path %>%{gem_name}-%{version}.gem
 
-Autoreq: 0
-
 # start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>

--- a/gem2rpm/smart_proxy_plugin.spec.erb
+++ b/gem2rpm/smart_proxy_plugin.spec.erb
@@ -35,8 +35,6 @@ URL: <%= spec.homepage %>
 <% end -%>
 Source0: <%= download_path %>%{gem_name}-%{version}.gem
 
-Autoreq: 0
-
 # start specfile generated dependencies
 Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)


### PR DESCRIPTION
Autoreq is generally a good principle. It had some issues in the Katello gem when it used pre-release dependencies but that's uncommon and shouldn't be applied by default.

This reverts commit d9e34da672f04c120bfb1331d373dc9ca1420c1f.