### PR TITLE
Update foreman_remote_execution to 4.6.0 and core to 1.5.0

### DIFF
--- a/dependencies/bionic/foreman_remote_execution_core/changelog
+++ b/dependencies/bionic/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.5.0-1) stable; urgency=low
+
+  * 1.5.0 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Mon, 07 Jun 2021 13:27:26 +0200
+
 ruby-foreman-remote-execution-core (1.4.2-1) stable; urgency=low
 
   * 1.4.2 released

--- a/dependencies/bionic/foreman_remote_execution_core/control
+++ b/dependencies/bionic/foreman_remote_execution_core/control
@@ -13,5 +13,5 @@ Package: ruby-foreman-remote-execution-core
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, rake,
-  ruby-foreman-tasks-core (>= 0.1.5), ruby-net-scp, ruby-net-ssh
+  ruby-foreman-tasks-core (>= 0.1.5), ruby-net-scp, ruby-net-ssh, ruby-smart-proxy-remote-execution-ssh (>= 0.4.0)
 Description: Foreman remote execution - core bits

--- a/dependencies/buster/foreman_remote_execution_core/changelog
+++ b/dependencies/buster/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.5.0-1) stable; urgency=low
+
+  * 1.5.0 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Mon, 07 Jun 2021 13:27:26 +0200
+
 ruby-foreman-remote-execution-core (1.4.2-1) stable; urgency=low
 
   * 1.4.2 released

--- a/dependencies/buster/foreman_remote_execution_core/control
+++ b/dependencies/buster/foreman_remote_execution_core/control
@@ -13,5 +13,5 @@ Package: ruby-foreman-remote-execution-core
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, rake,
-  ruby-foreman-tasks-core (>= 0.1.5), ruby-net-scp, ruby-net-ssh
+  ruby-foreman-tasks-core (>= 0.1.5), ruby-net-scp, ruby-net-ssh, ruby-smart-proxy-remote-execution-ssh (>= 0.4.0)
 Description: Foreman remote execution - core bits

--- a/dependencies/focal/foreman_remote_execution_core/changelog
+++ b/dependencies/focal/foreman_remote_execution_core/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution-core (1.5.0-1) stable; urgency=low
+
+  * 1.5.0 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Mon, 07 Jun 2021 13:27:26 +0200
+
 ruby-foreman-remote-execution-core (1.4.2-1) stable; urgency=low
 
   * 1.4.2 released

--- a/dependencies/focal/foreman_remote_execution_core/control
+++ b/dependencies/focal/foreman_remote_execution_core/control
@@ -13,5 +13,5 @@ Package: ruby-foreman-remote-execution-core
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, rake,
-  ruby-foreman-tasks-core (>= 0.1.5), ruby-net-scp, ruby-net-ssh
+  ruby-foreman-tasks-core (>= 0.1.5), ruby-net-scp, ruby-net-ssh, ruby-smart-proxy-remote-execution-ssh (>= 0.4.0)
 Description: Foreman remote execution - core bits

--- a/plugins/ruby-foreman-remote-execution/debian/changelog
+++ b/plugins/ruby-foreman-remote-execution/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution (4.6.0-1) stable; urgency=low
+
+  * 4.6.0 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Mon, 07 Jun 2021 13:25:20 +0200
+
 ruby-foreman-remote-execution (4.5.0-1) stable; urgency=low
 
   * 4.5.0 released

--- a/plugins/ruby-foreman-remote-execution/debian/gem.list
+++ b/plugins/ruby-foreman-remote-execution/debian/gem.list
@@ -1,3 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_remote_execution-4.5.0.gem"
+GEMS="https://rubygems.org/downloads/foreman_remote_execution-4.6.0.gem"
 GEMS="$GEMS https://rubygems.org/downloads/foreman_remote_execution_core-1.3.0.gem"

--- a/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
+++ b/plugins/ruby-foreman-remote-execution/foreman_remote_execution.rb
@@ -1,1 +1,1 @@
-gem 'foreman_remote_execution', '4.5.0'
+gem 'foreman_remote_execution', '4.6.0'


### PR DESCRIPTION
- Update foreman_remote_execution to 4.6.0
- Update foreman_remote_execution_core to 1.5.0

Requires:
- [x] https://github.com/theforeman/foreman-packaging/pull/6757