### PR TITLE
Disable automatic dbgsym packages for foreman

### DIFF
--- a/debian/buster/foreman/rules
+++ b/debian/buster/foreman/rules
@@ -5,6 +5,10 @@
 # DEB_VERBOSE_ALL=1
 # DH_VERBOSE=1
 
+# Disable automatic dbgsym packages
+# https://lists.debian.org/debian-devel/2015/12/msg00262.html
+DEB_BUILD_OPTIONS=noddebs
+
 build:
 	/bin/cp config/settings.yaml.example config/settings.yaml
 	/bin/cp config/database.yml.example config/database.yml


### PR DESCRIPTION
This takes a long time and is generally not needed since Foreman doesn't ship compiled code with debug symbols.

For now this really is just an experiment.