### PR TITLE
Obsolete hammer_cli_foreman_docker as we ship conflicting commands

### DIFF
--- a/packages/katello/rubygem-hammer_cli_katello/rubygem-hammer_cli_katello.spec
+++ b/packages/katello/rubygem-hammer_cli_katello/rubygem-hammer_cli_katello.spec
@@ -5,7 +5,7 @@
 %global gem_name hammer_cli_katello
 %global plugin_name katello
 
-%global release 2
+%global release 3
 %global prereleasesource pre.master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
 
@@ -33,6 +33,8 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 # end specfile generated dependencies
+
+Obsoletes: %{?scl_prefix}rubygem-hammer_cli_foreman_docker < 0.0.7-2
 
 %description
 Hammer-CLI-Katello is a plugin for Hammer to provide connectivity to a Katello
@@ -94,6 +96,9 @@ install -m 0644 .%{gem_instdir}/config/%{plugin_name}.yml \
 %{gem_instdir}/test
 
 %changelog
+* Wed Mar 24 2021 Evgeni Golov - 1.0.1-0.3.pre.master
+- Obsolete hammer_cli_foreman_docker as we ship conflicting commands
+
 * Mon Mar 15 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.0.1-0.2.pre.master
 - Drop hammer_cli_docker and hammer_cli_bootdisk requires
 


### PR DESCRIPTION
Otherwise you get errors like this when both are installed:

    [ERROR 2021-03-24T11:27:33 Modules] Error while loading module hammer_cli_katello.
    Warning: An error occured while loading module hammer_cli_katello.
    [ERROR 2021-03-24T11:27:33 Modules] <HammerCLI::CommandConflict> Can't replace subcommand docker (HammerCLIForemanDocker::DockerCommand) with docker (Class).
    	/opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-2.5.0.pre.develop/lib/hammer_cli/subcommand.rb:120:in `define_subcommand'
    	/opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-2.5.0.pre.develop/lib/hammer_cli/subcommand.rb:89:in `lazy_subcommand'
    	/opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli_katello-1.0.1.pre.master/lib/hammer_cli_katello.rb:158:in `<module:HammerCLIKatello>'
    	/opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli_katello-1.0.1.pre.master/lib/hammer_cli_katello.rb:9:in `<top (required)>'
    	/opt/rh/rh-ruby25/root/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:135:in `require'
    	/opt/rh/rh-ruby25/root/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
    	/opt/rh/rh-ruby25/root/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:39:in `require'
    	/opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-2.5.0.pre.develop/lib/hammer_cli/modules.rb:75:in `require_module'
    	/opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-2.5.0.pre.develop/lib/hammer_cli/modules.rb:54:in `load!'
    	/opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-2.5.0.pre.develop/lib/hammer_cli/modules.rb:69:in `load'
    	/opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-2.5.0.pre.develop/lib/hammer_cli/modules.rb:80:in `block in load_all'
    	/opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-2.5.0.pre.develop/lib/hammer_cli/modules.rb:79:in `each'
    	/opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-2.5.0.pre.develop/lib/hammer_cli/modules.rb:79:in `load_all'
    	/opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-2.5.0.pre.develop/bin/hammer:134:in `<top (required)>'
    	/bin/hammer:23:in `load'
    	/bin/hammer:23:in `<main>'
    	--- Caused by ---
    	<LoadError> cannot load such file -- hammer_cli_katello
    	/opt/rh/rh-ruby25/root/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:59:in `require'
    	/opt/rh/rh-ruby25/root/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:59:in `require'
    	/opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-2.5.0.pre.develop/lib/hammer_cli/modules.rb:75:in `require_module'
    	/opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-2.5.0.pre.develop/lib/hammer_cli/modules.rb:54:in `load!'
    	/opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-2.5.0.pre.develop/lib/hammer_cli/modules.rb:69:in `load'

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
