### PR TITLE
drop build_vars.sh from core projects

### DIFF
--- a/debian/bionic/foreman-installer/build_vars.sh
+++ b/debian/bionic/foreman-installer/build_vars.sh
@@ -1,1 +1,0 @@
-UPSTREAM=develop

--- a/debian/bionic/foreman-proxy/build_vars.sh
+++ b/debian/bionic/foreman-proxy/build_vars.sh
@@ -1,1 +1,0 @@
-UPSTREAM=develop

--- a/debian/bionic/foreman/build_vars.sh
+++ b/debian/bionic/foreman/build_vars.sh
@@ -1,1 +1,0 @@
-UPSTREAM=develop

--- a/debian/buster/foreman-installer/build_vars.sh
+++ b/debian/buster/foreman-installer/build_vars.sh
@@ -1,1 +1,0 @@
-UPSTREAM=develop

--- a/debian/buster/foreman-proxy/build_vars.sh
+++ b/debian/buster/foreman-proxy/build_vars.sh
@@ -1,1 +1,0 @@
-UPSTREAM=develop

--- a/debian/buster/foreman/build_vars.sh
+++ b/debian/buster/foreman/build_vars.sh
@@ -1,1 +1,0 @@
-UPSTREAM=develop

--- a/debian/focal/foreman-installer/build_vars.sh
+++ b/debian/focal/foreman-installer/build_vars.sh
@@ -1,1 +1,0 @@
-UPSTREAM=develop

--- a/debian/focal/foreman-proxy/build_vars.sh
+++ b/debian/focal/foreman-proxy/build_vars.sh
@@ -1,1 +1,0 @@
-UPSTREAM=develop

--- a/debian/focal/foreman/build_vars.sh
+++ b/debian/focal/foreman/build_vars.sh
@@ -1,1 +1,0 @@
-UPSTREAM=develop


### PR DESCRIPTION
these were introduced in 3eb8abc3c644819a232b2a37ba26c320a2775b93 but
nothing uses them anymore (build_vars.sh for core isn't even loaded
these days)

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
