### PR TITLE
Fixes #32125 - only update hammer config when present

### DIFF
--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -495,9 +495,14 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
       STDOUT.puts "updating hostname in foreman installer scenarios"
       self.run_cmd("sed -i -e 's/#{@old_hostname}/#{@new_hostname}/Ig' #{scenarios_path}/*.yaml")
 
-      STDOUT.puts "updating hostname in hammer configuration"
-      self.run_cmd("sed -i.bak -e 's/#{@old_hostname}/#{@new_hostname}/Ig' #{hammer_root_config_path}/*.yml")
-      self.run_cmd("sed -i.bak -e 's/#{@old_hostname}/#{@new_hostname}/Ig' #{hammer_config_path}/*.yml")
+      if File.exist?(hammer_root_config_path) or File.exist?(hammer_config_path)
+        STDOUT.puts "updating hostname in hammer configuration"
+        [hammer_root_config_path, hammer_config_path].each do |config_dir|
+          Dir[File.join(config_dir, "*.yml")].each do |config_file|
+            self.run_cmd("sed -i.bak -e 's/#{@old_hostname}/#{@new_hostname}/Ig' #{config_file}")
+          end
+        end
+      end
 
       if File.exist?(last_scenario_yaml)
         STDOUT.puts 'backing up last_scenario.yaml'

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,7 +5,7 @@
 %global confdir common
 %global prereleasesource master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 2
+%global release 3
 
 Name:       katello
 Version:    4.1.0
@@ -144,6 +144,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Fri Mar 19 2021 Pablo N. Hess <phess@redhat.com> - 4.1.0-0.3.master
+- Fixes #32125 - katello-change-hostname now looks for hammer config before changing it
+
 * Fri Mar 05 2021 Chris Roberts <chrobert@redhat.com> - 4.1.0-0.2.master
 - Update katello-debug with correct qpid commands
 


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->

Thank you @wbclark for the wonderful collab work in making this patch.