### PR TITLE
Fixes #33623 - Add cron rule for audits cleanup

### DIFF
--- a/debian/bionic/foreman/foreman.cron.d
+++ b/debian/bionic/foreman/foreman.cron.d
@@ -15,6 +15,9 @@ FOREMAN_HOME=/usr/share/foreman
 # Expire old reports
 30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake reports:expire 2>&1 | gawk '{ print strftime("[\%Y-\%m-\%d \%H:\%M:\%S]"), $0 }' >>/var/log/foreman/cron.log
 
+# Expire old audits
+0 1 * * *       foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake audits:expire 2>&1 | gawk '{ print strftime("[\%Y-\%m-\%d \%H:\%M:\%S]"), $0 }' >>/var/log/foreman/cron.log
+
 # Refreshes ldap usergroups. Can be disabled if you're not using LDAP authentication.
 */30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake ldap:refresh_usergroups 2>&1 | gawk '{ print strftime("[\%Y-\%m-\%d \%H:\%M:\%S]"), $0 }' >>/var/log/foreman/cron.log
 # Clean expired notifications

--- a/debian/buster/foreman/foreman.cron.d
+++ b/debian/buster/foreman/foreman.cron.d
@@ -15,6 +15,9 @@ FOREMAN_HOME=/usr/share/foreman
 # Expire old reports
 30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake reports:expire 2>&1 | gawk '{ print strftime("[\%Y-\%m-\%d \%H:\%M:\%S]"), $0 }' >>/var/log/foreman/cron.log
 
+# Expire old audits
+0 1 * * *       foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake audits:expire 2>&1 | gawk '{ print strftime("[\%Y-\%m-\%d \%H:\%M:\%S]"), $0 }' >>/var/log/foreman/cron.log
+
 # Refreshes ldap usergroups. Can be disabled if you're not using LDAP authentication.
 */30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake ldap:refresh_usergroups 2>&1 | gawk '{ print strftime("[\%Y-\%m-\%d \%H:\%M:\%S]"), $0 }' >>/var/log/foreman/cron.log
 # Clean expired notifications

--- a/debian/focal/foreman/foreman.cron.d
+++ b/debian/focal/foreman/foreman.cron.d
@@ -15,6 +15,9 @@ FOREMAN_HOME=/usr/share/foreman
 # Expire old reports
 30 7 * * *      foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake reports:expire 2>&1 | gawk '{ print strftime("[\%Y-\%m-\%d \%H:\%M:\%S]"), $0 }' >>/var/log/foreman/cron.log
 
+# Expire old audits
+0 1 * * *       foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake audits:expire 2>&1 | gawk '{ print strftime("[\%Y-\%m-\%d \%H:\%M:\%S]"), $0 }' >>/var/log/foreman/cron.log
+
 # Refreshes ldap usergroups. Can be disabled if you're not using LDAP authentication.
 */30 * * * *    foreman    cd ${FOREMAN_HOME} && /usr/sbin/foreman-rake ldap:refresh_usergroups 2>&1 | gawk '{ print strftime("[\%Y-\%m-\%d \%H:\%M:\%S]"), $0 }' >>/var/log/foreman/cron.log
 # Clean expired notifications


### PR DESCRIPTION
Adding cron rule for audits:expire rake task for removing old audits in automate way.

This PR is same like https://github.com/theforeman/foreman-packaging/pull/7150, only the Debian is the difference

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
