### PR TITLE
Stop building packages for RHEL 6

### DIFF
--- a/add_gem_package.sh
+++ b/add_gem_package.sh
@@ -57,7 +57,6 @@ add_to_all_tito_props() {
 		add_to_tito_props foreman-plugins-nightly-el8
 	elif [[ $TITO_TAG == "foreman-client-nightly-rhel7" ]] ; then
 		add_to_tito_props foreman-client-nightly-el8
-		add_to_tito_props foreman-client-nightly-rhel6
 		add_to_tito_props foreman-client-nightly-fedora29
 	elif [[ $TITO_TAG == "katello-nightly-rhel7" ]] ; then
 		add_to_tito_props katello-nightly-el8
@@ -85,7 +84,6 @@ add_gem_to_all_comps() {
 		add_gem_to_comps foreman-plugins-nightly-el8
 	elif [[ $TITO_TAG == "foreman-client-nightly-rhel7" ]] ; then
 		add_gem_to_comps foreman-client-nightly-el8
-		add_gem_to_comps foreman-client-nightly-rhel6
 		add_gem_to_comps foreman-client-nightly-fedora29
 	elif [[ $TITO_TAG == "katello-nightly-rhel7" ]] ; then
 		add_gem_to_comps katello-nightly-el8

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -733,8 +733,6 @@ foreman_client_packages:
         dist: '.el8'
       - name: "foreman-client-{{ foreman_version }}-rhel7"
         dist: '.el7'
-      - name: "foreman-client-{{ foreman_version }}-rhel6"
-        dist: '.el6'
       - name: "foreman-client-{{ foreman_version }}-fedora29"
         dist: '.fc29'
     repoclosure_target_repos:
@@ -742,8 +740,6 @@ foreman_client_packages:
         - "el8-foreman-client-{{ foreman_version }}"
       rhel7:
         - "el7-foreman-client-{{ foreman_version }}"
-      rhel6:
-        - "el6-foreman-client-{{ foreman_version }}"
       fedora29:
         - "f29-foreman-client-{{ foreman_version }}"
     repoclosure_lookaside_repos:
@@ -761,15 +757,6 @@ foreman_client_packages:
         - el7-epel
         - el7-extras
         - el7-puppet-6
-      rhel6:
-        - el6-base
-        - el6-updates
-        - el6-epel
-        - el6-extras
-        - el6-puppet-6
-        - el6-qpid
-        - el6-subscription-manager
-        - el6-pulp
       fedora29:
         - f29-base
         - f29-updates
@@ -1224,21 +1211,6 @@ repoclosures:
           - el7-epel
           - el7-extras
           - el7-puppet-6
-    foreman-client-repoclosure-el6:
-      repoclosure_target_repos:
-        rhel6:
-          - "el6-foreman-client-{{ foreman_version }}"
-      repoclosure_target_dist: rhel6
-      repoclosure_lookaside_repos:
-        rhel6:
-          - el6-base
-          - el6-updates
-          - el6-epel
-          - el6-extras
-          - el6-puppet-6
-          - el6-qpid
-          - el6-pulp
-          - el6-subscription-manager
     foreman-client-repoclosure-f29:
       repoclosure_target_repos:
         fedora29:
@@ -1262,8 +1234,6 @@ foreman_release_packages:
         dist: '.el8'
       - name: "foreman-client-{{ foreman_version }}-rhel7"
         dist: '.el7'
-      - name: "foreman-client-{{ foreman_version }}-rhel6"
-        dist: '.el6'
       - name: "foreman-client-{{ foreman_version }}-fedora29"
         dist: '.fc29'
     releasers:
@@ -1275,8 +1245,6 @@ foreman_release_packages:
         - "el8-foreman-client-{{ foreman_version }}"
       rhel7:
         - "el7-foreman-client-{{ foreman_version }}"
-      rhel6:
-        - "el6-foreman-client-{{ foreman_version }}"
       fedora29:
         - "f29-foreman-client-{{ foreman_version }}"
     repoclosure_lookaside_repos:
@@ -1293,15 +1261,6 @@ foreman_release_packages:
         - el7-extras
         - el7-puppet-6
         - "el7-foreman-{{ foreman_version }}"
-      rhel6:
-        - el6-base
-        - el6-updates
-        - el6-epel
-        - el6-extras
-        - el6-puppet-6
-        - el6-qpid
-        - el6-subscription-manager
-        - el6-pulp
       fedora29:
         - f29-base
         - f29-updates

--- a/packages/foreman/foreman-release/foreman-release.spec
+++ b/packages/foreman/foreman-release/foreman-release.spec
@@ -13,7 +13,7 @@
 %define repo_dist %{dist}
 %endif
 
-%global release 1
+%global release 2
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -30,8 +30,6 @@ Source1:  foreman-plugins.repo
 Source2:  foreman.gpg
 Source5:  foreman-client.repo
 Source6:  qpid-copr.repo
-Source8:  pulp.repo
-Source9:  subscription-manager-el6.repo
 
 BuildArch: noarch
 
@@ -53,11 +51,6 @@ Defines yum repositories for Foreman clients.
 %config %{repo_dir}/foreman-client.repo
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman-client
 
-%if 0%{?rhel} == 6
-%config %{repo_dir}/pulp.repo
-%config %{repo_dir}/subscription-manager.repo
-%endif
-
 %if 0%{?rhel} == 7
 %config %{repo_dir}/qpid-copr.repo
 %endif
@@ -73,11 +66,6 @@ Defines yum repositories for Foreman clients.
 install -Dpm0644 %{SOURCE0} %{buildroot}%{repo_dir}/foreman.repo
 install -Dpm0644 %{SOURCE1} %{buildroot}%{repo_dir}/foreman-plugins.repo
 install -Dpm0644 %{SOURCE5} %{buildroot}%{repo_dir}/foreman-client.repo
-
-%if 0%{?rhel} == 6
-install -m 644 %{SOURCE8} %{buildroot}%{repo_dir}/pulp.repo
-install -m 644 %{SOURCE9} %{buildroot}%{repo_dir}/subscription-manager.repo
-%endif
 
 %if 0%{?rhel} == 7
 install -m 644 %{SOURCE6} %{buildroot}%{repo_dir}/qpid-copr.repo
@@ -102,6 +90,9 @@ install -Dpm0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-f
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman
 
 %changelog
+* Tue Jan 25 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.2.0-0.2.develop
+- Drop EL6 compatibility
+
 * Fri Nov 12 2021 Odilon Sousa <osousa@redhat.com> - 3.2.0-0.1.develop
 - Bump version to 3.2-develop
 

--- a/packages/foreman/foreman-release/pulp.repo
+++ b/packages/foreman/foreman-release/pulp.repo
@@ -1,7 +1,0 @@
-[pulp]
-name=Pulp Community Release
-baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/stable/latest/$releasever/$basearch
-gpgkey=https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2
-enabled=1
-gpgcheck=1
-module_hotfixes=1

--- a/packages/foreman/foreman-release/subscription-manager-el6.repo
+++ b/packages/foreman/foreman-release/subscription-manager-el6.repo
@@ -1,5 +1,0 @@
-[subscription-manager]
-name=Subscription manager repository from Candlepin
-baseurl=https://copr-be.cloud.fedoraproject.org/results/dgoodwin/subscription-manager/epel-6-x86_64/
-gpgcheck=0
-enabled=1

--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -24,11 +24,11 @@ builder.rpmbuild_options = --define "foremandist .fm3_2"
 
 [koji-foreman-client]
 releaser = tito.release.KojiReleaser
-autobuild_tags = foreman-client-nightly-rhel6 foreman-client-nightly-rhel7 foreman-client-nightly-el8 foreman-client-nightly-fedora29
+autobuild_tags = foreman-client-nightly-rhel7 foreman-client-nightly-el8 foreman-client-nightly-fedora29
 
 [koji-foreman-client-jenkins]
 releaser = tito.release.KojiReleaser
-autobuild_tags = foreman-client-nightly-rhel6 foreman-client-nightly-rhel7 foreman-client-nightly-el8 foreman-client-nightly-fedora29
+autobuild_tags = foreman-client-nightly-rhel7 foreman-client-nightly-el8 foreman-client-nightly-fedora29
 builder = tito.builder.FetchBuilder
 
 # Katello Releasers

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -989,12 +989,6 @@ whitelist =
   rubygem-foreman_scap_client
   tracer
 
-[foreman-client-nightly-rhel6]
-disttag = .el6
-whitelist = foreman-release
-  katello-host-tools
-  rubygem-foreman_scap_client
-
 [foreman-client-nightly-fedora29]
 disttag = .fc29
 whitelist =

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -141,51 +141,6 @@ baseurl=http://koji.katello.org/releases/yum/katello-nightly/candlepin/el7/x86_6
 name=Katello Candlepin nightly EL8
 baseurl=http://koji.katello.org/releases/yum/katello-nightly/candlepin/el8/x86_64/
 
-[el6-base]
-name=BaseOS
-enabled=1
-baseurl=https://vault.centos.org/6.10/os/x86_64/
-failovermethod=priority
-
-[el6-updates]
-name=updates
-enabled=1
-baseurl=https://vault.centos.org/6.10/updates/x86_64/
-failovermethod=priority
-
-[el6-extras]
-name=extras
-baseurl=https://vault.centos.org/6.10/extras/x86_64/
-
-[el6-epel]
-name=epel
-baseurl=https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/
-failovermethod=priority
-
-[el6-puppet-4]
-name=el6-puppet-4
-baseurl=http://yum.puppetlabs.com/el/6/PC1/x86_64/
-
-[el6-puppet-6]
-name=el6-puppet-6
-baseurl=https://yum.puppetlabs.com/puppet6/el/6/x86_64/
-
-[el6-subscription-manager]
-name=el6-subscription-manager
-baseurl=https://copr-be.cloud.fedoraproject.org/results/dgoodwin/subscription-manager/epel-6-x86_64/
-
-[el6-qpid]
-name=el6-qpid
-baseurl=https://copr-be.cloud.fedoraproject.org/results/ndp/qpid/epel-6-x86_64/
-
-[el6-pulp]
-name=Pulp Community Release
-baseurl=https://repos.fedorapeople.org/repos/pulp/pulp/stable/latest/6/x86_64
-
-[el6-foreman-client-nightly]
-name=Foreman Client nightly EL6
-baseurl=http://koji.katello.org/releases/yum/foreman-client-nightly/el6/x86_64/
-
 [f29-base]
 name=BaseOS
 enabled=1


### PR DESCRIPTION
Since Foreman 3.0 this is no longer mashed so building and maintainig it is a waste of resources.

It does update foreman-release, but does not modify other specs since there is no benefit.