### PR TITLE
Prevent end of line whitespace in scl gem2rpm template

### DIFF
--- a/gem2rpm/foreman_plugin.spec.erb
+++ b/gem2rpm/foreman_plugin.spec.erb
@@ -56,14 +56,14 @@ Source0: <%= download_path %>%{gem_name}-%{version}.gem
 Requires: foreman >= %{foreman_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>
-Requires: %{?scl_prefix_ruby}ruby <%= req %>
+Requires: %{?scl_prefix_ruby}ruby<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% for req in spec.required_rubygems_version -%>
-Requires: %{?scl_prefix_ruby}ruby(rubygems) <%= req %>
+Requires: %{?scl_prefix_ruby}ruby(rubygems)<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% for d in spec.runtime_dependencies -%>
 <% for req in d.requirement -%>
-Requires: %{?scl_prefix<%= SCL_PREFIXES[d.name] %>}rubygem(<%= d.name %>) <%= req  %>
+Requires: %{?scl_prefix<%= SCL_PREFIXES[d.name] %>}rubygem(<%= d.name %>)<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% end -%>
 <% if has_assets || has_webpack -%>
@@ -73,16 +73,16 @@ BuildRequires: foreman-plugin >= %{foreman_min_version}
 <% if has_assets || has_webpack || has_apidoc -%>
 <% for d in spec.runtime_dependencies -%>
 <% for req in d.requirement -%>
-BuildRequires: %{?scl_prefix<%= SCL_PREFIXES[d.name] %>}rubygem(<%= d.name %>) <%= req  %>
+BuildRequires: %{?scl_prefix<%= SCL_PREFIXES[d.name] %>}rubygem(<%= d.name %>)<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% end -%>
 <% end -%>
 BuildRequires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>
-BuildRequires: %{?scl_prefix_ruby}ruby<%= "-devel" unless spec.extensions.empty? %> <%= req %>
+BuildRequires: %{?scl_prefix_ruby}ruby<%= "-devel" unless spec.extensions.empty? %><%= " #{req}" unless req.empty? %>
 <% end -%>
 <% for req in spec.required_rubygems_version -%>
-BuildRequires: %{?scl_prefix_ruby}rubygems-devel <%= req %>
+BuildRequires: %{?scl_prefix_ruby}rubygems-devel<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% if spec.extensions.empty? -%>
 BuildArch: noarch

--- a/gem2rpm/hammer_plugin.spec.erb
+++ b/gem2rpm/hammer_plugin.spec.erb
@@ -29,22 +29,22 @@ Source0: <%= download_path %>%{gem_name}-%{version}.gem
 # start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>
-Requires: %{?scl_prefix_ruby}ruby <%= req %>
+Requires: %{?scl_prefix_ruby}ruby<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% for req in spec.required_rubygems_version -%>
-Requires: %{?scl_prefix_ruby}ruby(rubygems) <%= req %>
+Requires: %{?scl_prefix_ruby}ruby(rubygems)<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% for d in spec.runtime_dependencies -%>
 <% for req in d.requirement -%>
-Requires: %{?scl_prefix<%= SCL_PREFIXES[d.name] %>}rubygem(<%= d.name %>) <%= req  %>
+Requires: %{?scl_prefix<%= SCL_PREFIXES[d.name] %>}rubygem(<%= d.name %>)<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% end -%>
 BuildRequires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>
-BuildRequires: %{?scl_prefix_ruby}ruby<%= "-devel" unless spec.extensions.empty? %> <%= req %>
+BuildRequires: %{?scl_prefix_ruby}ruby<%= "-devel" unless spec.extensions.empty? %><%= " #{req}" unless req.empty? %>
 <% end -%>
 <% for req in spec.required_rubygems_version -%>
-BuildRequires: %{?scl_prefix_ruby}rubygems-devel <%= req %>
+BuildRequires: %{?scl_prefix_ruby}rubygems-devel<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% if spec.extensions.empty? -%>
 BuildArch: noarch

--- a/gem2rpm/nonscl.spec.erb
+++ b/gem2rpm/nonscl.spec.erb
@@ -21,29 +21,29 @@ Source0: <%= download_path %>%{gem_name}-%{version}.gem
 # start specfile generated dependencies
 Requires: ruby(release)
 <% for req in spec.required_ruby_version -%>
-Requires: ruby <%= req %>
+Requires: ruby<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% for req in spec.required_rubygems_version -%>
-Requires: ruby(rubygems) <%= req %>
+Requires: ruby(rubygems)<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% for d in spec.runtime_dependencies -%>
 <% for req in d.requirement -%>
-Requires: rubygem(<%= d.name %>) <%= req  %>
+Requires: rubygem(<%= d.name %>)<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% end -%>
 BuildRequires: ruby(release)
 <% for req in spec.required_ruby_version -%>
-BuildRequires: ruby<%= "-devel" unless spec.extensions.empty? %> <%= req %>
+BuildRequires: ruby<%= "-devel" unless spec.extensions.empty? %><%= " #{req}" unless req.empty? %>
 <% end -%>
 <% for req in spec.required_rubygems_version -%>
-BuildRequires: rubygems-devel <%= req %>
+BuildRequires: rubygems-devel<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% if spec.extensions.empty? -%>
 BuildArch: noarch
 <% else -%>
 <% for d in spec.runtime_dependencies -%>
 <% for req in d.requirement -%>
-BuildRequires: rubygem(<%= d.name %>) <%= req  %>
+BuildRequires: rubygem(<%= d.name %>)<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% end -%>
 <% end -%>

--- a/gem2rpm/scl.spec.erb
+++ b/gem2rpm/scl.spec.erb
@@ -33,29 +33,29 @@ Source0: <%= download_path %>%{gem_name}-%{version}.gem
 # start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>
-Requires: %{?scl_prefix_ruby}ruby <%= req %>
+Requires: %{?scl_prefix_ruby}ruby<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% for req in spec.required_rubygems_version -%>
-Requires: %{?scl_prefix_ruby}ruby(rubygems) <%= req %>
+Requires: %{?scl_prefix_ruby}ruby(rubygems)<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% for d in spec.runtime_dependencies -%>
 <% for req in d.requirement -%>
-Requires: %{?scl_prefix<%= SCL_PREFIXES[d.name] %>}rubygem(<%= d.name %>) <%= req  %>
+Requires: %{?scl_prefix<%= SCL_PREFIXES[d.name] %>}rubygem(<%= d.name %>)<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% end -%>
 BuildRequires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>
-BuildRequires: %{?scl_prefix_ruby}ruby<%= "-devel" unless spec.extensions.empty? %> <%= req %>
+BuildRequires: %{?scl_prefix_ruby}ruby<%= "-devel" unless spec.extensions.empty? %><%= " #{req}" unless req.empty? %>
 <% end -%>
 <% for req in spec.required_rubygems_version -%>
-BuildRequires: %{?scl_prefix_ruby}rubygems-devel <%= req %>
+BuildRequires: %{?scl_prefix_ruby}rubygems-devel<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% if spec.extensions.empty? -%>
 BuildArch: noarch
 <% else -%>
 <% for d in spec.runtime_dependencies -%>
 <% for req in d.requirement -%>
-BuildRequires: %{?scl_prefix<%= SCL_PREFIXES[d.name] %>}rubygem(<%= d.name %>) <%= req  %>
+BuildRequires: %{?scl_prefix<%= SCL_PREFIXES[d.name] %>}rubygem(<%= d.name %>)<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% end -%>
 <% end -%>

--- a/gem2rpm/smart_proxy_plugin.spec.erb
+++ b/gem2rpm/smart_proxy_plugin.spec.erb
@@ -43,22 +43,22 @@ Source0: <%= download_path %>%{gem_name}-%{version}.gem
 Requires: foreman-proxy >= %{foreman_proxy_min_version}
 Requires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>
-Requires: %{?scl_prefix_ruby}ruby <%= req %>
+Requires: %{?scl_prefix_ruby}ruby<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% for req in spec.required_rubygems_version -%>
-Requires: %{?scl_prefix_ruby}ruby(rubygems) <%= req %>
+Requires: %{?scl_prefix_ruby}ruby(rubygems)<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% for d in spec.runtime_dependencies -%>
 <% for req in d.requirement -%>
-Requires: %{?scl_prefix<%= SCL_PREFIXES[d.name] %>}rubygem(<%= d.name %>) <%= req  %>
+Requires: %{?scl_prefix<%= SCL_PREFIXES[d.name] %>}rubygem(<%= d.name %>)<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% end -%>
 BuildRequires: %{?scl_prefix_ruby}ruby(release)
 <% for req in spec.required_ruby_version -%>
-BuildRequires: %{?scl_prefix_ruby}ruby<%= "-devel" unless spec.extensions.empty? %> <%= req %>
+BuildRequires: %{?scl_prefix_ruby}ruby<%= "-devel" unless spec.extensions.empty? %><%= " #{req}" unless req.empty? %>
 <% end -%>
 <% for req in spec.required_rubygems_version -%>
-BuildRequires: %{?scl_prefix_ruby}rubygems-devel <%= req %>
+BuildRequires: %{?scl_prefix_ruby}rubygems-devel<%= " #{req}" unless req.empty? %>
 <% end -%>
 <% if spec.extensions.empty? -%>
 BuildArch: noarch


### PR DESCRIPTION
If there is no 'req' to append at the end of a line, the line will
end up with the space before becoming trailing whitespace.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
