### PR TITLE
Compatibility with semver < 2.7.0

### DIFF
--- a/update-requirements
+++ b/update-requirements
@@ -24,9 +24,9 @@ def get_requirement(version):
 
     if version.startswith('^') or version.startswith('~'):
         modifier = version[0]
-        parsed = semver.parse_version_info(version[1:])
+        parsed = semver.parse(version[1:])
 
-        min_version = '{}.{}.{}'.format(parsed.major, parsed.minor, parsed.patch)
+        min_version = '{}.{}.{}'.format(parsed['major'], parsed['minor'], parsed['patch'])
         if modifier == '^':
             max_version = semver.bump_major(min_version)
         elif modifier == '~':


### PR DESCRIPTION
Ubuntu 20.04 ships semver version 2.0.1 and parse_version_info was introduced in 2.7.0. This makes it easier to use in GitHub Actions without having to resort to using pip.