### PR TITLE
Update rubygem-pulp_deb_client to 2.11.1

### DIFF
--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -9,7 +9,7 @@
 %global prereleasesource pre.master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
 %global mainver 4.1.0
-%global release 8
+%global release 9
 
 Name:    %{?scl_prefix}rubygem-%{gem_name}
 Summary: Content and Subscription Management plugin for Foreman
@@ -57,7 +57,7 @@ Requires: %{?scl_prefix}rubygem(pulp_ansible_client) < 0.8
 Requires: %{?scl_prefix}rubygem(pulp_container_client) >= 2.4.0
 Requires: %{?scl_prefix}rubygem(pulp_container_client) < 2.5.0
 Requires: %{?scl_prefix}rubygem(pulp_deb_client) >= 2.10.0
-Requires: %{?scl_prefix}rubygem(pulp_deb_client) < 2.11.0
+Requires: %{?scl_prefix}rubygem(pulp_deb_client) < 2.12.0
 Requires: %{?scl_prefix}rubygem(pulp_rpm_client) >= 3.10.0
 Requires: %{?scl_prefix}rubygem(pulp_rpm_client) < 3.11.0
 Requires: %{?scl_prefix}rubygem(pulp_certguard_client) < 2.0
@@ -95,7 +95,7 @@ BuildRequires: %{?scl_prefix}rubygem(pulp_ansible_client) < 0.8
 BuildRequires: %{?scl_prefix}rubygem(pulp_container_client) >= 2.4.0
 BuildRequires: %{?scl_prefix}rubygem(pulp_container_client) < 2.5.0
 BuildRequires: %{?scl_prefix}rubygem(pulp_deb_client) >= 2.10.0
-BuildRequires: %{?scl_prefix}rubygem(pulp_deb_client) < 2.11.0
+BuildRequires: %{?scl_prefix}rubygem(pulp_deb_client) < 2.12.0
 BuildRequires: %{?scl_prefix}rubygem(pulp_rpm_client) >= 3.10.0
 BuildRequires: %{?scl_prefix}rubygem(pulp_rpm_client) < 3.11.0
 BuildRequires: %{?scl_prefix}rubygem(pulp_certguard_client) < 2.0
@@ -231,6 +231,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/webpack
 
 %changelog
+* Tue Apr 27 2021 Quirin Pamp <pamp@atix.de> 4.1.0-0.9.pre.master
+- Update Katello's pulp_deb_client requirement to 2.11
+
 * Mon Apr 12 2021 ianballou <ianballou67@gmail.com> 4.1.0-0.8.pre.master
 - Update Katello's pulp_rpm_client requirement to 3.10.0
 

--- a/packages/katello/rubygem-pulp_deb_client/pulp_deb_client-2.10.0.gem
+++ b/packages/katello/rubygem-pulp_deb_client/pulp_deb_client-2.10.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/2V/gw/SHA256E-s80896--f1f891e38af77d6c59ada76e043ae6b3e475eec1d8b8f6a08e40b2c7da1ded4d.0.gem/SHA256E-s80896--f1f891e38af77d6c59ada76e043ae6b3e475eec1d8b8f6a08e40b2c7da1ded4d.0.gem

--- a/packages/katello/rubygem-pulp_deb_client/pulp_deb_client-2.11.1.gem
+++ b/packages/katello/rubygem-pulp_deb_client/pulp_deb_client-2.11.1.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/K5/7V/SHA256E-s80896--8fca94b047041ffccd73fe6763a83b1e18839fefa0eda628ec6a3ef29079131a.1.gem/SHA256E-s80896--8fca94b047041ffccd73fe6763a83b1e18839fefa0eda628ec6a3ef29079131a.1.gem

--- a/packages/katello/rubygem-pulp_deb_client/rubygem-pulp_deb_client.spec
+++ b/packages/katello/rubygem-pulp_deb_client/rubygem-pulp_deb_client.spec
@@ -10,7 +10,7 @@
 # %%global prereleaserpm %{?prerelease:.}%{?prerelease}
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 2.10.0
+Version: 2.11.1
 
 Release: %{?prereleaserpm:0.}%{release}%{?prereleaserpm}%{?dist}
 Summary: Pulp 3 DEB plugin API Ruby Gem
@@ -89,6 +89,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Tue Apr 27 2021 Quirin Pamp <pamp@atix.de> 2.11.1-1
+- Update to 2.11.1
+
 * Mon Apr 12 2021 Justin Sherrill <jsherril@redhat.com> 2.10.0-1
 - Update to 2.10.0
 


### PR DESCRIPTION
The relevant pulp_deb version is already available in pulpcore-packaging:

https://yum.theforeman.org/pulpcore/3.11/el7/x86_64/python3-pulp-deb-2.11.1-1.el7.noarch.rpm
