### PR TITLE
don't use nightly releasers for 3.1

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -60,7 +60,6 @@ foreman_scl_packages:
           foremandist: "{{ foremandist }}"
     releasers:
       - koji-foreman
-    nightly_releaser: koji-foreman-jenkins
     repoclosure_target_repos:
       rhel7:
         - "el7-foreman-{{ foreman_version }}"
@@ -86,16 +85,7 @@ foreman_scl_packages:
   children:
     rails_core_packages: {}
   hosts:
-    foreman:
-      releasers:
-        - "{{ nightly_releaser }}"
-      build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
-      nightly_package_tito_releaser_args:
-        - "jenkins_job=foreman-develop-source-release"
-        - "jenkins_url=https://ci.theforeman.org"
-      build_package_tito_builder: "tito.builder.FetchBuilder"
-      source_location: https://ci.theforeman.org/job/foreman-develop-source-release
-      source_system: jenkins
+    foreman: {}
     rubygem-activerecord-nulldb-adapter: {}
     rubygem-activerecord-session_store: {}
     rubygem-addressable: {}
@@ -164,26 +154,8 @@ foreman_scl_packages:
     rubygem-googleauth: {}
     rubygem-graphql: {}
     rubygem-graphql-batch: {}
-    rubygem-hammer_cli:
-      releasers:
-        - "{{ nightly_releaser }}"
-      build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
-      nightly_package_tito_releaser_args:
-        - "jenkins_job=hammer-cli-master-source-release"
-        - "jenkins_url=https://ci.theforeman.org"
-      build_package_tito_builder: "tito.builder.FetchBuilder"
-      source_location: https://ci.theforeman.org/job/hammer-cli-master-source-release
-      source_system: jenkins
-    rubygem-hammer_cli_foreman:
-      releasers:
-        - "{{ nightly_releaser }}"
-      build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
-      nightly_package_tito_releaser_args:
-        - "jenkins_job=hammer-cli-foreman-master-source-release"
-        - "jenkins_url=https://ci.theforeman.org"
-      build_package_tito_builder: "tito.builder.FetchBuilder"
-      source_location: https://ci.theforeman.org/job/hammer-cli-foreman-master-source-release
-      source_system: jenkins
+    rubygem-hammer_cli: {}
+    rubygem-hammer_cli_foreman: {}
     rubygem-hashie: {}
     rubygem-hirb-unicode-steakknife: {}
     rubygem-hirb: {}
@@ -465,7 +437,6 @@ foreman_installer_packages:
         dist: '.el8'
     releasers:
       - koji-foreman
-    nightly_releaser: koji-foreman-jenkins
     repoclosure_target_repos:
       rhel7:
         - "el7-foreman-{{ foreman_version }}"
@@ -490,26 +461,8 @@ foreman_installer_packages:
         - el8-devel
         - "el8-katello-candlepin-{{ katello_version }}"
   hosts:
-    foreman-installer:
-      releasers:
-        - "{{ nightly_releaser }}"
-      build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
-      nightly_package_tito_releaser_args:
-        - "jenkins_job=foreman-installer-develop-source-release"
-        - "jenkins_url=https://ci.theforeman.org"
-      build_package_tito_builder: "tito.builder.FetchBuilder"
-      source_location: https://ci.theforeman.org/job/foreman-installer-develop-source-release
-      source_system: jenkins
-    foreman-selinux:
-      releasers:
-        - "{{ nightly_releaser }}"
-      build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
-      nightly_package_tito_releaser_args:
-        - "jenkins_job=foreman-selinux-develop-source-release"
-        - "jenkins_url=https://ci.theforeman.org"
-      build_package_tito_builder: "tito.builder.FetchBuilder"
-      source_location: https://ci.theforeman.org/job/foreman-selinux-develop-source-release
-      source_system: jenkins
+    foreman-installer: {}
+    foreman-selinux: {}
     katello-certs-tools: {}
     puppet-agent-oauth: {}
     puppet-agent-puppet-strings: {}
@@ -530,7 +483,6 @@ foreman_nonscl_packages:
         dist: '.el8'
     releasers:
       - koji-foreman
-    nightly_releaser: koji-foreman-jenkins
     repoclosure_target_repos:
       rhel7:
         - "el7-foreman-{{ foreman_version }}"
@@ -575,7 +527,6 @@ foreman_proxy_packages:
           foremandist: "{{ foremandist }}"
     releasers:
       - koji-foreman
-    nightly_releaser: koji-foreman-jenkins
     repoclosure_config: repoclosure/yum.conf
     repoclosure_lookaside_repos:
       rhel7:
@@ -593,16 +544,7 @@ foreman_proxy_packages:
         - el8-puppet-6
         - "el8-foreman-{{ foreman_version }}"
   hosts:
-    foreman-proxy:
-      releasers:
-        - "{{ nightly_releaser }}"
-      build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
-      nightly_package_tito_releaser_args:
-        - "jenkins_job=smart-proxy-develop-source-release"
-        - "jenkins_url=https://ci.theforeman.org"
-      build_package_tito_builder: "tito.builder.FetchBuilder"
-      source_location: https://ci.theforeman.org/job/smart-proxy-develop-source-release
-      source_system: jenkins
+    foreman-proxy: {}
     rubygem-concurrent-ruby: {}
     rubygem-gssapi: {}
     rubygem-rake-compiler: {}
@@ -627,7 +569,6 @@ foreman_proxy_plugin_packages:
           foremandist: "{{ foremandist }}"
     releasers:
       - koji-foreman-plugins
-    nightly_releaser: koji-foreman-plugins-jenkins
     repoclosure_lookaside_repos:
       rhel7:
         - el7-base
@@ -699,7 +640,6 @@ foreman_scl_and_nonscl_packages:
         dist: '.el8'
     releasers:
       - koji-foreman
-    nightly_releaser: koji-foreman-jenkins
     repoclosure_target_repos:
       rhel7:
         - "el7-foreman-{{ foreman_version }}"
@@ -800,7 +740,6 @@ katello_packages:
           foremandist: "{{ foremandist }}"
     releasers:
       - koji-katello
-    nightly_releaser: koji-katello-jenkins
     repoclosure_target_repos:
       rhel7:
         - "el7-katello-{{ katello_version }}"
@@ -860,26 +799,8 @@ katello_packages:
     rubygem-hammer_cli_foreman_rh_cloud: {}
     rubygem-hammer_cli_foreman_scc_manager: {}
     rubygem-hammer_cli_foreman_virt_who_configure: {}
-    rubygem-hammer_cli_katello:
-      releasers:
-        - "{{ nightly_releaser }}"
-      build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
-      nightly_package_tito_releaser_args:
-        - "jenkins_job=hammer-cli-katello-master-source-release"
-        - "jenkins_url=https://ci.theforeman.org"
-      build_package_tito_builder: "tito.builder.FetchBuilder"
-      source_location: https://ci.theforeman.org/job/hammer-cli-katello-master-source-release
-      source_system: jenkins
-    rubygem-katello:
-      releasers:
-        - "{{ nightly_releaser }}"
-      build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
-      nightly_package_tito_releaser_args:
-        - "jenkins_job=katello-master-source-release"
-        - "jenkins_url=https://ci.theforeman.org"
-      build_package_tito_builder: "tito.builder.FetchBuilder"
-      source_location: https://ci.theforeman.org/job/katello-master-source-release
-      source_system: jenkins
+    rubygem-hammer_cli_katello: {}
+    rubygem-katello: {}
     rubygem-pulp_python_client: {}
     rubygem-pulpcore_client: {}
     rubygem-pulp_ansible_client: {}
@@ -917,7 +838,6 @@ plugin_scl_packages:
           foremandist: "{{ foremandist }}"
     releasers:
       - koji-foreman-plugins
-    nightly_releaser: koji-foreman-plugins-jenkins
     repoclosure_target_repos:
       rhel7:
         - "el7-foreman-plugins-{{ foreman_version }}"
@@ -1081,7 +1001,6 @@ plugin_nonscl_packages:
         dist: '.el8'
     releasers:
       - koji-foreman-plugins
-    nightly_releaser: koji-foreman-plugins-jenkins
     repoclosure_target_repos:
       rhel7:
         - "el7-foreman-plugins-{{ foreman_version }}"


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
