### PR TITLE
Fixes #32743 - Correct scenario answers file

### DIFF
--- a/packages/katello/katello/helper.rb
+++ b/packages/katello/katello/helper.rb
@@ -32,8 +32,16 @@ module KatelloUtilities
       "This utility can't run on a non-katello system."
     end
 
+    def load_scenario_data(scenario)
+      YAML.load_file(File.join(scenarios_path, "#{scenario}.yaml"))
+    end
+
     def load_scenario_answers(scenario)
-      YAML.load_file("/etc/foreman-installer/scenarios.d/#{scenario}-answers.yaml")
+      data = load_scenario_data(scenario)
+      unless data && data[:answer_file]
+        fail_with_message("Could not determine answers file location for scenario '#{scenario}'")
+      end
+      YAML.load_file(data[:answer_file])
     end
 
     def fail_with_message(message, opt_parser=nil)


### PR DESCRIPTION
The script used to assume it's always ${scenario}-answers.yaml which can lead to incorrect behavior. The right way to determine the answers file location is to read the scenario file and use the value for :answer_file.

It has some safeguard that it could at least determine the path.