### PR TITLE
Add template header to plugins missing it

### DIFF
--- a/packages/plugins/rubygem-foreman_m2/rubygem-foreman_m2.spec
+++ b/packages/plugins/rubygem-foreman_m2/rubygem-foreman_m2.spec
@@ -1,3 +1,4 @@
+# template: foreman_plugin
 %{?scl:%scl_package rubygem-%{gem_name}}
 %{!?scl:%global pkg_name %{name}}
 

--- a/packages/plugins/rubygem-foreman_rescue/rubygem-foreman_rescue.spec
+++ b/packages/plugins/rubygem-foreman_rescue/rubygem-foreman_rescue.spec
@@ -1,3 +1,4 @@
+# template: foreman_plugin
 %{?scl:%scl_package rubygem-%{gem_name}}
 %{!?scl:%global pkg_name %{name}}
 

--- a/packages/plugins/rubygem-foreman_spacewalk/rubygem-foreman_spacewalk.spec
+++ b/packages/plugins/rubygem-foreman_spacewalk/rubygem-foreman_spacewalk.spec
@@ -1,3 +1,4 @@
+# template: foreman_plugin
 %{?scl:%scl_package rubygem-%{gem_name}}
 %{!?scl:%global pkg_name %{name}}
 


### PR DESCRIPTION
These files are all Foreman plugins but lack the right template header. This means the version bumping script can't update the dependencies automatically.