### PR TITLE
don't generate dbgsym packages

### DIFF
--- a/debian/bionic/foreman/rules
+++ b/debian/bionic/foreman/rules
@@ -5,6 +5,8 @@
 # DEB_VERBOSE_ALL=1
 # DH_VERBOSE=1
 
+DEB_BUILD_OPTIONS=noautodbgsym
+
 build:
 	/bin/cp config/settings.yaml.example config/settings.yaml
 	/bin/cp config/database.yml.example config/database.yml

--- a/debian/buster/foreman/rules
+++ b/debian/buster/foreman/rules
@@ -5,6 +5,8 @@
 # DEB_VERBOSE_ALL=1
 # DH_VERBOSE=1
 
+DEB_BUILD_OPTIONS=noautodbgsym
+
 build:
 	/bin/cp config/settings.yaml.example config/settings.yaml
 	/bin/cp config/database.yml.example config/database.yml

--- a/debian/focal/foreman/rules
+++ b/debian/focal/foreman/rules
@@ -5,6 +5,8 @@
 # DEB_VERBOSE_ALL=1
 # DH_VERBOSE=1
 
+DEB_BUILD_OPTIONS=noautodbgsym
+
 build:
 	/bin/cp config/settings.yaml.example config/settings.yaml
 	/bin/cp config/database.yml.example config/database.yml


### PR DESCRIPTION
this change is *mostly* cosmetical (it doesn't really save time), but it saves the *upload* of the debug package (which will be just thrown away on the other side anyways)