### PR TITLE
Compatibility with old python-semver

### DIFF
--- a/update-requirements
+++ b/update-requirements
@@ -28,9 +28,9 @@ def get_requirement(version):
 
         min_version = '{}.{}.{}'.format(parsed['major'], parsed['minor'], parsed['patch'])
         if modifier == '^':
-            max_version = semver.bump_major(min_version)
+            max_version = '{}.0.0'.format(parsed['major'] + 1)
         elif modifier == '~':
-            max_version = semver.bump_minor(min_version)
+            max_version = '{}.{}.0'.format(parsed['major'], parsed['minor'] + 1)
 
         return ['>= {}'.format(min_version), '< {}'.format(max_version)]
 


### PR DESCRIPTION
The version in Ubuntu is older than 2.4.1 so bump_major and bump_minor are unavailable. This implements it manually.

https://github.com/python-semver/python-semver/commit/6ae029f9014ac77620d8e1679a291cd8927f9cbc is the commit that implemented it in python-semver