### PR TITLE
Fixes #32743 - Correct scenario answers file

### DIFF
--- a/packages/katello/katello/helper.rb
+++ b/packages/katello/katello/helper.rb
@@ -32,8 +32,16 @@ module KatelloUtilities
       "This utility can't run on a non-katello system."
     end
 
+    def load_scenario_data(scenario)
+      YAML.load_file(File.join(scenarios_path, "#{scenario}.yaml"))
+    end
+
     def load_scenario_answers(scenario)
-      YAML.load_file("/etc/foreman-installer/scenarios.d/#{scenario}-answers.yaml")
+      data = load_scenario_data(scenario)
+      unless data && data[:answer_file]
+        fail_with_message("Could not determine answers file location for scenario '#{scenario}'")
+      end
+      YAML.load_file(data[:answer_file])
     end
 
     def fail_with_message(message, opt_parser=nil)


### PR DESCRIPTION
The script used to assume it's always ${scenario}-answers.yaml which can
lead to incorrect behavior. The right way to determine the answers file
location is to read the scenario file and use the value for
:answer_file.

It has some safeguard that it could at least determine the path.

(cherry picked from commit de4d531a4ef4df0d31e0f3b0bc739828de273a68)

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
