### PR TITLE
Release hammer-cli and hammer-cli-foreman 3.2.0

### DIFF
--- a/dependencies/bullseye/hammer_cli/changelog
+++ b/dependencies/bullseye/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (3.2.0-1) stable; urgency=low
+
+  * 3.2.0 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Thu, 10 Feb 2022 18:28:38 +0000
+
 ruby-hammer-cli (3.1.0-1) stable; urgency=low
 
   * 3.1.0 released

--- a/dependencies/bullseye/hammer_cli_foreman/changelog
+++ b/dependencies/bullseye/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (3.2.0-1) stable; urgency=low
+
+  * 3.2.0 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Thu, 10 Feb 2022 18:28:46 +0000
+
 ruby-hammer-cli-foreman (3.1.0-1) stable; urgency=low
 
   * 3.1.0 released

--- a/dependencies/bullseye/hammer_cli_foreman/control
+++ b/dependencies/bullseye/hammer_cli_foreman/control
@@ -12,7 +12,7 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 3.1.0),
+         ruby-hammer-cli (>= 3.2.0),
          ruby-apipie-bindings (>= 0.4.0),
          ruby-jwt (>= 2.2.1),
          ruby-rest-client (>= 1.8.0),

--- a/dependencies/buster/hammer_cli/changelog
+++ b/dependencies/buster/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (3.2.0-1) stable; urgency=low
+
+  * 3.2.0 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Thu, 10 Feb 2022 18:28:38 +0000
+
 ruby-hammer-cli (3.1.0-1) stable; urgency=low
 
   * 3.1.0 released

--- a/dependencies/buster/hammer_cli_foreman/changelog
+++ b/dependencies/buster/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (3.2.0-1) stable; urgency=low
+
+  * 3.2.0 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Thu, 10 Feb 2022 18:28:46 +0000
+
 ruby-hammer-cli-foreman (3.1.0-1) stable; urgency=low
 
   * 3.1.0 released

--- a/dependencies/buster/hammer_cli_foreman/control
+++ b/dependencies/buster/hammer_cli_foreman/control
@@ -12,7 +12,7 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 3.1.0),
+         ruby-hammer-cli (>= 3.2.0),
          ruby-apipie-bindings (>= 0.4.0),
          ruby-jwt (>= 2.2.1),
          ruby-rest-client (>= 1.8.0),

--- a/dependencies/focal/hammer_cli/changelog
+++ b/dependencies/focal/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (3.2.0-1) stable; urgency=low
+
+  * 3.2.0 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Thu, 10 Feb 2022 18:28:38 +0000
+
 ruby-hammer-cli (3.1.0-1) stable; urgency=low
 
   * 3.1.0 released

--- a/dependencies/focal/hammer_cli_foreman/changelog
+++ b/dependencies/focal/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (3.2.0-1) stable; urgency=low
+
+  * 3.2.0 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Thu, 10 Feb 2022 18:28:47 +0000
+
 ruby-hammer-cli-foreman (3.1.0-1) stable; urgency=low
 
   * 3.1.0 released

--- a/dependencies/focal/hammer_cli_foreman/control
+++ b/dependencies/focal/hammer_cli_foreman/control
@@ -12,7 +12,7 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 3.1.0),
+         ruby-hammer-cli (>= 3.2.0),
          ruby-apipie-bindings (>= 0.4.0),
          ruby-jwt (>= 2.2.1),
          ruby-rest-client (>= 1.8.0),


### PR DESCRIPTION
Supported Versions:

 * Nightly
 * 3.2