### PR TITLE
Remove unused smart_proxy_dynflow_bundlerd_dir macro

### DIFF
--- a/gem2rpm/smart_proxy_plugin.spec.erb
+++ b/gem2rpm/smart_proxy_plugin.spec.erb
@@ -26,7 +26,6 @@ config.rules[:ignore] << 'config'
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: <%= spec.version %>

--- a/packages/plugins/rubygem-smart_proxy_chef/rubygem-smart_proxy_chef.spec
+++ b/packages/plugins/rubygem-smart_proxy_chef/rubygem-smart_proxy_chef.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.2.0

--- a/packages/plugins/rubygem-smart_proxy_dhcp_bluecat/rubygem-smart_proxy_dhcp_bluecat.spec
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_bluecat/rubygem-smart_proxy_dhcp_bluecat.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.1.5

--- a/packages/plugins/rubygem-smart_proxy_dhcp_device42/rubygem-smart_proxy_dhcp_device42.spec
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_device42/rubygem-smart_proxy_dhcp_device42.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.7

--- a/packages/plugins/rubygem-smart_proxy_dhcp_dnsmasq/rubygem-smart_proxy_dhcp_dnsmasq.spec
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_dnsmasq/rubygem-smart_proxy_dhcp_dnsmasq.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.7

--- a/packages/plugins/rubygem-smart_proxy_dhcp_infoblox/rubygem-smart_proxy_dhcp_infoblox.spec
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_infoblox/rubygem-smart_proxy_dhcp_infoblox.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.0.16

--- a/packages/plugins/rubygem-smart_proxy_dhcp_remote_isc/rubygem-smart_proxy_dhcp_remote_isc.spec
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_remote_isc/rubygem-smart_proxy_dhcp_remote_isc.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.0.5

--- a/packages/plugins/rubygem-smart_proxy_discovery/rubygem-smart_proxy_discovery.spec
+++ b/packages/plugins/rubygem-smart_proxy_discovery/rubygem-smart_proxy_discovery.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.5

--- a/packages/plugins/rubygem-smart_proxy_discovery_image/rubygem-smart_proxy_discovery_image.spec
+++ b/packages/plugins/rubygem-smart_proxy_discovery_image/rubygem-smart_proxy_discovery_image.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.3.2

--- a/packages/plugins/rubygem-smart_proxy_dns_infoblox/rubygem-smart_proxy_dns_infoblox.spec
+++ b/packages/plugins/rubygem-smart_proxy_dns_infoblox/rubygem-smart_proxy_dns_infoblox.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.1.0

--- a/packages/plugins/rubygem-smart_proxy_dns_powerdns/rubygem-smart_proxy_dns_powerdns.spec
+++ b/packages/plugins/rubygem-smart_proxy_dns_powerdns/rubygem-smart_proxy_dns_powerdns.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.0

--- a/packages/plugins/rubygem-smart_proxy_dns_route53/rubygem-smart_proxy_dns_route53.spec
+++ b/packages/plugins/rubygem-smart_proxy_dns_route53/rubygem-smart_proxy_dns_route53.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.0.1

--- a/packages/plugins/rubygem-smart_proxy_m2/rubygem-smart_proxy_m2.spec
+++ b/packages/plugins/rubygem-smart_proxy_m2/rubygem-smart_proxy_m2.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.0.1

--- a/packages/plugins/rubygem-smart_proxy_monitoring/rubygem-smart_proxy_monitoring.spec
+++ b/packages/plugins/rubygem-smart_proxy_monitoring/rubygem-smart_proxy_monitoring.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.1.2

--- a/packages/plugins/rubygem-smart_proxy_omaha/rubygem-smart_proxy_omaha.spec
+++ b/packages/plugins/rubygem-smart_proxy_omaha/rubygem-smart_proxy_omaha.spec
@@ -15,7 +15,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 %global content_dir %{foreman_proxy_statedir}/omaha
 %global proxy_user foreman-proxy

--- a/packages/plugins/rubygem-smart_proxy_openscap/rubygem-smart_proxy_openscap.spec
+++ b/packages/plugins/rubygem-smart_proxy_openscap/rubygem-smart_proxy_openscap.spec
@@ -15,7 +15,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 %global spool_dir %{_var}/spool/foreman-proxy/openscap
 %global content_dir %{foreman_proxy_statedir}/openscap

--- a/packages/plugins/rubygem-smart_proxy_pulp/rubygem-smart_proxy_pulp.spec
+++ b/packages/plugins/rubygem-smart_proxy_pulp/rubygem-smart_proxy_pulp.spec
@@ -15,7 +15,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.2.0

--- a/packages/plugins/rubygem-smart_proxy_realm_ad_plugin/rubygem-smart_proxy_realm_ad_plugin.spec
+++ b/packages/plugins/rubygem-smart_proxy_realm_ad_plugin/rubygem-smart_proxy_realm_ad_plugin.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.1

--- a/packages/plugins/rubygem-smart_proxy_shellhooks/rubygem-smart_proxy_shellhooks.spec
+++ b/packages/plugins/rubygem-smart_proxy_shellhooks/rubygem-smart_proxy_shellhooks.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.9.2

--- a/packages/plugins/rubygem-smart_proxy_spacewalk/rubygem-smart_proxy_spacewalk.spec
+++ b/packages/plugins/rubygem-smart_proxy_spacewalk/rubygem-smart_proxy_spacewalk.spec
@@ -14,7 +14,6 @@
 %global foreman_proxy_statedir %{_root_localstatedir}/lib/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
-%global smart_proxy_dynflow_bundlerd_dir %{_datadir}/smart_proxy_dynflow_core/bundler.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.1.0


### PR DESCRIPTION
smart_proxy_dynflow_core is no more. Everything now runs in the smart-proxy process itself.

There are still 3 cases where it's used:
* rubygem-smart-proxy-probing
* rubygem-smart_proxy_acd
* rubygem-smart_proxy_salt

These need an actual update and is non-trivial.

For now I haven't added changelogs and haven't bumped the releases because it shouldn't make a difference in the final builds. I'm not sure what's wise here.