### PR TITLE
Updated hammer_cli_foreman_puppet to 0.0.5

### DIFF
--- a/dependencies/bullseye/hammer_cli_foreman_puppet/changelog
+++ b/dependencies/bullseye/hammer_cli_foreman_puppet/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-puppet (0.0.5-1) stable; urgency=low
+
+  * 0.0.5 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Wed, 16 Mar 2022 16:58:45 +0000
+
 ruby-hammer-cli-foreman-puppet (0.0.4-1) stable; urgency=low
 
   * 0.0.4 released

--- a/dependencies/buster/hammer_cli_foreman_puppet/changelog
+++ b/dependencies/buster/hammer_cli_foreman_puppet/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-puppet (0.0.5-1) stable; urgency=low
+
+  * 0.0.5 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Wed, 16 Mar 2022 16:58:45 +0000
+
 ruby-hammer-cli-foreman-puppet (0.0.4-1) stable; urgency=low
 
   * 0.0.4 released

--- a/dependencies/focal/hammer_cli_foreman_puppet/changelog
+++ b/dependencies/focal/hammer_cli_foreman_puppet/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-puppet (0.0.5-1) stable; urgency=low
+
+  * 0.0.5 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Wed, 16 Mar 2022 16:58:45 +0000
+
 ruby-hammer-cli-foreman-puppet (0.0.4-1) stable; urgency=low
 
   * 0.0.4 released


### PR DESCRIPTION
Supported Versions:

 * Nightly