### PR TITLE
Fixes #32725 - Make delete_puppet_certs handle all input on rpm/2.5

### DIFF
--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -212,6 +212,8 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
     end
 
     def delete_puppet_certs
+      return unless @scenario_answers['puppet'].is_a?(Hash)
+
       puppet_ssldir = @scenario_answers['puppet']['ssldir']
 
       run_cmd("rm -rf '#{puppet_ssldir}'")


### PR DESCRIPTION
If a user runs the installer with --no-enable-puppet the value of
@scenario_answers['puppet'] becomes false. false['ssldir'] raises an
exception. By returning early, it's handled safely.

(cherry picked from commit ee14227ebe203d54e5640c67d7d4925c60b9b27a)

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
