### PR TITLE
Fixes #34507 - Drop Foreman's nodejs dependency

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -9,7 +9,7 @@
 %global scl_ruby_bin /usr/bin/%{?scl:%{scl_prefix}}ruby
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 1
+%global release 2
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -537,6 +537,9 @@ Meta package to install asset pipeline support.
 %{_datadir}/%{name}/bundler.d/assets.rb
 %{_datadir}/%{name}/webpack
 %{_datadir}/%{name}/.babelrc.js
+%{_datadir}/%{name}/script/npm*
+%{_datadir}/%{name}/script/plugin_webpack*
+%{_datadir}/%{name}/script/webpack-analyze*
 
 %package plugin
 Summary: Foreman plugin support
@@ -941,6 +944,12 @@ rm -rf %{buildroot}
 %exclude %{_datadir}/%{name}/app/assets/stylesheets
 %exclude %{_datadir}/%{name}/app/assets/javascripts
 %exclude %{_datadir}/%{name}/script/%{name}-debug.d
+%exclude %{_datadir}/%{name}/script/%{name}-puma-status
+%exclude %{_datadir}/%{name}/script/%{name}-rake
+%exclude %{_datadir}/%{name}/script/%{name}-tail
+%exclude %{_datadir}/%{name}/script/npm*
+%exclude %{_datadir}/%{name}/script/plugin_webpack*
+%exclude %{_datadir}/%{name}/script/webpack-analyze*
 %dir %{_datadir}/%{name}/bundler.d
 %exclude %{_datadir}/%{name}/bundler.d/development.rb
 %{_datadir}/%{name}/bundler.d/facter.rb
@@ -951,6 +960,7 @@ rm -rf %{buildroot}
 %{_datadir}/%{name}/config*
 %{_datadir}/%{name}/db
 %{_datadir}/%{name}/extras
+%exclude %{_datadir}/%{name}/extras/systemd
 %{_datadir}/%{name}/Gemfile.in
 %{_datadir}/%{name}/lib
 %{_datadir}/%{name}/locale
@@ -1036,6 +1046,10 @@ exit 0
 %systemd_postun %{name}.socket
 
 %changelog
+* Wed Feb 23 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.3.0-0.2.develop
+- Drop accidental nodejs dependency by moving files
+- Exclude redundant systemd files
+
 * Thu Feb 10 2022 Zach Huntington-Meath <zhunting@redhat.com> - 3.3.0-0.1.develop
 - Bump version to 3.3-develop
 


### PR DESCRIPTION
Due to automatic dependencies nodejs ended up being pulled in. This moves some NPM related scripts to foreman-assets which already depends on nodejs anyway. It also excludes the systemd files because they're redundant.

Should be verified by using `rpm -q --requires foreman.rpm`.