### PR TITLE
Remove unused ruby dependencies on sp_dns_powerdns

### DIFF
--- a/plugins/smart_proxy_dns_powerdns/changelog
+++ b/plugins/smart_proxy_dns_powerdns/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-dns-powerdns (1.0.0-2) stable; urgency=low
+
+  * Remove unused ruby-mysql2 and ruby-pg dependencies
+
+ -- Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl>  Mon, 04 Apr 2022 15:44:39 +0200
+
 ruby-smart-proxy-dns-powerdns (1.0.0-1) stable; urgency=low
 
   * 1.0.0 released

--- a/plugins/smart_proxy_dns_powerdns/control
+++ b/plugins/smart_proxy_dns_powerdns/control
@@ -12,7 +12,7 @@ XS-Ruby-Versions: all
 Package: ruby-smart-proxy-dns-powerdns
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.13.0~rc1), ruby-mysql2, ruby-pg
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, foreman-proxy (>= 1.13.0~rc1)
 Recommends: pdns-server
 Description: PowerDNS DNS provider plugin for Foreman's smart proxy
  PowerDNS DNS provider plugin for Foreman's smart proxy


### PR DESCRIPTION
These were dropped in the 1.0.0 release (in favor of only supporting the REST API) but that wasn't reflected in [the packaging bump](113756a181fe5687fcd06c1933ba208dfc2af391).