### PR TITLE
Fixes #32725 - Make delete_puppet_certs handle all input

### DIFF
--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -212,6 +212,8 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
     end
 
     def delete_puppet_certs
+      return unless @scenario_answers['puppet'].is_a?(Hash)
+
       puppet_ssldir = @scenario_answers['puppet']['ssldir']
 
       run_cmd("rm -rf '#{puppet_ssldir}'")


### PR DESCRIPTION
If a user runs the installer with --no-enable-puppet the value of @scenario_answers['puppet'] becomes false. false['ssldir'] raises an exception. By returning early, it's handled safely.

Draft since it's untested and probably needs a Redmine issue for tracking and cherry picking. Submitting this since it's easier to review.