### PR TITLE
Update rubygem-smart_proxy_container_gateway to 1.0.5

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_container_gateway/rubygem-smart_proxy_container_gateway.spec
+++ b/packages/plugins/rubygem-smart_proxy_container_gateway/rubygem-smart_proxy_container_gateway.spec
@@ -11,7 +11,7 @@
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 1.0.4
+Version: 1.0.5
 Release: 1%{?dist}
 Summary: Pulp 3 container registry support for Foreman/Katello Smart-Proxy
 Group: Development/Languages
@@ -97,6 +97,9 @@ mv %{buildroot}%{gem_instdir}/bundler.d/%{plugin_name}.rb \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jun 14 2021 ianballou <ianballou67@gmail.com> 1.0.5-1
+- Update to 1.0.5
+
 * Mon Apr 26 2021 ianballou <ianballou67@gmail.com> 1.0.4-1
 - Update to 1.0.4
 

--- a/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-1.0.4.gem
+++ b/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-1.0.4.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/X3/FZ/SHA256E-s22528--dcc981c6266ad733ee994b9cf1b9f8eb65356fa34aa3c31f50e0609fdeba6dc1.4.gem/SHA256E-s22528--dcc981c6266ad733ee994b9cf1b9f8eb65356fa34aa3c31f50e0609fdeba6dc1.4.gem

--- a/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-1.0.5.gem
+++ b/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-1.0.5.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/kM/8x/SHA256E-s22528--817605c8cea9ab67ad4ed4d4e057f4030ff3368b2a4b9cfba43d37c767c65285.5.gem/SHA256E-s22528--817605c8cea9ab67ad4ed4d4e057f4030ff3368b2a4b9cfba43d37c767c65285.5.gem


### PR DESCRIPTION
Cherry-picked from https://github.com/theforeman/foreman-packaging/pull/6780