### PR TITLE
Update rubygem-smart_proxy_remote_execution_ssh to 0.5.1

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
+++ b/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
@@ -16,7 +16,7 @@
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 0.5.0
+Version: 0.5.1
 Release: 1%{?foremandist}%{?dist}
 Summary: Ssh remote execution provider for Foreman Smart-Proxy
 Group: Applications/Internet
@@ -121,6 +121,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/remote_execution_ssh.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Tue Jan 04 2022 Adam Ruzicka <aruzicka@redhat.com> 0.5.1-1
+- Update to 0.5.1
+
 * Tue Nov 16 2021 Adam Ruzicka <aruzicka@redhat.com> 0.5.0-1
 - Update to 0.5.0
 

--- a/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/smart_proxy_remote_execution_ssh-0.5.0.gem
+++ b/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/smart_proxy_remote_execution_ssh-0.5.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/wP/VJ/SHA256E-s35840--7850ffc85cbcded6b6b4525a21cc91c116fb26485edad8c902f02f39dc35284e.0.gem/SHA256E-s35840--7850ffc85cbcded6b6b4525a21cc91c116fb26485edad8c902f02f39dc35284e.0.gem

--- a/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/smart_proxy_remote_execution_ssh-0.5.1.gem
+++ b/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/smart_proxy_remote_execution_ssh-0.5.1.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/7m/q0/SHA256E-s35840--90493f6d9cad56327d33cf6174de8bb5ff7bb59046758f058ced9589b47eaeca.1.gem/SHA256E-s35840--90493f6d9cad56327d33cf6174de8bb5ff7bb59046758f058ced9589b47eaeca.1.gem


### PR DESCRIPTION
CPs:
- 3.1
