### PR TITLE
Do not Obsolete foreman_remote_execution_core from smart_proxy_remote_execution_ssh

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
+++ b/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
@@ -17,7 +17,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.4.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Ssh remote execution provider for Foreman Smart-Proxy
 Group: Applications/Internet
 License: GPLv3
@@ -41,7 +41,6 @@ Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
 %{?scl:Obsoletes: rubygem-%{gem_name}}
-Obsoletes: %{?scl_prefix}rubygem-foreman_remote_execution_core
 
 %description
 Ssh remote execution provider for Foreman Smart-Proxy.
@@ -121,6 +120,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/remote_execution_ssh.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Fri Jul 09 2021 Eric D. Helms <ericdhelms@gmail.com> - 0.4.1-2
+- Do not obsolete foreman_remote_execution_core
+
 * Fri Jul 09 2021 Adam Ruzicka <aruzicka@redhat.com> 0.4.1-1
 - Update to 0.4.1
 


### PR DESCRIPTION
@adamruzicka @evgeni @ekohl Please take a look

The interesting part here is, and I don't know the code enough, is that by smart_proxy_remote_execution_ssh obsoleting foreman_remote_execution_core we are *introducing* functionality that was not present before. That is, previously only the core code parts existed via the foreman_remote_execution_core gem. Now we are introducing the actual smart_proxy_remote_execution plugin even though a user may not have had it configured.

On upgrade, the yum output is:
```
 tfm-rubygem-smart_proxy_remote_execution_ssh                                      noarch                                      0.4.1-1.fm2_6.el7                                                                          foreman-plugins-koji                                       35 k
     replacing  tfm-rubygem-foreman_remote_execution_core.noarch 1.4.3-1.el7
```

This is, what in turn results in:
```
# cat /etc/foreman-proxy/settings.d/remote_execution_ssh.yml 
---
:enabled: true
:ssh_identity_key_file: '~/.ssh/id_rsa_foreman_proxy'
:local_working_dir: '/var/tmp'
:remote_working_dir: '/var/tmp'
# :kerberos_auth: false
# :async_ssh: false

# Defines how often (in seconds) should the runner check
# for new data leave empty to use the runner's default
# (1 second for regular, 60 seconds with async_ssh enabled)
# :runner_refresh_interval:

# Defines the verbosity of logging coming from Net::SSH
# one of :debug, :info, :warn, :error, :fatal
# must be lower than general log level
# :ssh_log_level: fatal

# Remove working directories on job completion
# :cleanup_working_dirs: true
```

Even though, a user has:
```
# grep -r remote_execution::ssh /etc/foreman-installer/scenarios.d/katello-answers.yaml
foreman_proxy::plugin::remote_execution::ssh: false
```

So I think that this is what was breaking the upgrade before:
https://github.com/theforeman/foreman-packaging/pull/6855/files#diff-5639bb35f3b9b6c5d8eb5121c28b627340d9fa15bbee42e94682fc58cb51a4d6L24

And now, the Obsoletes is breaking us. Something maybe ought to clean up the system, but not the smart proxy plugin.