### PR TITLE
Deploy bundlerd files for *_core gems to the smart proxy as well

### DIFF
--- a/packages/plugins/rubygem-smart-proxy-probing/rubygem-smart-proxy-probing.spec
+++ b/packages/plugins/rubygem-smart-proxy-probing/rubygem-smart-proxy-probing.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.0.3
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Gem to allow probing through smart-proxy
 Group: Applications/Internet
 License: GPLv3
@@ -103,7 +103,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/probing.yml.example \
    %{buildroot}%{foreman_proxy_settingsd_dir}/probing.yml
 
 mkdir -p %{buildroot}%{smart_proxy_dynflow_bundlerd_dir}
-cat <<EOF > %{buildroot}%{smart_proxy_dynflow_bundlerd_dir}/foreman_probing_core.rb
+cat <<EOF | tee %{buildroot}%{smart_proxy_dynflow_bundlerd_dir}/foreman_probing_core.rb \
+                %{buildroot}%{foreman_proxy_bundlerd_dir}/foreman_probing_core.rb \
+                >/dev/null
 gem 'foreman_probing_core'
 EOF
 
@@ -117,6 +119,7 @@ EOF
 %{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
 %exclude %{gem_cache}
 %{gem_spec}
+%{foreman_proxy_bundlerd_dir}/foreman_probing_core.rb
 %{smart_proxy_dynflow_bundlerd_dir}/foreman_probing_core.rb
 
 %files doc
@@ -124,6 +127,9 @@ EOF
 
 
 %changelog
+* Wed Mar 17 2021 Adam Ruzicka <aruzicka@redhat.com> 0.0.3-2
+- Deploy bundlerd file for foreman proxy
+
 * Wed Nov 18 2020 Adam Ruzicka <aruzicka@redhat.com> - 0.0.3-1
 - Update to 0.0.3
 

--- a/packages/plugins/rubygem-smart_proxy_acd/rubygem-smart_proxy_acd.spec
+++ b/packages/plugins/rubygem-smart_proxy_acd/rubygem-smart_proxy_acd.spec
@@ -19,7 +19,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.1.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Application Centric Deployment smart proxy plugin
 Group: Applications/Internet
 License: GPLv3
@@ -97,7 +97,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/acd.yml.example \
 
 # bundler.d file for smart_proxy_acd_core
 mkdir -p %{buildroot}%{smart_proxy_dynflow_bundlerd_dir}
-cat <<EOF > %{buildroot}%{smart_proxy_dynflow_bundlerd_dir}/smart_proxy_acd_core.rb
+cat <<EOF | tee %{buildroot}%{smart_proxy_dynflow_bundlerd_dir}/smart_proxy_acd_core.rb \
+                %{buildroot}%{foreman_proxy_bundlerd_dir}/smart_proxy_acd_core.rb \
+                >/dev/null
 gem 'smart_proxy_acd_core'
 EOF
 
@@ -109,6 +111,7 @@ EOF
 %{gem_libdir}
 %{gem_instdir}/settings.d
 %{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
+%{foreman_proxy_bundlerd_dir}/smart_proxy_acd_core.rb
 %{smart_proxy_dynflow_bundlerd_dir}/smart_proxy_acd_core.rb
 %exclude %{gem_cache}
 %{gem_spec}
@@ -118,6 +121,9 @@ EOF
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Mar 17 2021 Adam Ruzicka <aruzicka@redhat.com> 0.1.0-2
+- Deploy bundlerd file for foreman proxy
+
 * Tue Mar 09 2021 Bernhard Suttner <suttner@atix.de> 0.1.0-1
 - Update to 0.1.0
 

--- a/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
+++ b/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.0.1
-Release: 6%{?foremandist}%{?dist}
+Release: 7%{?foremandist}%{?dist}
 Summary: Smart-Proxy Ansible plugin
 Group: Applications/Internet
 License: GPLv3
@@ -122,7 +122,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/ansible.yml.example \
    %{buildroot}%{foreman_proxy_settingsd_dir}/ansible.yml
 
 mkdir -p %{buildroot}%{smart_proxy_dynflow_bundlerd_dir}
-cat <<EOF > %{buildroot}%{smart_proxy_dynflow_bundlerd_dir}/foreman_ansible_core.rb
+cat <<EOF | tee %{buildroot}%{smart_proxy_dynflow_bundlerd_dir}/foreman_ansible_core.rb \
+                %{buildroot}%{foreman_proxy_bundlerd_dir}/foreman_ansible_core.rb \
+                >/dev/null
 gem 'foreman_ansible_core'
 EOF
 
@@ -152,6 +154,7 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 %attr(-,foreman-proxy,foreman-proxy) %{foreman_proxy_statedir}/ansible
 %attr(-,foreman-proxy,foreman-proxy) %{foreman_proxy_statedir}/ansible_galaxy
 %ghost %attr(0640,root,foreman-proxy) %config(noreplace) %{_root_sysconfdir}/foreman-proxy/ansible.cfg
+%{foreman_proxy_bundlerd_dir}/foreman_ansible_core.rb
 %{smart_proxy_dynflow_bundlerd_dir}/foreman_ansible_core.rb
 
 %files doc
@@ -159,6 +162,9 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Mar 17 2021 Adam Ruzicka <aruzicka@redhat.com> 3.0.1-7
+- Deploy bundlerd file for foreman proxy
+
 * Mon Jun 22 2020 Evgeni Golov - 3.0.1-6
 - Fix bundler.d location on EL8
 

--- a/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
+++ b/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.3.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Ssh remote execution provider for Foreman Smart-Proxy
 Group: Applications/Internet
 License: GPLv3
@@ -114,7 +114,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/remote_execution_ssh.yml.example \
    %{buildroot}%{foreman_proxy_settingsd_dir}/remote_execution_ssh.yml
 
 mkdir -p %{buildroot}%{smart_proxy_dynflow_bundlerd_dir}
-cat <<EOF > %{buildroot}%{smart_proxy_dynflow_bundlerd_dir}/foreman_remote_execution_core.rb
+cat <<EOF | tee %{buildroot}%{smart_proxy_dynflow_bundlerd_dir}/foreman_remote_execution_core.rb \
+                %{buildroot}%{foreman_proxy_bundlerd_dir}/foreman_remote_execution_core.rb \
+                >/dev/null
 gem 'foreman_remote_execution_core'
 EOF
 
@@ -126,6 +128,7 @@ EOF
 %{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
 %exclude %{gem_cache}
 %{gem_spec}
+%{foreman_proxy_bundlerd_dir}/foreman_remote_execution_core.rb
 %{smart_proxy_dynflow_bundlerd_dir}/foreman_remote_execution_core.rb
 %{foreman_proxy_dir}/.ssh
 %attr(0750,foreman-proxy,foreman-proxy) %{foreman_proxy_statedir}/ssh
@@ -135,6 +138,9 @@ EOF
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Mar 17 2021 Adam Ruzicka <aruzicka@redhat.com> 0.3.1-2
+- Deploy bundlerd file for foreman proxy
+
 * Mon Nov 09 2020 Adam Ruzicka <aruzicka@redhat.com> 0.3.1-1
 - Update to 0.3.1
 

--- a/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
+++ b/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
@@ -35,7 +35,7 @@
 Summary: SaltStack support for Foreman Smart-Proxy
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.1.2
-Release: 6%{?foremandist}%{?dist}
+Release: 7%{?foremandist}%{?dist}
 Group: Applications/System
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_salt
@@ -155,7 +155,9 @@ mkdir -p %{buildroot}%{_root_sbindir}
 mv %{buildroot}/%{gem_instdir}/sbin/upload-salt-reports %{buildroot}%{_root_sbindir}/upload-salt-reports
 mv .%{gem_instdir}/cron/smart_proxy_salt %{buildroot}%{_root_sysconfdir}/cron.d/%{gem_name}
 mkdir -p %{buildroot}%{smart_proxy_dynflow_bundlerd_dir}
-cat <<EOF > %{buildroot}%{smart_proxy_dynflow_bundlerd_dir}/smart_proxy_salt_core.rb
+cat <<EOF | tee %{buildroot}%{smart_proxy_dynflow_bundlerd_dir}/smart_proxy_salt_core.rb \
+                %{buildroot}%{foreman_proxy_bundlerd_dir}/smart_proxy_salt_core.rb \
+                >/dev/null
 gem 'smart_proxy_salt_core'
 EOF
 
@@ -175,6 +177,7 @@ EOF
 %{foreman_proxy_bundlerd_dir}/%{plugin_name}.rb
 %exclude %{gem_cache}
 %{gem_spec}
+%{foreman_proxy_bundlerd_dir}/smart_proxy_salt_core.rb
 %{smart_proxy_dynflow_bundlerd_dir}/smart_proxy_salt_core.rb
 %config(noreplace) %{salt_config_dir}/foreman.yaml
 %config %{_root_sysconfdir}/cron.d/%{gem_name}
@@ -186,6 +189,9 @@ EOF
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Mar 17 2021 Adam Ruzicka <aruzicka@redhat.com> 3.1.2-7
+- Deploy bundlerd file for foreman proxy
+
 * Thu Jul 09 2020 Bernhard Suttner <suttner@atix.de> - 3.1.2-6
 - Fix upload-salt-report path
 - Fix hashbang for foreman-node helper script


### PR DESCRIPTION
This way, the gems get loaded both into foreman-proxy and
smart_proxy_dynflow_core, but remain unused in foreman-proxy
unless it is set to not use external core.

Implements step 1 of [Phasing out smart_proxy_dynflow_core](https://community.theforeman.org/t/phasing-out-smart-proxy-dynflow-core/22841) 

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
