### PR TITLE
Add base modulemd for Foreman and Katello

### DIFF
--- a/modulemd/modulemd-foreman-el8.yaml
+++ b/modulemd/modulemd-foreman-el8.yaml
@@ -1,0 +1,28 @@
+---
+document: modulemd
+version: 2
+data:
+  name: foreman
+  stream: latest
+  version: 0
+  arch: x86_64
+  summary: Foreman module
+  description: >-
+    A module to make Foreman easier to install.
+  license:
+    module:
+      - GPLv3
+  profiles:
+    installer:
+      rpms:
+        - foreman-installer
+  dependencies:
+    - buildrequires:
+        platform: ['el8']
+        nodejs: ['12']
+        ruby: ['2.7']
+        postgresql: ['12']
+      requires:
+        platform: ['el8']
+        ruby: ['2.7']
+        postgresql: ['12']

--- a/modulemd/modulemd-katello-el8.yaml
+++ b/modulemd/modulemd-katello-el8.yaml
@@ -1,0 +1,25 @@
+---
+document: modulemd
+version: 2
+data:
+  name: katello
+  stream: latest
+  version: 0
+  arch: x86_64
+  summary: Katello module
+  description: >-
+    A module to make Katello easier to install.
+  license:
+    module:
+      - GPLv3
+  profiles:
+    installer:
+      rpms:
+        - foreman-installer-katello
+  dependencies:
+    - buildrequires:
+        platform: ['el8']
+        foreman: ['latest']
+      requires:
+        foreman: ['latest']
+        pki-core: []


### PR DESCRIPTION
This adds base modulemd configurations for Foreman and Katello repositories that would be used as inputs to mashing (see https://github.com/theforeman/foreman-infra/pull/1698). See modulemd reference (https://github.com/fedora-modularity/libmodulemd/blob/main/yaml_specs/modulemd_stream_v2.yaml).

The base module metadata would be dynamically altered during mashing to add all the actual RPM builds when creating the new repository. This base metadata defines the module dependencies that allow for automatic module dependency resolution and ease of installation for users. Since the metadata and dependencies are per repository, we would have modules and streams each for Foreman and Katello. One open question might be how to handle something like PostgreSQL which has a module, and has a module stream we'd like to require but we do not require PostgreSQL in all cases (e.g. external database).

You can see some example output from playing around with this for the Satellite ecosystem:

```
# dnf module enable satellite
Failed to set locale, defaulting to C.UTF-8
Last metadata expiration check: 0:00:26 ago on Wed Dec  8 02:11:41 2021.
Problems in request:
Modular dependency problems with Defaults:
 Problem: module satellite:7:0:-0.noarch requires module(ruby:2.7), but none of the providers can be installed
  - module ruby:2.5:8040020210629164822:9f9e2e7e-0.x86_64 conflicts with module(ruby:2.7) provided by ruby:2.7:8040020210805145045:9f9e2e7e-0.x86_64
  - module ruby:2.7:8040020210805145045:9f9e2e7e-0.x86_64 conflicts with module(ruby:2.5) provided by ruby:2.5:8040020210629164822:9f9e2e7e-0.x86_64
  - conflicting requests
Dependencies resolved.
==========================================================================================================================================================================================================================================================================================
 Package                                                              Architecture                                                        Version                                                              Repository                                                            Size
==========================================================================================================================================================================================================================================================================================
Enabling module streams:
 pki-core                                                                                                                                 10.6                                                                                                                                           
 pki-deps                                                                                                                                 10.6                                                                                                                                           
 ruby                                                                                                                                     2.7                                                                                                                                            
 satellite                                                                                                                                7                                                                                                                                              
Transaction Summary
==========================================================================================================================================================================================================================================================================================
```