### PR TITLE
Stop calling gem compare in bump_rpm.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ If you're just submitting a fix, you don't need anything special.
 If you're submitting a patch which adds/updates a gem package, you will need:
 
 * [gem2rpm](https://rubygems.org/gems/gem2rpm) or rubygem-gem2rpm
-* [gem-compare](https://rubygems.org/gems/gem-compare)
 * [git-annex](http://git-annex.branchable.com/)
 * crudini: for fedora use `dnf install crudini`
 * ruamel: for fedora use `dnf install python3-ruamel-yaml`

--- a/bump_rpm.sh
+++ b/bump_rpm.sh
@@ -6,7 +6,6 @@
 # python3-semver
 # rpm-build
 # rpmdevtools
-# rubygem-gem-compare
 # rubygem-gem2rpm
 
 if [[ -z $1 ]] ; then
@@ -87,9 +86,6 @@ if [[ $CURRENT_VERSION != $NEW_VERSION ]] ; then
 			gem2rpm -t $ROOT/gem2rpm/$TEMPLATE.spec.erb *.gem | $SCRIPT_DIR/update-requirements specfile - $SPEC_FILE
 			git add $SPEC_FILE
 		fi
-
-		echo "* Calling gem compare"
-		gem compare -b $GEM_NAME $CURRENT_VERSION $NEW_VERSION
 	else
 		echo "TODO:"
 		echo "* Verify the dependencies"


### PR DESCRIPTION
This command was very useful to detect new dependency updates, but most gems now have code where update-requirements can actually update it automatically. That means it's mostly useless. The file changes are generally not that interesting. In addition to that, it's also broken on Ruby 3 and has old outdated dependencies.