### PR TITLE
Katello comps cleanup

### DIFF
--- a/comps/comps-katello-el8.xml
+++ b/comps/comps-katello-el8.xml
@@ -38,7 +38,6 @@
       <packagereq type="default">rubygem-ansi</packagereq>
       <packagereq type="default">rubygem-foreman_rh_cloud</packagereq>
       <packagereq type="default">rubygem-foreman_scc_manager</packagereq>
-      <packagereq type="default">rubygem-fssm</packagereq>
       <packagereq type="default">rubygem-fx</packagereq>
       <packagereq type="default">rubygem-hammer_cli_csv</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_rh_cloud</packagereq>

--- a/comps/comps-katello-el8.xml
+++ b/comps/comps-katello-el8.xml
@@ -41,7 +41,6 @@
       <packagereq type="default">rubygem-hammer_cli_csv</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_rh_cloud</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_scc_manager</packagereq>
-      <packagereq type="default">rubygem-i18n_data</packagereq>
       <packagereq type="default">rubygem-pulpcore_client</packagereq>
       <packagereq type="default">rubygem-pulp_ansible_client</packagereq>
       <packagereq type="default">rubygem-pulp_certguard_client</packagereq>

--- a/comps/comps-katello-el8.xml
+++ b/comps/comps-katello-el8.xml
@@ -22,7 +22,6 @@
       <packagereq type="default">rubygem-ethon</packagereq>
       <packagereq type="default">rubygem-foreman_virt_who_configure</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_virt_who_configure</packagereq>
-      <packagereq type="default">rubygem-hammer_cli_import</packagereq>
       <packagereq type="default">rubygem-hammer_cli_katello</packagereq>
       <packagereq type="default">rubygem-katello</packagereq>
       <packagereq type="default">rubygem-katello-assets</packagereq>

--- a/comps/comps-katello-el8.xml
+++ b/comps/comps-katello-el8.xml
@@ -42,7 +42,6 @@
       <packagereq type="default">rubygem-hammer_cli_csv</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_rh_cloud</packagereq>
       <packagereq type="default">rubygem-hammer_cli_foreman_scc_manager</packagereq>
-      <packagereq type="default">rubygem-hpricot</packagereq>
       <packagereq type="default">rubygem-i18n_data</packagereq>
       <packagereq type="default">rubygem-pulpcore_client</packagereq>
       <packagereq type="default">rubygem-pulp_ansible_client</packagereq>
@@ -92,7 +91,6 @@
       <packagereq type="optional">rubygem-foreman_scc_manager-doc</packagereq>
       <packagereq type="optional">rubygem-foreman_virt_who_configure-doc</packagereq>
       <packagereq type="optional">rubygem-fx-doc</packagereq>
-      <packagereq type="optional">rubygem-hpricot-doc</packagereq>
       <packagereq type="optional">rubygem-pulpcore_client-doc</packagereq>
       <packagereq type="optional">rubygem-pulp_ansible_client-doc</packagereq>
       <packagereq type="optional">rubygem-pulp_certguard_client-doc</packagereq>

--- a/comps/comps-katello-el8.xml
+++ b/comps/comps-katello-el8.xml
@@ -45,7 +45,6 @@
       <packagereq type="default">rubygem-hammer_cli_foreman_scc_manager</packagereq>
       <packagereq type="default">rubygem-hpricot</packagereq>
       <packagereq type="default">rubygem-i18n_data</packagereq>
-      <packagereq type="default">rubygem-justified</packagereq>
       <packagereq type="default">rubygem-pulpcore_client</packagereq>
       <packagereq type="default">rubygem-pulp_ansible_client</packagereq>
       <packagereq type="default">rubygem-pulp_certguard_client</packagereq>

--- a/comps/comps-katello-el8.xml
+++ b/comps/comps-katello-el8.xml
@@ -58,7 +58,6 @@
       <packagereq type="default">rubygem-qpid_proton</packagereq>
       <packagereq type="default">rubygem-robotex</packagereq>
       <packagereq type="default">rubygem-runcible</packagereq>
-      <packagereq type="default">rubygem-sexp_processor</packagereq>
       <packagereq type="default">rubygem-stomp</packagereq>
       <packagereq type="default">rubygem-typhoeus</packagereq>
       <packagereq type="default">rubygem-zest</packagereq>
@@ -104,7 +103,6 @@
       <packagereq type="optional">rubygem-pulp_ostree_client-doc</packagereq>
       <packagereq type="optional">rubygem-pulp_python_client-doc</packagereq>
       <packagereq type="optional">rubygem-runcible-doc</packagereq>
-      <packagereq type="optional">rubygem-sexp_processor-doc</packagereq>
       <packagereq type="optional">rubygem-stomp-doc</packagereq>
       <packagereq type="optional">rubygem-typhoeus-doc</packagereq>
       <packagereq type="optional">rubygem-zest-doc</packagereq>

--- a/comps/comps-katello-el8.xml
+++ b/comps/comps-katello-el8.xml
@@ -35,7 +35,6 @@
       <packagereq type="default">nodejs-strict-uri-encode</packagereq>
       <!-- katello thirdparty rubygem packages -->
       <packagereq type="default">rubygem-anemone</packagereq>
-      <packagereq type="default">rubygem-ansi</packagereq>
       <packagereq type="default">rubygem-foreman_rh_cloud</packagereq>
       <packagereq type="default">rubygem-foreman_scc_manager</packagereq>
       <packagereq type="default">rubygem-fx</packagereq>

--- a/comps/comps-katello-el8.xml
+++ b/comps/comps-katello-el8.xml
@@ -36,7 +36,6 @@
       <!-- katello thirdparty rubygem packages -->
       <packagereq type="default">rubygem-anemone</packagereq>
       <packagereq type="default">rubygem-ansi</packagereq>
-      <packagereq type="default">rubygem-chunky_png</packagereq>
       <packagereq type="default">rubygem-foreman_rh_cloud</packagereq>
       <packagereq type="default">rubygem-foreman_scc_manager</packagereq>
       <packagereq type="default">rubygem-fssm</packagereq>

--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -44,7 +44,6 @@
       <packagereq type="default">tfm-rubygem-hammer_cli_csv</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_rh_cloud</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_scc_manager</packagereq>
-      <packagereq type="default">tfm-rubygem-hpricot</packagereq>
       <packagereq type="default">tfm-rubygem-i18n_data</packagereq>
       <packagereq type="default">tfm-rubygem-pulpcore_client</packagereq>
       <packagereq type="default">tfm-rubygem-pulp_ansible_client</packagereq>
@@ -75,7 +74,6 @@
       <packagereq type="optional">tfm-rubygem-foreman_scc_manager-doc</packagereq>
       <packagereq type="optional">tfm-rubygem-foreman_virt_who_configure-doc</packagereq>
       <packagereq type="default">tfm-rubygem-fx-doc</packagereq>
-      <packagereq type="optional">tfm-rubygem-hpricot-doc</packagereq>
       <packagereq type="optional">tfm-rubygem-pulpcore_client-doc</packagereq>
       <packagereq type="optional">tfm-rubygem-pulp_ansible_client-doc</packagereq>
       <packagereq type="optional">tfm-rubygem-pulp_certguard_client-doc</packagereq>

--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -38,7 +38,6 @@
       <!-- katello thirdparty rubygem packages -->
       <packagereq type="default">tfm-rubygem-anemone</packagereq>
       <packagereq type="default">tfm-rubygem-ansi</packagereq>
-      <packagereq type="default">tfm-rubygem-chunky_png</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_rh_cloud</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_scc_manager</packagereq>
       <packagereq type="default">tfm-rubygem-fssm</packagereq>

--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -60,7 +60,6 @@
       <packagereq type="default">tfm-rubygem-qpid_proton</packagereq>
       <packagereq type="default">tfm-rubygem-robotex</packagereq>
       <packagereq type="default">tfm-rubygem-runcible</packagereq>
-      <packagereq type="default">tfm-rubygem-sexp_processor</packagereq>
       <packagereq type="default">tfm-rubygem-stomp</packagereq>
       <packagereq type="default">tfm-rubygem-typhoeus</packagereq>
       <packagereq type="default">tfm-rubygem-zest</packagereq>
@@ -88,7 +87,6 @@
       <packagereq type="optional">tfm-rubygem-pulp_ostree_client-doc</packagereq>
       <packagereq type="optional">tfm-rubygem-qpid_proton-doc</packagereq>
       <packagereq type="optional">tfm-rubygem-runcible-doc</packagereq>
-      <packagereq type="optional">tfm-rubygem-sexp_processor-doc</packagereq>
       <packagereq type="optional">tfm-rubygem-stomp-doc</packagereq>
       <packagereq type="optional">tfm-rubygem-typhoeus-doc</packagereq>
       <packagereq type="optional">tfm-rubygem-zest-doc</packagereq>

--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -40,7 +40,6 @@
       <packagereq type="default">tfm-rubygem-ansi</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_rh_cloud</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_scc_manager</packagereq>
-      <packagereq type="default">tfm-rubygem-fssm</packagereq>
       <packagereq type="default">tfm-rubygem-fx</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_csv</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_rh_cloud</packagereq>

--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -18,7 +18,6 @@
       <packagereq type="default">katello-debug</packagereq>
       <packagereq type="default">katello-repos</packagereq>
       <packagereq type="default">katello-selinux</packagereq>
-      <packagereq type="default">katello-utils</packagereq>
       <packagereq type="default">python-gofer</packagereq>
       <packagereq type="default">python-gofer-qpid</packagereq>
       <packagereq type="default">tfm-rubygem-activerecord-import</packagereq>

--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -43,7 +43,6 @@
       <packagereq type="default">tfm-rubygem-hammer_cli_csv</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_rh_cloud</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_scc_manager</packagereq>
-      <packagereq type="default">tfm-rubygem-i18n_data</packagereq>
       <packagereq type="default">tfm-rubygem-pulpcore_client</packagereq>
       <packagereq type="default">tfm-rubygem-pulp_ansible_client</packagereq>
       <packagereq type="default">tfm-rubygem-pulp_certguard_client</packagereq>

--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -47,7 +47,6 @@
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_scc_manager</packagereq>
       <packagereq type="default">tfm-rubygem-hpricot</packagereq>
       <packagereq type="default">tfm-rubygem-i18n_data</packagereq>
-      <packagereq type="default">tfm-rubygem-justified</packagereq>
       <packagereq type="default">tfm-rubygem-pulpcore_client</packagereq>
       <packagereq type="default">tfm-rubygem-pulp_ansible_client</packagereq>
       <packagereq type="default">tfm-rubygem-pulp_certguard_client</packagereq>

--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -24,7 +24,6 @@
       <packagereq type="default">tfm-rubygem-ethon</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_virt_who_configure</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_foreman_virt_who_configure</packagereq>
-      <packagereq type="default">tfm-rubygem-hammer_cli_import</packagereq>
       <packagereq type="default">tfm-rubygem-hammer_cli_katello</packagereq>
       <packagereq type="default">tfm-rubygem-katello</packagereq>
       <packagereq type="default">tfm-rubygem-katello-assets</packagereq>

--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -17,7 +17,6 @@
       <packagereq type="default">katello-common</packagereq>
       <packagereq type="default">katello-debug</packagereq>
       <packagereq type="default">katello-repos</packagereq>
-      <packagereq type="default">katello-repos-testing</packagereq>
       <packagereq type="default">katello-selinux</packagereq>
       <packagereq type="default">katello-utils</packagereq>
       <packagereq type="default">python-gofer</packagereq>

--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -37,7 +37,6 @@
       <packagereq type="default">tfm-nodejs-strict-uri-encode</packagereq>
       <!-- katello thirdparty rubygem packages -->
       <packagereq type="default">tfm-rubygem-anemone</packagereq>
-      <packagereq type="default">tfm-rubygem-ansi</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_rh_cloud</packagereq>
       <packagereq type="default">tfm-rubygem-foreman_scc_manager</packagereq>
       <packagereq type="default">tfm-rubygem-fx</packagereq>


### PR DESCRIPTION
various things mashing warned about in the form of:

```
08:34:57  2022-01-27 07:34:57 [WARNING ] In comps but not in katello-nightly/katello/el7 tree: tfm-rubygem-chunky_png
08:34:57  2022-01-27 07:34:57 [WARNING ] In comps but not in katello-nightly/katello/el7 tree: tfm-rubygem-sexp_processor-doc
08:34:57  2022-01-27 07:34:57 [WARNING ] In comps but not in katello-nightly/katello/el7 tree: tfm-rubygem-sexp_processor
08:34:57  2022-01-27 07:34:57 [WARNING ] In comps but not in katello-nightly/katello/el7 tree: katello-repos-testing
08:34:57  2022-01-27 07:34:57 [WARNING ] In comps but not in katello-nightly/katello/el7 tree: tfm-rubygem-justified
08:34:57  2022-01-27 07:34:57 [WARNING ] In comps but not in katello-nightly/katello/el7 tree: tfm-rubygem-fssm
08:34:57  2022-01-27 07:34:57 [WARNING ] In comps but not in katello-nightly/katello/el7 tree: python-gofer
08:34:57  2022-01-27 07:34:57 [WARNING ] In comps but not in katello-nightly/katello/el7 tree: tfm-rubygem-hpricot
08:34:57  2022-01-27 07:34:57 [WARNING ] In comps but not in katello-nightly/katello/el7 tree: tfm-rubygem-ansi
08:34:57  2022-01-27 07:34:57 [WARNING ] In comps but not in katello-nightly/katello/el7 tree: python-gofer-qpid
08:34:57  2022-01-27 07:34:57 [WARNING ] In comps but not in katello-nightly/katello/el7 tree: tfm-rubygem-i18n_data
08:34:57  2022-01-27 07:34:57 [WARNING ] In comps but not in katello-nightly/katello/el7 tree: katello-utils
08:34:57  2022-01-27 07:34:57 [WARNING ] In comps but not in katello-nightly/katello/el7 tree: tfm-rubygem-hpricot-doc
08:34:57  2022-01-27 07:34:57 [WARNING ] In comps but not in katello-nightly/katello/el7 tree: tfm-rubygem-hammer_cli_import
```

I didn't touch the gofer things yet, they are always yuki.