### PR TITLE
[3.1] use versioned obsoletes for proxy plugins

### DIFF
--- a/gem2rpm/smart_proxy_plugin.spec.erb
+++ b/gem2rpm/smart_proxy_plugin.spec.erb
@@ -67,7 +67,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 <%= spec.description %>
@@ -79,7 +79,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.

--- a/packages/plugins/rubygem-smart-proxy-probing/rubygem-smart-proxy-probing.spec
+++ b/packages/plugins/rubygem-smart-proxy-probing/rubygem-smart-proxy-probing.spec
@@ -17,7 +17,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.0.4
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Gem to allow probing through smart-proxy
 Group: Applications/Internet
 License: GPLv3
@@ -41,7 +41,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 Gem to allow probing through smart-proxy.
@@ -53,7 +53,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -112,6 +112,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/probing.yml.example \
 
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.0.4-2
+- use versioned obsoletes for proxy plugins
+
 * Thu Oct 21 2021 Adam Ruzicka <aruzicka@redhat.com> 0.0.4-1
 - Update to 0.0.4
 

--- a/packages/plugins/rubygem-smart_proxy_acd/rubygem-smart_proxy_acd.spec
+++ b/packages/plugins/rubygem-smart_proxy_acd/rubygem-smart_proxy_acd.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.3.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Application Centric Deployment smart proxy plugin
 Group: Applications/Internet
 License: GPLv3
@@ -48,8 +48,6 @@ Summary: Documentation for %{name}
 Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
-
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
 
 %description doc
 Documentation for %{name}.
@@ -108,6 +106,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/acd.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.3.0-2
+- Drop obsoletes, there newer was a non-SCL ACD plugin on EL7
+
 * Tue Nov 16 2021 Bernhard Suttner <suttner@atix.de> 0.3.0-1
 - Update to 0.3.0
 

--- a/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
+++ b/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
@@ -17,7 +17,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.2.1
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Summary: Smart-Proxy Ansible plugin
 Group: Applications/Internet
 License: GPLv3
@@ -46,7 +46,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 Smart-Proxy ansible plugin.
@@ -58,7 +58,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -143,6 +143,9 @@ ln -sv %{_root_sysconfdir}/foreman-proxy/ansible.cfg %{buildroot}%{foreman_proxy
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 3.2.1-3
+- use versioned obsoletes for proxy plugins
+
 * Mon Jul 12 2021 Evgeni Golov - 3.2.1-2
 - Do not obsolete ansible_core from smart_proxy_ansible
 

--- a/packages/plugins/rubygem-smart_proxy_chef/rubygem-smart_proxy_chef.spec
+++ b/packages/plugins/rubygem-smart_proxy_chef/rubygem-smart_proxy_chef.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.2.0
-Release: 7%{?foremandist}%{?dist}
+Release: 8%{?foremandist}%{?dist}
 Summary: Chef support for Foreman Smart-Proxy
 Group: Applications/Internet
 License: GPLv3
@@ -49,7 +49,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -106,6 +106,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/chef.yml.example \
 %{gem_instdir}/Gemfile
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.2.0-8
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 0.2.0-7
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_dhcp_bluecat/rubygem-smart_proxy_dhcp_bluecat.spec
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_bluecat/rubygem-smart_proxy_dhcp_bluecat.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.1.5
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Summary: BlueCat DHCP provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -40,7 +40,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 BlueCat DHCP provider plugin for Foreman's smart proxy.
@@ -52,7 +52,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -111,6 +111,9 @@ mv %{buildroot}%{gem_instdir}/config/dhcp_bluecat.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.1.5-3
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 0.1.5-2
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_dhcp_device42/rubygem-smart_proxy_dhcp_device42.spec
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_device42/rubygem-smart_proxy_dhcp_device42.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.7
-Release: 8%{?foremandist}%{?dist}
+Release: 9%{?foremandist}%{?dist}
 Summary: Device42 DHCP provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -40,7 +40,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 Device42 DHCP provider plugin for Foreman's smart proxy.
@@ -52,7 +52,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -110,6 +110,9 @@ mv %{buildroot}%{gem_instdir}/config/dhcp_device42.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 1.0.7-9
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.0.7-8
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_dhcp_dnsmasq/rubygem-smart_proxy_dhcp_dnsmasq.spec
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_dnsmasq/rubygem-smart_proxy_dhcp_dnsmasq.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.7
-Release: 7%{?foremandist}%{?dist}
+Release: 8%{?foremandist}%{?dist}
 Summary: dnsmasq DHCP provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -38,7 +38,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 dnamasq DHCP provider plugin for Foreman's smart proxy.
@@ -50,7 +50,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -109,6 +109,9 @@ mv %{buildroot}%{gem_instdir}/config/dhcp_dnsmasq.yml \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.7-8
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 0.7-7
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_dhcp_infoblox/rubygem-smart_proxy_dhcp_infoblox.spec
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_infoblox/rubygem-smart_proxy_dhcp_infoblox.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.0.16
-Release: 5%{?foremandist}%{?dist}
+Release: 6%{?foremandist}%{?dist}
 Summary: Infoblox DHCP provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -40,7 +40,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 Infoblox DHCP provider plugin for Foreman's smart proxy.
@@ -52,7 +52,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -111,6 +111,9 @@ mv %{buildroot}%{gem_instdir}/config/dhcp_infoblox.yml.example \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.0.16-6
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 0.0.16-5
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_dhcp_remote_isc/rubygem-smart_proxy_dhcp_remote_isc.spec
+++ b/packages/plugins/rubygem-smart_proxy_dhcp_remote_isc/rubygem-smart_proxy_dhcp_remote_isc.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.0.5
-Release: 4%{?foremandist}%{?dist}
+Release: 5%{?foremandist}%{?dist}
 Summary: Smart-Proxy dhcp module provider for NFS-accessible ISC dhcpd installations
 Group: Applications/Internet
 License: GPLv3
@@ -38,7 +38,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 Smart-Proxy dhcp module provider for NFS-accessible ISC dhcpd installations.
@@ -50,7 +50,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -109,6 +109,9 @@ mv %{buildroot}%{gem_instdir}/config/dhcp_remote_isc.yml.example \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.0.5-5
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 0.0.5-4
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_discovery/rubygem-smart_proxy_discovery.spec
+++ b/packages/plugins/rubygem-smart_proxy_discovery/rubygem-smart_proxy_discovery.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.5
-Release: 7%{?foremandist}%{?dist}
+Release: 8%{?foremandist}%{?dist}
 Summary: Discovery plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -39,7 +39,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 This smart proxy plugin, together with a Foreman plugin, add the capability to
@@ -53,7 +53,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -110,6 +110,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/discovery.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 1.0.5-8
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.0.5-7
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_discovery_image/rubygem-smart_proxy_discovery_image.spec
+++ b/packages/plugins/rubygem-smart_proxy_discovery_image/rubygem-smart_proxy_discovery_image.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.3.2
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Summary: FDI API for Foreman Smart-Proxy
 Group: Applications/Internet
 License: GPLv3
@@ -38,7 +38,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 Smart Proxy plugin providing Image API on discovered nodes. This plugin is
@@ -52,7 +52,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -110,6 +110,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/discovery_image.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 1.3.2-3
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.3.2-2
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_dns_dnsmasq/rubygem-smart_proxy_dns_dnsmasq.spec
+++ b/packages/plugins/rubygem-smart_proxy_dns_dnsmasq/rubygem-smart_proxy_dns_dnsmasq.spec
@@ -17,7 +17,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.6
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Summary: dnsmasq DNS provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -37,7 +37,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 dnamasq DNS provider plugin for Foreman's smart proxy.
@@ -49,7 +49,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -108,6 +108,9 @@ mv %{buildroot}%{gem_instdir}/config/dns_dnsmasq.yml \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.6-3
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 0.6-2
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_dns_infoblox/rubygem-smart_proxy_dns_infoblox.spec
+++ b/packages/plugins/rubygem-smart_proxy_dns_infoblox/rubygem-smart_proxy_dns_infoblox.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.1.0
-Release: 5%{?foremandist}%{?dist}
+Release: 6%{?foremandist}%{?dist}
 Summary: Infoblox DNS provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -40,7 +40,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 Infoblox DNS provider plugin for Foreman's smart proxy.
@@ -52,7 +52,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -111,6 +111,9 @@ mv %{buildroot}%{gem_instdir}/config/dns_infoblox.yml.example \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 1.1.0-6
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.1.0-5
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_dns_powerdns/rubygem-smart_proxy_dns_powerdns.spec
+++ b/packages/plugins/rubygem-smart_proxy_dns_powerdns/rubygem-smart_proxy_dns_powerdns.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.0
-Release: 6%{?foremandist}%{?dist}
+Release: 7%{?foremandist}%{?dist}
 Summary: PowerDNS DNS provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -38,7 +38,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 PowerDNS DNS provider plugin for Foreman's smart proxy.
@@ -50,7 +50,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -109,6 +109,9 @@ mv %{buildroot}%{gem_instdir}/config/dns_powerdns.yml \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 1.0.0-7
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.0.0-6
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_dns_route53/rubygem-smart_proxy_dns_route53.spec
+++ b/packages/plugins/rubygem-smart_proxy_dns_route53/rubygem-smart_proxy_dns_route53.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.0.1
-Release: 7%{?foremandist}%{?dist}
+Release: 8%{?foremandist}%{?dist}
 Summary: Route 53 DNS provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -39,7 +39,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 Route 53 DNS provider plugin for Foreman's smart proxy.
@@ -51,7 +51,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -110,6 +110,9 @@ mv %{buildroot}%{gem_instdir}/config/dns_route53.yml \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 3.0.1-8
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 3.0.1-7
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_dynflow/rubygem-smart_proxy_dynflow.spec
+++ b/packages/plugins/rubygem-smart_proxy_dynflow/rubygem-smart_proxy_dynflow.spec
@@ -18,7 +18,7 @@
 Summary: Dynflow runtime for Foreman smart proxy
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.6.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Group: Applications/System
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_dynflow
@@ -43,7 +43,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 Use the Dynflow inside Foreman smart proxy.
@@ -55,7 +55,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -117,6 +117,9 @@ mkdir -p %{buildroot}%{foreman_proxy_statedir}/dynflow
 %{gem_instdir}/Gemfile
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.6.1-2
+- use versioned obsoletes for proxy plugins
+
 * Fri Dec 03 2021 Adam Ruzicka <aruzicka@redhat.com> 0.6.1-1
 - Update to 0.6.1
 

--- a/packages/plugins/rubygem-smart_proxy_m2/rubygem-smart_proxy_m2.spec
+++ b/packages/plugins/rubygem-smart_proxy_m2/rubygem-smart_proxy_m2.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.0.1
-Release: 7%{?foremandist}%{?dist}
+Release: 8%{?foremandist}%{?dist}
 Summary: M2 smart proxy plugin for Foreman
 Group: Applications/Internet
 License: GPLv3
@@ -38,7 +38,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 M2 smart proxy plugin for Foreman.
@@ -50,7 +50,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -107,6 +107,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/m2.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.0.1-8
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 0.0.1-7
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_monitoring/rubygem-smart_proxy_monitoring.spec
+++ b/packages/plugins/rubygem-smart_proxy_monitoring/rubygem-smart_proxy_monitoring.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.1.2
-Release: 7%{?foremandist}%{?dist}
+Release: 8%{?foremandist}%{?dist}
 Summary: Monitoring plug-in for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -40,7 +40,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 Monitoring plug-in for Foreman's smart proxy.
@@ -52,7 +52,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -119,6 +119,9 @@ mkdir -p %{buildroot}%{_root_sysconfdir}/foreman-proxy/monitoring
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.1.2-8
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 0.1.2-7
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_omaha/rubygem-smart_proxy_omaha.spec
+++ b/packages/plugins/rubygem-smart_proxy_omaha/rubygem-smart_proxy_omaha.spec
@@ -22,7 +22,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.1.0
-Release: 5%{?foremandist}%{?dist}
+Release: 6%{?foremandist}%{?dist}
 Summary: Omaha protocol support for smart-proxy
 Group: Applications/Internet
 License: GPLv3
@@ -44,7 +44,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 This plug-in adds support for the Omaha Procotol to Foreman's Smart Proxy.
@@ -56,7 +56,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -134,6 +134,9 @@ mkdir -p %{buildroot}%{content_dir}
 %{gem_instdir}/test
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.1.0-6
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 0.1.0-5
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_openscap/rubygem-smart_proxy_openscap.spec
+++ b/packages/plugins/rubygem-smart_proxy_openscap/rubygem-smart_proxy_openscap.spec
@@ -23,7 +23,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.9.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: OpenSCAP plug-in for Foreman's smart-proxy
 Group: Applications/Internet
 License: GPLv3+
@@ -47,7 +47,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 A plug-in to the Foreman's smart-proxy which receives
@@ -60,7 +60,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -153,6 +153,9 @@ ln -sv %{content_dir} %{buildroot}%{foreman_proxy_dir}/openscap
 %{gem_instdir}/test
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.9.1-2
+- use versioned obsoletes for proxy plugins
+
 * Wed Jul 14 2021 Ondrej Prazak <oprazak@redhat.com> 0.9.1-1
 - Update to 0.9.1
 

--- a/packages/plugins/rubygem-smart_proxy_pulp/rubygem-smart_proxy_pulp.spec
+++ b/packages/plugins/rubygem-smart_proxy_pulp/rubygem-smart_proxy_pulp.spec
@@ -19,7 +19,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.2.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Basic Pulp support for Foreman Smart-Proxy
 Group: Applications/Internet
 License: GPLv3
@@ -41,7 +41,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 Basic Pulp support for Foreman Smart-Proxy.
@@ -53,7 +53,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -112,6 +112,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/pulpcore.yml.example \
 %{gem_instdir}/Gemfile
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 3.2.0-2
+- use versioned obsoletes for proxy plugins
+
 * Thu Sep 02 2021 Eric D. Helms <ericdhelms@gmail.com> - 3.2.0-1
 - Release rubygem-smart_proxy_pulp 3.2.0
 

--- a/packages/plugins/rubygem-smart_proxy_realm_ad_plugin/rubygem-smart_proxy_realm_ad_plugin.spec
+++ b/packages/plugins/rubygem-smart_proxy_realm_ad_plugin/rubygem-smart_proxy_realm_ad_plugin.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.1
-Release: 8%{?foremandist}%{?dist}
+Release: 9%{?foremandist}%{?dist}
 Summary: A realm ad provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -40,7 +40,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 A realm ad provider plugin for Foreman's smart proxy.
@@ -52,7 +52,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -111,6 +111,9 @@ mv %{buildroot}%{gem_instdir}/config/realm_ad.yml.example \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.1-9
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 0.1-8
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
+++ b/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
@@ -17,7 +17,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.5.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Ssh remote execution provider for Foreman Smart-Proxy
 Group: Applications/Internet
 License: GPLv3
@@ -41,7 +41,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 Ssh remote execution provider for Foreman Smart-Proxy.
@@ -53,7 +53,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -121,6 +121,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/remote_execution_ssh.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.5.1-2
+- use versioned obsoletes for proxy plugins
+
 * Tue Jan 04 2022 Adam Ruzicka <aruzicka@redhat.com> 0.5.1-1
 - Update to 0.5.1
 

--- a/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
+++ b/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
@@ -35,7 +35,7 @@
 Summary: SaltStack support for Foreman Smart-Proxy
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.1.2
-Release: 8%{?foremandist}%{?dist}
+Release: 9%{?foremandist}%{?dist}
 Group: Applications/System
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_salt
@@ -73,7 +73,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 SaltStack Plug-In for Foreman's Smart Proxy.
@@ -85,7 +85,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -189,6 +189,9 @@ EOF
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 3.1.2-9
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 3.1.2-8
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-smart_proxy_spacewalk/rubygem-smart_proxy_spacewalk.spec
+++ b/packages/plugins/rubygem-smart_proxy_spacewalk/rubygem-smart_proxy_spacewalk.spec
@@ -18,7 +18,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.1.0
-Release: 7%{?foremandist}%{?dist}
+Release: 8%{?foremandist}%{?dist}
 Summary: Spacewalk integration support for smart-proxy
 Group: Applications/Internet
 License: GPLv3
@@ -39,7 +39,7 @@ Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
-%{?scl:Obsoletes: rubygem-%{gem_name}}
+%{?scl:Obsoletes: rubygem-%{gem_name} < %{version}-%{release}}
 
 %description
 This plug-in adds support for managing hosts registered at a spacewalk server
@@ -52,7 +52,7 @@ Group: Documentation
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
-%{?scl:Obsoletes: rubygem-%{gem_name}-doc}
+%{?scl:Obsoletes: rubygem-%{gem_name}-doc < %{version}-%{release}}
 
 %description doc
 Documentation for %{name}.
@@ -114,6 +114,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/spacewalk.yml.example \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jan 10 2022 Evgeni Golov - 0.1.0-8
+- use versioned obsoletes for proxy plugins
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 0.1.0-7
 - Rebuild for Ruby 2.7
 


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
