### PR TITLE
Fix typo in katello tag

### DIFF
--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -987,7 +987,7 @@ whitelist =
   tracer
   yggdrasil
 
-[katallo-4.4-rhel7]
+[katello-4.4-rhel7]
 disttag = .el7
 scl = tfm
 whitelist = katello


### PR DESCRIPTION
Fixes: 3a6a1ba1d5117e6ac71f23c358dd81f64249222a