### PR TITLE
Set module_hotfixes to true for repoclosure on EL8

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -1156,7 +1156,6 @@ repoclosures:
           - el7-puppet-6
           - "el7-foreman-{{ foreman_version }}"
           - el7-configmanagement-salt
-
     plugins-repoclosure-el8:
       repoclosure_target_repos:
         el8:

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -25,6 +25,7 @@ name=AppStream
 enabled=1
 mirrorlist=http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=AppStream
 failovermethod=priority
+module_hotfixes=1
 
 [el8-configmanagement-ansible]
 name=Ansible configmanagement


### PR DESCRIPTION
The move to Ruby 2.7 means needing a module that is not the default
profile. There is no way with repoclosure to set which module stream
to use when computing repoclosure. Adding module_hotfixes to the
AppStream repository definition for repoclosure allows repoclosure
to look at the AppStream repository as a regular/flat repository
and resolve dependencies.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
