### PR TITLE
Restart Foreman services after package upgrade on Debian

### DIFF
--- a/debian/buster/foreman/changelog
+++ b/debian/buster/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (3.1.0-2) stable; urgency=low
+
+  * Restart foreman services after package upgrade
+
+ -- Eric D. Helms <ericdhelms@gmail.com>  Mon, 01 Nov 2021 10:59:14 -0400
+
 foreman (3.1.0-1) stable; urgency=low
 
   * Bump changelog to 3.1.0 to match VERSION

--- a/debian/buster/foreman/rules
+++ b/debian/buster/foreman/rules
@@ -47,10 +47,10 @@ build:
 	dh $@ --with=systemd
 
 override_dh_systemd_start:
-	dh_systemd_start --no-start --name=foreman.service --package=foreman-service
-	dh_systemd_start --no-start --name=foreman.socket --package=foreman-service
-	dh_systemd_start --no-start --name=dynflow-sidekiq@orchestrator --package=foreman-dynflow-sidekiq
-	dh_systemd_start --no-start --name=dynflow-sidekiq@worker --package=foreman-dynflow-sidekiq
+	dh_systemd_start --no-start --restart-after-upgrade --name=foreman.service --package=foreman-service
+	dh_systemd_start --no-start --restart-after-upgrade --name=foreman.socket --package=foreman-service
+	dh_systemd_start --no-start --restart-after-upgrade --name=dynflow-sidekiq@orchestrator --package=foreman-dynflow-sidekiq
+	dh_systemd_start --no-start --restart-after-upgrade --name=dynflow-sidekiq@worker --package=foreman-dynflow-sidekiq
 
 override_dh_systemd_enable:
 	dh_systemd_enable --name=foreman.service --package=foreman-service

--- a/debian/focal/foreman/changelog
+++ b/debian/focal/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (3.1.0-2) stable; urgency=low
+
+  * Restart foreman services after package upgrade
+
+ -- Eric D. Helms <ericdhelms@gmail.com>  Mon, 01 Nov 2021 10:59:14 -0400
+
 foreman (3.1.0-1) stable; urgency=low
 
   * Bump changelog to 3.1.0 to match VERSION

--- a/debian/focal/foreman/rules
+++ b/debian/focal/foreman/rules
@@ -47,10 +47,10 @@ build:
 	dh $@ --with=systemd
 
 override_dh_systemd_start:
-	dh_systemd_start --no-start --name=foreman.service --package=foreman-service
-	dh_systemd_start --no-start --name=foreman.socket --package=foreman-service
-	dh_systemd_start --no-start --name=dynflow-sidekiq@orchestrator --package=foreman-dynflow-sidekiq
-	dh_systemd_start --no-start --name=dynflow-sidekiq@worker --package=foreman-dynflow-sidekiq
+	dh_systemd_start --no-start --restart-after-upgrade --name=foreman.service --package=foreman-service
+	dh_systemd_start --no-start --restart-after-upgrade --name=foreman.socket --package=foreman-service
+	dh_systemd_start --no-start --restart-after-upgrade --name=dynflow-sidekiq@orchestrator --package=foreman-dynflow-sidekiq
+	dh_systemd_start --no-start --restart-after-upgrade --name=dynflow-sidekiq@worker --package=foreman-dynflow-sidekiq
 
 override_dh_systemd_enable:
 	dh_systemd_enable --name=foreman.service --package=foreman-service


### PR DESCRIPTION
This puts Debian on the same footing as RPM where we do not start
services on initial install but we do restart them after package
upgrades.

Opening as a draft so I can get some builds to test.
