### PR TITLE
Clean up dead entries from comps

### DIFF
--- a/comps/comps-foreman-plugins-el8.xml
+++ b/comps/comps-foreman-plugins-el8.xml
@@ -14,7 +14,6 @@
       <packagereq type="default">ansiblerole-satellite-receptor-installer</packagereq>
       <packagereq type="default">foreman-discovery-image-service</packagereq>
       <packagereq type="default">foreman-discovery-image-service-tui</packagereq>
-      <packagereq type="default">ipxe-bootimgs</packagereq>
       <packagereq type="default">nodejs-babel-plugin-module-resolver</packagereq>
       <packagereq type="default">nodejs-patternfly-react-catalog-view-extension</packagereq>
       <packagereq type="default">nodejs-react-json-tree</packagereq>
@@ -42,7 +41,6 @@
       <packagereq type="default">rubygem-elastic-apm</packagereq>
       <packagereq type="default">rubygem-faraday-cookie_jar</packagereq>
       <packagereq type="default">rubygem-faraday_middleware</packagereq>
-      <packagereq type="default">rubygem-fast_gettext</packagereq>
       <packagereq type="default">rubygem-fog-kubevirt</packagereq>
       <packagereq type="default">rubygem-fog-proxmox</packagereq>
       <packagereq type="default">rubygem-foreman-tasks</packagereq>
@@ -203,7 +201,6 @@
       <packagereq type="default">rubygem-elastic-apm-doc</packagereq>
       <packagereq type="default">rubygem-faraday-cookie_jar-doc</packagereq>
       <packagereq type="default">rubygem-faraday_middleware-doc</packagereq>
-      <packagereq type="default">rubygem-fast_gettext-doc</packagereq>
       <packagereq type="default">rubygem-fog-kubevirt-doc</packagereq>
       <packagereq type="default">rubygem-fog-proxmox-doc</packagereq>
       <packagereq type="default">rubygem-foreman_acd-doc</packagereq>

--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -14,7 +14,6 @@
       <packagereq type="default">ansiblerole-satellite-receptor-installer</packagereq>
       <packagereq type="default">foreman-discovery-image-service</packagereq>
       <packagereq type="default">foreman-discovery-image-service-tui</packagereq>
-      <packagereq type="default">ipxe-bootimgs</packagereq>
       <packagereq type="default">puppet-foreman_scap_client</packagereq>
       <packagereq type="default">puppetlabs-stdlib</packagereq>
       <packagereq type="default">tfm-nodejs-babel-plugin-module-resolver</packagereq>


### PR DESCRIPTION
It's unclear why these entries even exist in these files.

* ipxe-bootimgs is actually packaged in EL7 and EL8 so we don't package this.
* rubygem-fast_gettext is in foreman itself, not foreman-plugins.