### PR TITLE
Update rubygem-foreman_bootdisk to 19.0.0

### DIFF
--- a/packages/plugins/rubygem-foreman_bootdisk/foreman_bootdisk-18.0.0.gem
+++ b/packages/plugins/rubygem-foreman_bootdisk/foreman_bootdisk-18.0.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/V1/Xq/SHA256E-s89088--adee27fe5dbee500677a3f9507bc70bd229e040294b8ebb8cbc9921d9ecf8b0f.0.gem/SHA256E-s89088--adee27fe5dbee500677a3f9507bc70bd229e040294b8ebb8cbc9921d9ecf8b0f.0.gem

--- a/packages/plugins/rubygem-foreman_bootdisk/foreman_bootdisk-19.0.0.gem
+++ b/packages/plugins/rubygem-foreman_bootdisk/foreman_bootdisk-19.0.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/Wv/gX/SHA256E-s104960--3ec97a49201bb2e2930de29039b83a1a5dc32741e4eb0e8c7a3eb0a8fbbc20e0.0.gem/SHA256E-s104960--3ec97a49201bb2e2930de29039b83a1a5dc32741e4eb0e8c7a3eb0a8fbbc20e0.0.gem

--- a/packages/plugins/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
+++ b/packages/plugins/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
@@ -8,7 +8,7 @@
 
 Summary:    Create boot disks to provision hosts with Foreman
 Name:       %{?scl_prefix}rubygem-%{gem_name}
-Version:    18.0.0
+Version:    19.0.0
 Release:    1%{?foremandist}%{?dist}
 Group:      Applications/Systems
 License:    GPLv3
@@ -84,16 +84,16 @@ cp -pa .%{gem_dir}/* \
 
 %files
 %dir %{gem_instdir}
-%exclude %{gem_instdir}/.tx
 %license %{gem_instdir}/LICENSE
 %{gem_instdir}/app
 %{gem_instdir}/config
 %{gem_instdir}/db
-%{gem_libdir}
+%{gem_instdir}/webpack
+%{gem_instdir}/lib
 %{gem_instdir}/locale
+%{gem_instdir}/package.json
 %exclude %{gem_cache}
 %exclude %{gem_instdir}/release-gem
-%exclude %{gem_instdir}/.github
 %{gem_spec}
 %{foreman_bundlerd_plugin}
 %{foreman_apipie_cache_foreman}
@@ -104,10 +104,11 @@ cp -pa .%{gem_dir}/* \
 %doc %{gem_docdir}
 %doc %{gem_instdir}/CHANGES.md
 %doc %{gem_instdir}/README.md
-%doc %{gem_instdir}/AUTHORS
-%{gem_instdir}/test
 
 %changelog
+* Wed Dec 08 2021 Odilon Sousa <osousa@redhat.com> - 19.0.0-1
+- Release rubygem-foreman_bootdisk 19.0.0
+
 * Fri Sep 24 2021 Lukas Zapletal <lzap+rpm@redhat.com> 18.0.0-1
 - Update to 18.0.0
 


### PR DESCRIPTION
Alternative to #7367

Removing some lines that got changed in the gemspec for 19.0.0

https://github.com/theforeman/foreman_bootdisk/commit/3d35118e09a4c1db3c0bad61648c409b60fb54d7#diff-fd2f7e5ff7f39b53681e8d8638b603e949963eff09427b7e75904c585f9ed420