### PR TITLE
Place convenience scripts into root bindir

### DIFF
--- a/packages/plugins/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
+++ b/packages/plugins/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
@@ -2,6 +2,7 @@
 %{?scl:%scl_package rubygem-%{gem_name}}
 %{!?scl:%global pkg_name %{name}}
 %{!?_root_sysconfdir:%global _root_sysconfdir %{_sysconfdir}}
+%{!?_root_bindir:%global _root_bindir %{_bindir}}
 
 %global gem_name foreman-tasks
 %global plugin_name foreman-tasks
@@ -9,7 +10,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 5.2.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman plugin for showing tasks information for resources and users
 Group: Applications/Systems
 License: GPLv3
@@ -117,9 +118,9 @@ chmod +x %{buildroot}%{gem_instdir}/extra/dynflow-debug.sh
 ln -s %{gem_instdir}/extra/dynflow-debug.sh %{buildroot}%{foreman_dir}/script/foreman-debug.d/60-dynflow_debug
 
 # Link rake task interface scripts into /usr/bin
-mkdir -p %{buildroot}%{_bindir}
-ln -s %{gem_instdir}/extra/foreman-tasks-cleanup.sh %{buildroot}%{_bindir}/foreman-tasks-cleanup
-ln -s %{gem_instdir}/extra/foreman-tasks-export.sh %{buildroot}%{_bindir}/foreman-tasks-export
+mkdir -p %{buildroot}%{_root_bindir}
+ln -s %{gem_instdir}/extra/foreman-tasks-cleanup.sh %{buildroot}%{_root_bindir}/foreman-tasks-cleanup
+ln -s %{gem_instdir}/extra/foreman-tasks-export.sh %{buildroot}%{_root_bindir}/foreman-tasks-export
 
 # Logrotate script
 install -Dp -m0644 %{SOURCE1} %{buildroot}%{_root_sysconfdir}/logrotate.d/%{gem_name}
@@ -146,8 +147,8 @@ type foreman-selinux-relabel >/dev/null 2>&1 && foreman-selinux-relabel 2>&1 >/d
 %{gem_instdir}/db
 %{gem_instdir}/deploy
 %{gem_instdir}/extra
-%{_bindir}/foreman-tasks-cleanup
-%{_bindir}/foreman-tasks-export
+%{_root_bindir}/foreman-tasks-cleanup
+%{_root_bindir}/foreman-tasks-export
 %exclude %{gem_instdir}/gemfile.d
 %{gem_libdir}
 %{gem_instdir}/locale
@@ -176,6 +177,9 @@ type foreman-selinux-relabel >/dev/null 2>&1 && foreman-selinux-relabel 2>&1 >/d
 %{gem_instdir}/test
 
 %changelog
+* Mon Feb 28 2022 Adam Ruzicka <aruzicka@redhat.com> 5.2.1-2
+- Place convenience script into root bindir instead of scl bindir
+
 * Wed Jan 26 2022 Adam Ruzicka <aruzicka@redhat.com> 5.2.1-1
 - Update to 5.2.1
 


### PR DESCRIPTION
On EL7 they were ending up in scl bindir
