### PR TITLE
rename stream to el8 to avoid problems with puppet

### DIFF
--- a/modulemd/modulemd-foreman-el8.yaml
+++ b/modulemd/modulemd-foreman-el8.yaml
@@ -3,7 +3,7 @@ document: modulemd
 version: 2
 data:
   name: foreman
-  stream: latest
+  stream: el8
   version: 0
   arch: x86_64
   summary: Foreman module

--- a/modulemd/modulemd-katello-el8.yaml
+++ b/modulemd/modulemd-katello-el8.yaml
@@ -3,7 +3,7 @@ document: modulemd
 version: 2
 data:
   name: katello
-  stream: latest
+  stream: el8
   version: 0
   arch: x86_64
   summary: Katello module


### PR DESCRIPTION
for puppet `latest` has a special meaning, so if you instruct it to
enable the `foreman` module, `latest` stream, it actually looks for the
latest version available, not for the stream with the literal name
`latest`.

looking at the output of `dnf module list` on an EL8 machine, most
streams use the version of the software here, or `rhel8`.
we didn't want to use the version, as that would mean our users need to
explicitly `dnf module reset` and `dnf module enable` the newer version
on upgrades, which seems like a burden given the fact that our repo will
never contain multiple release streams at once anyways.

as Foreman also works fine on non-RH EL8, I propose the name `el8`

possible alternatives: current, released?

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
