### PR TITLE
make deb compare packages more robust

### DIFF
--- a/scripts/compare_deb_repo.py
+++ b/scripts/compare_deb_repo.py
@@ -9,6 +9,7 @@ from debian.changelog import Changelog
 
 DISTS = [path.name for path in Path('debian/').glob('*') if path.name != 'buildscripts']
 PLUGINS = ['plugins']
+NIGHTLY_PACKAGES = ['foreman', 'foreman-installer', 'foreman-proxy']
 
 
 def get_repo_packages(dist, release='nightly', arch='amd64'):
@@ -23,7 +24,7 @@ def get_repo_packages(dist, release='nightly', arch='amd64'):
     return repo_packages
 
 
-def get_git_packages(dist):
+def get_git_packages(dist, release='nightly'):
     if dist == 'plugins':
         package_folders = Path('plugins/').glob('*/debian')
     else:
@@ -32,6 +33,8 @@ def get_git_packages(dist):
     for package_folder in package_folders:
         with package_folder.joinpath('changelog').open() as debchangelog:
             changelog = Changelog(debchangelog)
+            if release == 'nightly' and changelog.package in NIGHTLY_PACKAGES:
+                continue
             packages.add((str(changelog.package), str(changelog.version)))
     return packages
 
@@ -49,7 +52,7 @@ def main():
     parser.add_argument('--release', default='nightly', help='release to compare for (default: %(default)s)')
     args = parser.parse_args()
     for dist in DISTS + PLUGINS:
-        packages = get_git_packages(dist)
+        packages = get_git_packages(dist, release=args.release)
         repo_packages = get_repo_packages(dist, release=args.release)
         print_diff(dist, repo_packages, packages)
 

--- a/scripts/compare_deb_repo.py
+++ b/scripts/compare_deb_repo.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from debian.deb822 import Packages
 from debian.changelog import Changelog
 
-DISTS = [path.name for path in Path('debian/').glob('*') if path.name != 'buildscripts']
+DISTS = [path.name for path in Path('debian/').glob('*')]
 PLUGINS = ['plugins']
 NIGHTLY_PACKAGES = ['foreman', 'foreman-installer', 'foreman-proxy']
 

--- a/scripts/compare_deb_repo.py
+++ b/scripts/compare_deb_repo.py
@@ -26,12 +26,12 @@ def get_repo_packages(dist, release='nightly', arch='amd64'):
 
 def get_git_packages(dist, release='nightly'):
     if dist == 'plugins':
-        package_folders = Path('plugins/').glob('*/debian')
+        package_changelogs = Path('plugins/').glob('**/changelog')
     else:
-        package_folders = chain(Path('debian/').glob(f'{dist}/*'), Path('dependencies/').glob(f'{dist}/*'))
+        package_changelogs = chain(Path('debian/').glob(f'{dist}/**/changelog'), Path('dependencies/').glob(f'{dist}/**/changelog'))
     packages = set()
-    for package_folder in package_folders:
-        with package_folder.joinpath('changelog').open() as debchangelog:
+    for package_changelog in package_changelogs:
+        with package_changelog.open() as debchangelog:
             changelog = Changelog(debchangelog)
             if release == 'nightly' and changelog.package in NIGHTLY_PACKAGES:
                 continue


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
