### PR TITLE
exclude ruby 3 packages from repoclosure

### DIFF
--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -26,6 +26,7 @@ enabled=1
 mirrorlist=http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=AppStream
 failovermethod=priority
 module_hotfixes=1
+excludepkgs=ruby-3*,ruby-devel-3*,ruby-libs-3*
 
 [el8-configmanagement-ansible]
 name=Ansible configmanagement


### PR DESCRIPTION
we're currently building with ruby 2.7, but the way "dnf repoclosure"
works it ends up detecting 3.0 as "latest" and then breaks our packages
that need 2.7

this will never happen in the real world, as there one needs to enable
the right version of the module explicitly

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
