### PR TITLE
Do not require qpid-tools in katello-debug

### DIFF
--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,7 +5,7 @@
 %global confdir common
 %global prereleasesource master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 5
+%global release 6
 
 Name:       katello
 Version:    4.1.0
@@ -109,7 +109,6 @@ Requires: foreman-debug
 Requires: findutils
 Requires: coreutils
 Requires: /bin/ps
-Requires: qpid-tools
 
 %description debug
 Useful utilities for debug info collecting
@@ -133,6 +132,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Wed Apr 28 2021 Eric D. Helms <ericdhelms@gmail.com> - 4.1.0-0.6.master
+- Do not require qpid-tools in katello-debug
+
 * Thu Apr 08 2021 Eric D. Helms <ericdhelms@gmail.com> - 4.1.0-0.5.master
 - Drop requirement on Hammer CLI packages
 


### PR DESCRIPTION
The Qpid components are now optional as katello-agent is not configured
by default. So if a user needs qpid-tools for debugging they can
install it directly.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
