### PR TITLE
Do not build qpid_messaging Ruby bindings for qpid-cpp

### DIFF
--- a/packages/katello/qpid-cpp/qpid-cpp.spec
+++ b/packages/katello/qpid-cpp/qpid-cpp.spec
@@ -8,7 +8,7 @@
 
 Name:          qpid-cpp
 Version:       1.39.0
-Release:       6%{?dist}
+Release:       7%{?dist}
 Summary:       Libraries for Qpid C++ client applications
 License:       ASL 2.0
 URL:           http://qpid.apache.org
@@ -465,7 +465,7 @@ export ADDFLAGS=""
 %cmake -DDOC_INSTALL_DIR:PATH=%{_pkgdocdir} \
        -DBUILD_LEGACYSTORE=false \
        -DBUILD_LINEARSTORE=true \
-       -DBUILD_BINDING_RUBY=true \
+       -DBUILD_BINDING_RUBY=false \
        "-DCMAKE_CXX_FLAGS=$CXXFLAGS $CXX11FLAG $ADDFLAGS" \
        .
 make %{?_smp_mflags}
@@ -537,6 +537,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Fri Mar 19 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.39.0-7
+- Do not build qpid_messaging Ruby binding
+
 * Tue Oct 20 2020 Mike Cressman <mcressma@redhat.com> - 1.39.0-6
 - add client fixes that are missing from RHEL-8 (which is based on 1.39.0)
   - Bug 1618908 - client memory leak when attaching to an unreachable broker address


### PR DESCRIPTION
Katello uses the rubygem-qpid_proton bindings that come from the
qpid-proton gem. Building the rubygem-qpid_messaging gem is broken
with Ruby 2.7 so we skip it all together.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
