### PR TITLE
Update smart proxy reports to 1.0.0 (CP)

### DIFF
--- a/plugins/smart_proxy_reports/changelog
+++ b/plugins/smart_proxy_reports/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-reports (1.0.0-1) stable; urgency=low
+
+  * 1.0.0 released
+
+ -- Lukas Zapletal <lzap+git@redhat.com>  Wed, 16 Feb 2022 14:45:56 +0100
+
 ruby-smart-proxy-reports (0.0.7-1) stable; urgency=medium
 
   * Initial release

--- a/plugins/smart_proxy_reports/install
+++ b/plugins/smart_proxy_reports/install
@@ -1,2 +1,2 @@
-bundler.d/reports.rb usr/share/foreman-proxy/bundler.d
+debian/reports.rb usr/share/foreman-proxy/bundler.d
 settings.d/reports.yml etc/foreman-proxy/settings.d

--- a/plugins/smart_proxy_reports/reports.rb
+++ b/plugins/smart_proxy_reports/reports.rb
@@ -1,0 +1,1 @@
+gem 'smart_proxy_reports', '1.0.0'


### PR DESCRIPTION
Hey,

this is backport of all Host Reports feature packages, that includes:

* Foreman Host Reports core plugin (1.0.2)
* Smart Proxy Reports plugin (1.0.0)

I tested everything on both CentOS 8 and Debian 10, the last version bump only adds migration rake task which was tested separately, there are no code changes or packaging changes. The complete list of all CPs:

* https://github.com/theforeman/foreman-packaging/pull/7708
* https://github.com/theforeman/foreman-packaging/pull/7709
* https://github.com/theforeman/foreman-packaging/pull/7710
* https://github.com/theforeman/foreman-packaging/pull/7711

I also request 3.2 repos regeneration, if this cannot be done due to the 3.2 release then please trigger it when it can be done, hopefully this is not 3.2.1 tho as we already have a yellow warning when you visit the old Reports page instructing users to migrate to the new format :-)

Thanks!