### PR TITLE
compare_deb_repo support for stagingdeb, json output and release detection

### DIFF
--- a/scripts/compare_deb_repo.py
+++ b/scripts/compare_deb_repo.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import requests
+import subprocess
 from collections import defaultdict
 from itertools import chain
 from pathlib import Path
@@ -47,9 +48,20 @@ def get_git_packages(dist, release='nightly'):
     return packages
 
 
+def get_release_from_git_branch(default='nightly'):
+    release = default
+    git_branch = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], encoding='utf-8').strip()
+    if git_branch.startswith('deb/'):
+        release = git_branch.replace('deb/', '')
+        if release == 'develop':
+            release = 'nightly'
+    return release
+
+
 def main():
+    default_release = get_release_from_git_branch()
     parser = argparse.ArgumentParser(description='compare git and debian repo')
-    parser.add_argument('--release', default='nightly', help='release to compare for (default: %(default)s)')
+    parser.add_argument('--release', default=default_release, help='release to compare for (default: %(default)s)')
     parser.add_argument('--staging', action='store_true', help='check staging repository')
     parser.add_argument('--json', action='store_true', help='JSON output')
     args = parser.parse_args()

--- a/scripts/compare_deb_repo.py
+++ b/scripts/compare_deb_repo.py
@@ -14,9 +14,13 @@ PLUGINS = ['plugins']
 NIGHTLY_PACKAGES = ['foreman', 'foreman-installer', 'foreman-proxy']
 
 
-def get_repo_packages(dist, release='nightly', arch='amd64'):
+def get_repo_packages(dist, release='nightly', arch='amd64', staging=False):
     packages = defaultdict(lambda: '0')
-    remote_packages = requests.get(f'https://deb.theforeman.org/dists/{dist}/{release}/binary-{arch}/Packages')
+    if staging and dist != 'plugins':
+        repo_url = f'https://stagingdeb.theforeman.org/dists/{dist}/theforeman-{release}/binary-{arch}/Packages'
+    else:
+        repo_url = f'https://deb.theforeman.org/dists/{dist}/{release}/binary-{arch}/Packages'
+    remote_packages = requests.get(repo_url)
     for pkg in Packages.iter_paragraphs(remote_packages.text, use_apt_pkg=False):
         source = pkg.get('Source', pkg['Package'])
         version = pkg['Version']
@@ -53,10 +57,11 @@ def print_diff(dist, repo_packages, git_packages):
 def main():
     parser = argparse.ArgumentParser(description='compare git and debian repo')
     parser.add_argument('--release', default='nightly', help='release to compare for (default: %(default)s)')
+    parser.add_argument('--staging', action='store_true', help='check staging repository')
     args = parser.parse_args()
     for dist in DISTS + PLUGINS:
         packages = get_git_packages(dist, release=args.release)
-        repo_packages = get_repo_packages(dist, release=args.release)
+        repo_packages = get_repo_packages(dist, release=args.release, staging=args.staging)
         print_diff(dist, repo_packages, packages)
 
 


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
