### PR TITLE
drop node dependencies which are unused for building

### DIFF
--- a/debian/bionic/foreman/rules
+++ b/debian/bionic/foreman/rules
@@ -16,6 +16,7 @@ build:
 	/bin/rm -f bundler.d/test.rb bundler.d/development.rb
 	/bin/sed -i '2i  gem "puma-status"' bundler.d/service.rb
 	BUNDLE_BUILD__SASSC=--disable-march-tune-native BUNDLE_RETRY=5 BUNDLE_JOBS=4 /usr/bin/bundle package
+	/usr/bin/python script/filter-package-json.py
 	/usr/bin/npm install --no-audit --no-optional --unsafe-perm
 	/bin/cp db/schema.rb.nulldb db/schema.rb
 	/usr/bin/bundle exec rake locale:pack RAILS_ENV=production

--- a/debian/buster/foreman/rules
+++ b/debian/buster/foreman/rules
@@ -14,6 +14,7 @@ build:
 	/bin/rm -f bundler.d/test.rb bundler.d/development.rb
 	/bin/sed -i '2i  gem "puma-status"' bundler.d/service.rb
 	BUNDLE_BUILD__SASSC=--disable-march-tune-native BUNDLE_RETRY=5 BUNDLE_JOBS=4 /usr/bin/bundle package
+	/usr/bin/python script/filter-package-json.py
 	/usr/bin/npm install --no-audit --no-optional --unsafe-perm
 	/bin/cp db/schema.rb.nulldb db/schema.rb
 	/usr/bin/bundle exec rake locale:pack RAILS_ENV=production

--- a/debian/focal/foreman/rules
+++ b/debian/focal/foreman/rules
@@ -14,6 +14,7 @@ build:
 	/bin/rm -f bundler.d/test.rb bundler.d/development.rb
 	/bin/sed -i '2i  gem "puma-status"' bundler.d/service.rb
 	BUNDLE_BUILD__SASSC=--disable-march-tune-native BUNDLE_RETRY=5 BUNDLE_JOBS=4 /usr/bin/bundle package
+	/usr/bin/python script/filter-package-json.py
 	/usr/bin/npm install --no-audit --no-optional --unsafe-perm
 	/bin/cp db/schema.rb.nulldb db/schema.rb
 	/usr/bin/bundle exec rake locale:pack RAILS_ENV=production


### PR DESCRIPTION
(cherry picked from commit aca4fa59749f98984693e8ba976e001bce959672)

this will fail until rc2 is released, so it needs to be either part of the RC2 PR or merged now failing and hope it won't break RC2 (I am confident it wont)