### PR TITLE
Refs #33406: Move scenarios to /var/lib/foreman-installer

### DIFF
--- a/packages/foreman/foreman-installer/foreman-installer.spec
+++ b/packages/foreman/foreman-installer/foreman-installer.spec
@@ -1,7 +1,7 @@
 %{?scl:%global scl_prefix %{scl}-}
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 3
+%global release 4
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -73,6 +73,11 @@ Various scenarios and tools for the Katello ecosystem
   SYSCONFDIR=%{buildroot}%{_sysconfdir} \
   --trace
 
+%pre
+if [ -d %{_sysconfdir}/%{name}/scenarios.d ] ; then
+  mv %{_sysconfdir}/%{name}/scenarios.d %{_sharedstatedir}/%{name}
+fi
+
 %post
 foreman-installer --scenario foreman --migrations-only > /dev/null
 
@@ -86,7 +91,7 @@ foreman-installer --scenario katello --migrations-only > /dev/null
 for scenario in foreman-proxy-content katello ; do
 	MIGRATIONS=%{_sysconfdir}/%{name}/scenarios.d/$scenario.migrations
 	if [ -d $MIGRATIONS ] && [ ! -L $MIGRATIONS ] ; then
-		mv $MIGRATIONS/.applied %{_sysconfdir}/%{name}/scenarios.d/$scenario-migrations-applied
+		mv $MIGRATIONS/.applied %{_sharedstatedir}/%{name}/scenarios.d/$scenario-migrations-applied
 		rm -rf $MIGRATIONS
 	fi
 done
@@ -97,11 +102,12 @@ done
 %license LICENSE
 %dir %{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}/custom-hiera.yaml
-%dir %{_sysconfdir}/%{name}/scenarios.d
-%{_sysconfdir}/%{name}/scenarios.d/foreman.migrations
-%config(noreplace) %attr(600, root, root) %{_sysconfdir}/%{name}/scenarios.d/foreman.yaml
-%config(noreplace) %attr(600, root, root) %{_sysconfdir}/%{name}/scenarios.d/foreman-answers.yaml
-%config(noreplace) %{_sysconfdir}/%{name}/scenarios.d/foreman-migrations-applied
+%dir %{_sharedstatedir}/%{name}
+%dir %{_sharedstatedir}/%{name}/scenarios.d
+%{_sharedstatedir}/%{name}/scenarios.d/foreman.migrations
+%config(noreplace) %attr(600, root, root) %{_sharedstatedir}/%{name}/scenarios.d/foreman.yaml
+%config(noreplace) %attr(600, root, root) %{_sharedstatedir}/%{name}/scenarios.d/foreman-answers.yaml
+%config(noreplace) %{_sharedstatedir}/%{name}/scenarios.d/foreman-migrations-applied
 %{_sbindir}/%{name}
 %{_datadir}/%{name}
 %{_mandir}/man8
@@ -123,18 +129,18 @@ done
 # foreman-proxy-content scenario
 %{_datadir}/%{name}/config/foreman-proxy-content*
 %{_datadir}/%{name}/parser_cache/foreman-proxy-content.yaml
-%{_sysconfdir}/%{name}/scenarios.d/foreman-proxy-content.migrations
-%config(noreplace) %attr(600, root, root) %{_sysconfdir}/%{name}/scenarios.d/foreman-proxy-content.yaml
-%config(noreplace) %attr(600, root, root) %{_sysconfdir}/%{name}/scenarios.d/foreman-proxy-content-answers.yaml
-%config(noreplace) %{_sysconfdir}/%{name}/scenarios.d/foreman-proxy-content-migrations-applied
+%{_sharedstatedir}/%{name}/scenarios.d/foreman-proxy-content.migrations
+%config(noreplace) %attr(600, root, root) %{_sharedstatedir}/%{name}/scenarios.d/foreman-proxy-content.yaml
+%config(noreplace) %attr(600, root, root) %{_sharedstatedir}/%{name}/scenarios.d/foreman-proxy-content-answers.yaml
+%config(noreplace) %{_sharedstatedir}/%{name}/scenarios.d/foreman-proxy-content-migrations-applied
 
 # katello scenario
 %{_datadir}/%{name}/config/katello*
 %{_datadir}/%{name}/parser_cache/katello.yaml
-%{_sysconfdir}/%{name}/scenarios.d/katello.migrations
-%config(noreplace) %attr(600, root, root) %{_sysconfdir}/%{name}/scenarios.d/katello.yaml
-%config(noreplace) %attr(600, root, root) %{_sysconfdir}/%{name}/scenarios.d/katello-answers.yaml
-%config(noreplace) %{_sysconfdir}/%{name}/scenarios.d/katello-migrations-applied
+%{_sharedstatedir}/%{name}/scenarios.d/katello.migrations
+%config(noreplace) %attr(600, root, root) %{_sharedstatedir}/%{name}/scenarios.d/katello.yaml
+%config(noreplace) %attr(600, root, root) %{_sharedstatedir}/%{name}/scenarios.d/katello-answers.yaml
+%config(noreplace) %{_sharedstatedir}/%{name}/scenarios.d/katello-migrations-applied
 
 # foreman-proxy-certs-generate
 %{_datadir}/%{name}/katello-certs
@@ -142,6 +148,9 @@ done
 %{_sbindir}/foreman-proxy-certs-generate
 
 %changelog
+* Sat Jul 17 2021 Eric D. Helms <ericdhelms@gmail.com> - 1:2.6.0-0.4.develop
+- rebuilt
+
 * Wed May 19 2021 Eric D. Helms <ericdhelms@gmail.com> - 1:2.6.0-0.3.develop
 - Bump puppet-agent requires to 6.15.0
 

--- a/packages/katello/katello/helper.rb
+++ b/packages/katello/katello/helper.rb
@@ -9,7 +9,11 @@ module KatelloUtilities
     end
 
     def scenarios_path
-      '/etc/foreman-installer/scenarios.d'
+      if File.exist?('/var/lib/foreman-installer/scenarios.d')
+        '/var/lib/foreman-installer/scenarios.d'
+      else
+        '/etc/foreman-installer/scenarios.d'
+      end
     end
 
     def hammer_root_config_path

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,7 +5,7 @@
 %global confdir common
 %global prereleasesource master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 1
+%global release 2
 
 Name:       katello
 Version:    4.2.0
@@ -132,6 +132,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Tue Jul 27 2021 Eric D. Helms <ericdhelms@gmail.com> - 4.2.0-0.2.master
+- Support /var/lib/foreman-installer in change-hostname
+
 * Thu May 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 4.2.0-0.1.master
 - Update to 4.2.0
 


### PR DESCRIPTION
Supports the move of scenario answers and config to /var/lib (sharedstatedir)
and out of system config directory. On upgrade, before installing the
new version of the package the scenario files are moved out of /etc
and into /var/lib to allow migrations to apply on the new location properly.
The custom-hiera.yaml remains in /etc as users are expected to edit this file.

See https://github.com/theforeman/foreman-installer/pull/698

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
