### PR TITLE
Removing EL6 and FC29

### DIFF
--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -993,20 +993,6 @@ whitelist =
   rubygem-foreman_scap_client
   tracer
 
-[foreman-client-3.1-rhel6]
-disttag = .el6
-whitelist = foreman-release
-  katello-host-tools
-  rubygem-foreman_scap_client
-
-[foreman-client-3.1-fedora29]
-disttag = .fc29
-whitelist =
-  foreman-release
-  katello-host-tools
-  rubygem-foreman_scap_client
-  tracer
-
 [katello-4.3-rhel7]
 disttag = .el7
 scl = tfm


### PR DESCRIPTION
Foreman 3.0 already dropped EL6 and FC29, we might need to remove this later from rpm/develop