### PR TITLE
Fix katello nightly vs 4.2 references on 3.0 branch

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -34,12 +34,12 @@ builder = tito.builder.FetchBuilder
 # Katello Releasers
 [koji-katello]
 releaser = tito.release.KojiReleaser
-autobuild_tags = katello-nightly-rhel7 katello-nightly-el8
+autobuild_tags = katello-4.2-rhel7 katello-4.2-el8
 builder.rpmbuild_options = --define "foremandist .fm3_0"
 
 [koji-katello-jenkins]
 releaser = tito.release.KojiReleaser
-autobuild_tags = katello-nightly-rhel7 katello-nightly-el8
+autobuild_tags = katello-4.2-rhel7 katello-4.2-el8
 builder = tito.builder.FetchBuilder
 builder.jenkins_url = https://ci.theforeman.org
 builder.rpmbuild_options = --define "foremandist .fm3_0"

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -997,7 +997,7 @@ whitelist =
   rubygem-foreman_scap_client
   tracer
 
-[katello-nightly-rhel7]
+[katello-4.2-rhel7]
 disttag = .el7
 scl = tfm
 whitelist = katello
@@ -1042,7 +1042,7 @@ whitelist = katello
   rubygem-typhoeus
   rubygem-zest
 
-[katello-nightly-el8]
+[katello-4.2-el8]
 disttag = .el8
 whitelist = jsoncpp
   katello

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -126,23 +126,23 @@ name=SaltStack configmanagement
 baseurl=https://repo.saltstack.com/py3/redhat/7/x86_64/latest
 
 # Katello repos for lookaside
-[el7-katello-nightly]
-name=Katello nightly EL7
-baseurl=http://koji.katello.org/releases/yum/katello-nightly/katello/el7/x86_64/
+[el7-katello-4.2]
+name=Katello 4.2 EL7
+baseurl=http://koji.katello.org/releases/yum/katello-4.2/katello/el7/x86_64/
 
-[el8-katello-nightly]
-name=Katello nightly EL8
-baseurl=http://koji.katello.org/releases/yum/katello-nightly/katello/el8/x86_64/
+[el8-katello-4.2]
+name=Katello 4.2 EL8
+baseurl=http://koji.katello.org/releases/yum/katello-4.2/katello/el8/x86_64/
 
-[el7-katello-pulp-nightly]
-name=Katello Pulp nightly EL7
+[el7-katello-pulp-4.2]
+name=Katello Pulp 4.2 EL7
 baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/stable/2.19/7Server/x86_64/
 
-[el7-katello-candlepin-nightly]
-name=Katello Candlepin nightly EL7
-baseurl=http://koji.katello.org/releases/yum/katello-nightly/candlepin/el7/x86_64/
+[el7-katello-candlepin-4.2]
+name=Katello Candlepin 4.2 EL7
+baseurl=http://koji.katello.org/releases/yum/katello-4.2/candlepin/el7/x86_64/
 
-[el8-katello-candlepin-nightly]
-name=Katello Candlepin nightly EL8
-baseurl=http://koji.katello.org/releases/yum/katello-nightly/candlepin/el8/x86_64/
+[el8-katello-candlepin-4.2]
+name=Katello Candlepin 4.2 EL8
+baseurl=http://koji.katello.org/releases/yum/katello-4.2/candlepin/el8/x86_64/
 


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
