### PR TITLE
Respect GIT_AUTHOR_{NAME,EMAIL} env vars

### DIFF
--- a/scripts/changelog.rb
+++ b/scripts/changelog.rb
@@ -5,8 +5,8 @@ require 'time'
 
 options = {:message => []}
 
-author_name = `git config --get user.name`.chomp
-author_email = ENV['DEBEMAIL'] || ENV['EMAIL'] || `git config --get user.email`.chomp
+author_name = ENV['GIT_AUTHOR_NAME'] || `git config --get user.name`.chomp
+author_email = ENV['DEBEMAIL'] || ENV['EMAIL'] || ENV['GIT_AUTHOR_EMAIL'] || `git config --get user.email`.chomp
 options[:author] = "#{author_name} <#{author_email}>" if !author_name.nil? && !author_email.nil?
 
 OptionParser.new do |opts|


### PR DESCRIPTION
Git itself prefers these environment variables over what's in the config. I couldn't find a better way in git itself to get the name and email.

This makes it easier to use in scripting such as GitHub Actions.