### PR TITLE
Add a conflicts on installer-katello with Pulp < 3.14

### DIFF
--- a/packages/foreman/foreman-installer/foreman-installer.spec
+++ b/packages/foreman/foreman-installer/foreman-installer.spec
@@ -1,7 +1,7 @@
 %{?scl:%global scl_prefix %{scl}-}
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 1
+%global release 2
 
 Name:       foreman-installer
 Epoch:      1
@@ -37,6 +37,9 @@ Summary: Katello installer bits
 Group: Applications/System
 Provides: katello-installer-base < 3.11.0-1
 Obsoletes: katello-installer-base < 3.11.0-1
+
+# Users must have upgraded Pulp packages - it will break with < 3.14
+Conflicts: python3-pulpcore < 3.14
 
 Requires: %{name} = %{epoch}:%{version}-%{release}
 Requires: openssl
@@ -147,6 +150,9 @@ done
 %{_sbindir}/foreman-proxy-certs-generate
 
 %changelog
+* Fri Jul 16 2021 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1:2.5.2-2
+- Conflict with Pulpcore < 3.14
+
 * Thu Jul 15 2021 Zach Huntington-Meath <zhunting@redhat.com> - 1:2.5.2-1
 - Release foreman-installer 2.5.2
 


### PR DESCRIPTION
This was supposed to be done before 2.5.2 was released. This is because the theforeman/pulpcore was upgraded to a version that's only compatible with Pulp 3.14. Without this users can end up in broken situations. The conflict should prevent them from installing an incompatible version.

https://community.theforeman.org/t/issue-after-yum-update-foreman-2-5-2-pulpcore-workers-failing/24480 shows that users are running into this quickly.