### PR TITLE
Require python38-psutil on EL8 when using ansible-core

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
+++ b/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
@@ -17,7 +17,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.3.1
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Summary: Smart-Proxy Ansible plugin
 Group: Applications/Internet
 License: GPLv3
@@ -28,6 +28,7 @@ Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ansible
 %else
 Requires: (ansible or ansible-core)
+Requires: (python38-psutil if ansible-core)
 %endif
 
 Requires: ansible-collection-theforeman-foreman
@@ -147,6 +148,9 @@ ln -sv %{_root_sysconfdir}/foreman-proxy/ansible.cfg %{buildroot}%{foreman_proxy
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Mar 02 2022 Evgeni Golov - 3.3.1-3
+- Require python38-psutil on EL8 when using ansible-core
+
 * Wed Feb 23 2022 Evgeni Golov - 3.3.1-2
 - Require ansible or ansible-core on EL8+
 


### PR DESCRIPTION
ansible-core uses Python 3.8 (vs 3.6 as used by ansible 2.9), and to be
able to properly execute that, we need the psutil module, as otherwise
ansible fails to execute.

This is not a packaging issue with ansible-core itself, as that doesn't
require psutil, but with ansible-runner. However, our chances to get a
fixed runner RPM anytime soon are rather limited.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
