### PR TITLE
Remove module_hotfixes=1 from repo files

### DIFF
--- a/packages/foreman/foreman-release/foreman-plugins.repo
+++ b/packages/foreman/foreman-release/foreman-plugins.repo
@@ -4,7 +4,6 @@ baseurl=https://yum.theforeman.org/plugins/nightly/$DIST/$basearch
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
-module_hotfixes=1
 
 [foreman-plugins-source]
 name=Foreman plugins nightly - source

--- a/packages/foreman/foreman-release/foreman-release.spec
+++ b/packages/foreman/foreman-release/foreman-release.spec
@@ -13,7 +13,7 @@
 %define repo_dist %{dist}
 %endif
 
-%global release 1
+%global release 2
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -90,6 +90,9 @@ install -Dpm0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-f
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman
 
 %changelog
+* Mon Feb 28 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.3.0-0.2.develop
+- Remove module_hotfixes=1
+
 * Thu Feb 10 2022 Zach Huntington-Meath <zhunting@redhat.com> - 3.3.0-0.1.develop
 - Bump version to 3.3-develop
 

--- a/packages/foreman/foreman-release/foreman.repo
+++ b/packages/foreman/foreman-release/foreman.repo
@@ -4,7 +4,6 @@ baseurl=https://yum.theforeman.org/releases/nightly/$DIST/$basearch
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
-module_hotfixes=1
 
 [foreman-source]
 name=Foreman nightly - source

--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -5,7 +5,7 @@
 
 %global prereleasesource nightly
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 1
+%global release 2
 
 Name:           katello-repos
 Version:        4.5
@@ -68,6 +68,9 @@ rm -rf %{buildroot}
 %config %{repo_dir}/*.repo
 
 %changelog
+* Mon Feb 28 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 4.5-0.2.nightly
+- Remove module_hotfixes=1
+
 * Wed Feb 16 2022 Justin Sherrill <jsherril@redhat.com> 4.5-0.1.nightly
 - bump to version 4.5
 

--- a/packages/katello/katello-repos/katello.repo
+++ b/packages/katello/katello-repos/katello.repo
@@ -6,7 +6,6 @@ baseurl=https://yum.theforeman.org/katello/@REPO_VERSION@/katello/@DIST@/$basear
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=@REPO_GPGCHECK@
-module_hotfixes=1
 
 # Candlepin RPMs as supported by Katello - This is a coordinated
 # copy of Candlepin's packages in order to ensure compatibility
@@ -17,7 +16,6 @@ baseurl=https://yum.theforeman.org/katello/@REPO_VERSION@/candlepin/@DIST@/$base
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=@REPO_GPGCHECK@
-module_hotfixes=1
 
 [pulpcore]
 name=pulpcore: Fetch, Upload, Organize, and Distribute Software Packages.
@@ -25,7 +23,6 @@ baseurl=https://yum.theforeman.org/pulpcore/@PULPCORE_VERSION@/@DIST@/$basearch/
 gpgkey=https://yum.theforeman.org/pulpcore/@PULPCORE_VERSION@/GPG-RPM-KEY-pulpcore
 enabled=1
 gpgcheck=1
-module_hotfixes=1
 
 # source repositories
 


### PR DESCRIPTION
There is now modular metadata. Removing this means that must be used, but it can properly enforce that the correct dependent modules are also enabled.

Right now I'm starting this, but I'm not sure yet what else needs to be modified so it's still a draft.