### PR TITLE
Drop centos-release-scl-rh from EL7 comps & foreman-release compare fix

### DIFF
--- a/comps/comps-foreman-rhel7.xml
+++ b/comps/comps-foreman-rhel7.xml
@@ -8,7 +8,6 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="default">dynflow-utils</packagereq>
-      <packagereq type="default">centos-release-scl-rh</packagereq>
       <packagereq type="default">foreman</packagereq>
       <packagereq type="default">foreman-assets</packagereq>
       <packagereq type="default">foreman-bootloaders-redhat</packagereq>

--- a/rel-eng/compare-with-tags
+++ b/rel-eng/compare-with-tags
@@ -46,6 +46,11 @@ def main(filename: Path) -> None:
         missing_packages = comps_packages - koji_packages
         extra_packages = koji_packages - comps_packages
 
+        # We can't automatically build foreman-release in client, koji will fail with duplicate
+        # builds. We always manually tag it to client after.
+        if tag.startswith('foreman-client-'):
+            extra_packages -= {'foreman-release'}
+
         if missing_packages:
             print(f"\n# Packages missing in tag {tag}")
             for missing_package in sorted(missing_packages):


### PR DESCRIPTION
See individual commit for details. My goal is for `./rel-eng/compare-with-tags` to be clean. Also the mashing process should ideally be free of warnings, but we're not quite there yet.