### PR TITLE
Do not generate auto requires for rubygem-nokogiri

### DIFF
--- a/packages/foreman/rubygem-nokogiri/rubygem-nokogiri.spec
+++ b/packages/foreman/rubygem-nokogiri/rubygem-nokogiri.spec
@@ -7,12 +7,16 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.11.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby
 Group: Development/Languages
 License: MIT
 URL: https://nokogiri.org
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
+
+# On EL8 rubygem-racc is bundled into ruby-libs package and
+# auto-generated dependencies will break dependency resolution
+Autoreq: 0
 
 # start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
@@ -133,6 +137,9 @@ rm -rf gem_ext_test
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Thu May 27 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.11.3-2
+- Do not generate auto requires due to rubygem-racc
+
 * Fri Apr 30 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.11.3-1
 - Release 1.11.3
 


### PR DESCRIPTION
With auto requires created, a dependency on rubygem-racc is generated.
The gem racc is bundled into ruby-libs and is provided via
bundled(rubygem-racc). This will lead to a failure to install
as rubygem-racc cannot be resolved on install of this package
on EL8.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
