### PR TITLE
Swap wget for curl dependency on foreman-proxy

### DIFF
--- a/debian/buster/foreman-proxy/control
+++ b/debian/buster/foreman-proxy/control
@@ -13,7 +13,7 @@ Section: net
 Priority: extra
 Architecture: all
 Depends: ruby, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext, ruby-concurrent (>= 1.0.0), ruby-concurrent (<< 2.0.0), ruby-rsec, ruby-logging, ruby-sd-notify (>= 0.1.0), ruby-sd-notify (<< 0.2.0)
-Recommends: sudo, wget, ping, ruby-gssapi, ruby-rubyipmi (>= 0.10.0), ruby-redfish-client (>= 0.5.1), ruby-rkerberos (>= 0.1.1), ruby-libvirt (>= 0.6.0), ruby-rb-inotify, ruby-jwt (>= 1.5.6), ruby-xmlrpc (>= 0.3), foreman-debug
+Recommends: sudo, curl, ping, ruby-gssapi, ruby-rubyipmi (>= 0.10.0), ruby-redfish-client (>= 0.5.1), ruby-rkerberos (>= 0.1.1), ruby-libvirt (>= 0.6.0), ruby-rb-inotify, ruby-jwt (>= 1.5.6), ruby-xmlrpc (>= 0.3), foreman-debug
 Suggests: foreman-proxy-journald
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems

--- a/debian/focal/foreman-proxy/control
+++ b/debian/focal/foreman-proxy/control
@@ -13,7 +13,7 @@ Section: net
 Priority: extra
 Architecture: all
 Depends: ruby, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext, ruby-concurrent (>= 1.0.0), ruby-concurrent (<< 2.0.0), ruby-rsec, ruby-logging, ruby-sd-notify (>= 0.1.0), ruby-sd-notify (<< 0.2.0)
-Recommends: sudo, wget, ping, ruby-gssapi, ruby-rubyipmi (>= 0.10.0), ruby-redfish-client (>= 0.5.1), ruby-rkerberos (>= 0.1.1), ruby-libvirt (>= 0.6.0), ruby-rb-inotify, ruby-jwt (>= 1.5.6), ruby-xmlrpc (>= 0.3), foreman-debug
+Recommends: sudo, curl, ping, ruby-gssapi, ruby-rubyipmi (>= 0.10.0), ruby-redfish-client (>= 0.5.1), ruby-rkerberos (>= 0.1.1), ruby-libvirt (>= 0.6.0), ruby-rb-inotify, ruby-jwt (>= 1.5.6), ruby-xmlrpc (>= 0.3), foreman-debug
 Suggests: foreman-proxy-journald
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems


### PR DESCRIPTION
This reflects that the Smart Proxy now [uses curl instead of wget](https://github.com/theforeman/smart-proxy/commit/3d87c6feaa8caaf9b8c040f96061c3b8c33a39ef).