### PR TITLE
Use %{evr} macro in add_changelog

### DIFF
--- a/add_changelog.sh
+++ b/add_changelog.sh
@@ -9,7 +9,7 @@ if [[ -z $SPEC_FILE ]] || [[ ! -e $SPEC_FILE ]] ; then
 fi
 
 if [[ -z $VERSION ]] ; then
-	VERSION=$(rpmspec --srpm -q --queryformat="%{version}-%{release}" --undefine=dist $SPEC_FILE)
+	VERSION=$(rpmspec --srpm -q --queryformat="%{evr}" --undefine=dist $SPEC_FILE)
 fi
 
 read MESSAGE

--- a/bump_rpm.sh
+++ b/bump_rpm.sh
@@ -70,8 +70,7 @@ if [[ $CURRENT_VERSION != $NEW_VERSION ]] ; then
 		sed -i "s/^\(Release:\s\+\)${RELEASE}/\11/" $SPEC_FILE
 	fi
 
-	EVR=$(rpmspec --srpm -q --queryformat='%{evr}' --undefine=dist $SPEC_FILE)
-	$SCRIPT_DIR/add_changelog.sh $SPEC_FILE $EVR <<-EOF
+	$SCRIPT_DIR/add_changelog.sh $SPEC_FILE <<-EOF
 	- Update to $NEW_VERSION
 	EOF
 

--- a/bump_rpm.sh
+++ b/bump_rpm.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -e
 
 # Dependencies:
-# curl
-# jq
-# python3-semver
-# rpm-build
-# rpmdevtools
+# curl (if no new version is specified)
+# jq (if no new version is specified)
+# python3-semver (for update-requirements)
+# rpm-build (provides rpmspec)
+# rpmdevtools (provides spectool)
 # rubygem-gem2rpm
 
 if [[ -z $1 ]] ; then


### PR DESCRIPTION
This uses the %{evr} macro in add_changelog.sh. Changelogs must include the epoch.

It also drops EVR handling from bump_rpm.sh becaues now the add_changelog.sh script can handle it all properly.

While working on this, I also annotated the bump_rpm.sh dependencies.