### PR TITLE
Add in epoch to ensure priority over distro packages

### DIFF
--- a/packages/foreman/rubygem-sinatra/rubygem-sinatra.spec
+++ b/packages/foreman/rubygem-sinatra/rubygem-sinatra.spec
@@ -6,7 +6,8 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 2.1.0
-Release: 2%{?dist}
+Release: 3%{?dist}
+Epoch: 1
 Summary: Classy web-development dressed in a DSL
 Group: Development/Languages
 License: MIT
@@ -41,7 +42,7 @@ effort.
 %package doc
 Summary: Documentation for %{pkg_name}
 Group: Documentation
-Requires: %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+Requires: %{?scl_prefix}%{pkg_name} = %{epoch}:%{version}-%{release}
 BuildArch: noarch
 
 %description doc
@@ -109,6 +110,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/sinatra.gemspec
 
 %changelog
+* Thu Feb 10 2022 Patrick Creech <pcreech@redhat.com> - 1:2.1.0-3
+- rebuilt
+
 * Thu Mar 11 2021 Eric D. Helms <ericdhelms@gmail.com> - 2.1.0-2
 - Rebuild against rh-ruby27
 


### PR DESCRIPTION
Distros with rubygem-sinatra have "Epoch: 1", to ensure ours is installed we should have it too

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
