### PR TITLE
Drop requires on facter for foreman_maintain

### DIFF
--- a/packages/foreman/rubygem-foreman_maintain/rubygem-foreman_maintain.spec
+++ b/packages/foreman/rubygem-foreman_maintain/rubygem-foreman_maintain.spec
@@ -10,7 +10,7 @@
 Summary: The Foreman/Satellite maintenance tool
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.8.13
-Release: 1%{?dist}
+Release: 2%{?dist}
 Epoch: 1
 Group: Development/Languages
 License: GPLv3
@@ -23,7 +23,6 @@ Requires: %{?scl_prefix_ruby}ruby(rubygems)
 Requires: %{?scl_prefix}rubygem(clamp) >= 0.6.2
 Requires: %{?scl_prefix}rubygem(highline)
 Requires: yum-utils
-Requires: facter
 %if 0%{?rhel} < 8
 BuildRequires: python2-devel
 %else
@@ -127,6 +126,9 @@ install -D -m0644 %{SOURCE1} %{buildroot}%{_sysconfdir}/logrotate.d/%{gem_name}
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Tue Aug 31 2021 Eric D. Helms <ericdhelms@gmail.com> - 1:0.8.13-2
+- Drop requires on facter
+
 * Tue Aug 31 2021 Amit Upadhye <upadhyeammit@gmail.com> 1:0.8.13-1
 - Update to 0.8.13
 


### PR DESCRIPTION
The Puppet 7 puppet-agent package no longer provides facter and
this breaks nightly pipelines. Future foreman_maintain will drop
the need for facter all together.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
