### PR TITLE
Refs #34641 - Stop generating apipie cache in plugins

### DIFF
--- a/gem2rpm/foreman_plugin.spec.erb
+++ b/gem2rpm/foreman_plugin.spec.erb
@@ -24,7 +24,6 @@ has_webpack = spec.files.any? { |f| f.start_with?('webpack/') }
 has_package_json = spec.files.any? { |f| f == 'package.json' }
 
 precompile_flags = ''
-precompile_flags << ' -a' if has_apidoc
 precompile_flags << ' -s' if has_assets || has_webpack
 
 config.rules[:doc] << /\/?CHANGES/

--- a/packages/katello/rubygem-foreman_rh_cloud/rubygem-foreman_rh_cloud.spec
+++ b/packages/katello/rubygem-foreman_rh_cloud/rubygem-foreman_rh_cloud.spec
@@ -9,7 +9,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 5.0.33
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Connects Foreman with Red Hat Cloud services
 Group: Applications/Systems
 License: GPLv3
@@ -100,7 +100,7 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -115,8 +115,6 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_webpack_plugin}
 %{foreman_webpack_foreman}
 %{foreman_assets_plugin}
@@ -128,6 +126,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 5.0.33-2
+- Stop generaing apipie cache
+
 * Thu Apr 14 2022 Shimon Shtein <sshtein@redhat.com> 5.0.33-1
 - Update to 5.0.33-1
 

--- a/packages/katello/rubygem-foreman_scc_manager/rubygem-foreman_scc_manager.spec
+++ b/packages/katello/rubygem-foreman_scc_manager/rubygem-foreman_scc_manager.spec
@@ -9,7 +9,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.8.17
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Suse Customer Center plugin for Foreman
 Group: Applications/Systems
 License: GPLv3
@@ -80,7 +80,7 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -92,8 +92,6 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/locale
 %exclude %{gem_cache}
 %{gem_spec}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_bundlerd_plugin}
 %{foreman_assets_plugin}
 
@@ -104,6 +102,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 1.8.17-2
+- Stop generaing apipie cache
+
 * Tue Feb 01 2022 Nadja Heitmann <heitmann@atix.de> 1.8.17-1
 - Update to 1.8.17
 - Allow for new mirroring_policy setting in Katello >= 4.3

--- a/packages/katello/rubygem-foreman_virt_who_configure/rubygem-foreman_virt_who_configure.spec
+++ b/packages/katello/rubygem-foreman_virt_who_configure/rubygem-foreman_virt_who_configure.spec
@@ -8,7 +8,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.5.8
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: A plugin to make virt-who configuration easy
 Group: Applications/Systems
 License: GPLv3
@@ -74,7 +74,7 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -87,8 +87,6 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 
 %files doc
@@ -98,6 +96,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 0.5.8-2
+- Stop generaing apipie cache
+
 * Wed Nov 10 2021 Jonathon Turel <jturel@gmail.com> 0.5.8-1
 - Update to 0.5.8
 

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -9,7 +9,7 @@
 %global prereleasesource pre.master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
 %global mainver 4.5.0
-%global release 2
+%global release 3
 
 Name:    %{?scl_prefix}rubygem-%{gem_name}
 Summary: Content and Subscription Management plugin for Foreman
@@ -211,7 +211,7 @@ cp -pa .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -229,8 +229,6 @@ cp -pa .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 %{foreman_webpack_foreman}
 %{foreman_webpack_plugin}
@@ -244,6 +242,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/webpack
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 4.5.0-0.3.pre.master
+- Stop generaing apipie cache
+
 * Mon Feb 28 2022 Justin Sherrill <jsherril@redhat.com> 4.5.0-0.2.pre.master
 - update to pulp-rpm 3.17
 

--- a/packages/plugins/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
+++ b/packages/plugins/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
@@ -10,7 +10,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 6.0.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman plugin for showing tasks information for resources and users
 Group: Applications/Systems
 License: GPLv3
@@ -105,7 +105,7 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 mkdir -p %{buildroot}%{foreman_pluginconf_dir}
 mv %{buildroot}/%{gem_instdir}/config/%{gem_name}.yaml.example \
@@ -158,8 +158,6 @@ type foreman-selinux-relabel >/dev/null 2>&1 && foreman-selinux-relabel 2>&1 >/d
 %{gem_spec}
 %{foreman_bundlerd_plugin}
 %config %{foreman_pluginconf_dir}/%{gem_name}.yaml
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_dir}/script/foreman-debug.d/60-dynflow_debug
 %config(noreplace) %{_root_sysconfdir}/logrotate.d/%{gem_name}
 %{foreman_assets_plugin}
@@ -176,6 +174,9 @@ type foreman-selinux-relabel >/dev/null 2>&1 && foreman-selinux-relabel 2>&1 >/d
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 6.0.1-2
+- Stop generaing apipie cache
+
 * Fri Apr 01 2022 Adam Ruzicka <aruzicka@redhat.com> 6.0.1-1
 - Update to 6.0.1
 

--- a/packages/plugins/rubygem-foreman_ansible/rubygem-foreman_ansible.spec
+++ b/packages/plugins/rubygem-foreman_ansible/rubygem-foreman_ansible.spec
@@ -9,7 +9,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 7.1.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Ansible integration with Foreman (theforeman.org)
 Group: Applications/Systems
 License: GPLv3
@@ -95,7 +95,7 @@ cp -pa .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -110,8 +110,6 @@ cp -pa .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 %{foreman_webpack_plugin}
 %{foreman_webpack_foreman}
@@ -123,6 +121,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 7.1.0-2
+- Stop generaing apipie cache
+
 * Mon Mar 14 2022 Ondřej Ezr <oezr@redhat.com> 7.1.0-1
 - Update to 7.1.0
 

--- a/packages/plugins/rubygem-foreman_azure_rm/rubygem-foreman_azure_rm.spec
+++ b/packages/plugins/rubygem-foreman_azure_rm/rubygem-foreman_azure_rm.spec
@@ -8,7 +8,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 2.2.6
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Azure Resource Manager as a compute resource for The Foreman
 Group: Applications/Systems
 License: GPLv3
@@ -92,7 +92,6 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a
 
 %files
 %dir %{gem_instdir}
@@ -105,8 +104,6 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 
 %files doc
 %doc %{gem_docdir}
@@ -114,6 +111,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/Rakefile
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 2.2.6-2
+- Stop generaing apipie cache
+
 * Thu Nov 11 2021 Chris Roberts <chrobert@redhat.com> 2.2.6-1
 - Update to 2.2.6
 

--- a/packages/plugins/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
+++ b/packages/plugins/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
@@ -9,7 +9,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 19.0.4
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Create boot disks to provision hosts with Foreman
 Group: Applications/Systems
 License: GPLv3
@@ -90,7 +90,7 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -105,8 +105,6 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 %{foreman_webpack_plugin}
 %{foreman_webpack_foreman}
@@ -117,6 +115,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 19.0.4-2
+- Stop generaing apipie cache
+
 * Fri Mar 11 2022 Foreman Packaging Automation <packaging@theforeman.org> 19.0.4-1
 - Update to 19.0.4
 

--- a/packages/plugins/rubygem-foreman_datacenter/rubygem-foreman_datacenter.spec
+++ b/packages/plugins/rubygem-foreman_datacenter/rubygem-foreman_datacenter.spec
@@ -9,7 +9,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 2.3.0
-Release: 3%{?foremandist}%{?dist}
+Release: 4%{?foremandist}%{?dist}
 Summary: A plugin that lets you document your servers in a datacenter
 Group: Applications/Systems
 License: GPLv3
@@ -81,7 +81,7 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -94,8 +94,6 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 
 %files doc
@@ -105,6 +103,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 2.3.0-4
+- Stop generaing apipie cache
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 2.3.0-3
 - Rebuild plugins for Ruby 2.7
 

--- a/packages/plugins/rubygem-foreman_discovery/rubygem-foreman_discovery.spec
+++ b/packages/plugins/rubygem-foreman_discovery/rubygem-foreman_discovery.spec
@@ -9,7 +9,7 @@
 Summary:    MaaS Discovery Plugin for Foreman
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    21.0.0
-Release:    1%{?foremandist}%{?dist}
+Release:    2%{?foremandist}%{?dist}
 Group:      Applications/Systems
 License:    GPLv3
 URL:        https://github.com/theforeman/foreman_discovery
@@ -82,7 +82,7 @@ cp -pa .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -98,8 +98,6 @@ cp -pa .%{gem_dir}/* \
 %exclude %{gem_instdir}/webpack
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 %{foreman_webpack_plugin}
 %{foreman_webpack_foreman}
@@ -110,6 +108,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 21.0.0-2
+- Stop generaing apipie cache
+
 * Thu Mar 17 2022 Lukas Zapletal <lzap+rpm@redhat.com> 21.0.0-1
 - Update to 21.0.0
 

--- a/packages/plugins/rubygem-foreman_dlm/rubygem-foreman_dlm.spec
+++ b/packages/plugins/rubygem-foreman_dlm/rubygem-foreman_dlm.spec
@@ -10,7 +10,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 2.0.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Distributed Lock Manager for Foreman
 Group: Applications/Systems
 License: GPLv3
@@ -79,7 +79,6 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a
 
 #copy init scripts, sysconfigs and logrotate config
 install -Dp -m0644 %{buildroot}%{gem_instdir}/contrib/systemd/%{service_name}.service %{buildroot}%{_unitdir}/%{service_name}.service
@@ -103,8 +102,6 @@ install -Dp -m0644 %{buildroot}%{gem_instdir}/contrib/systemd/%{service_name}.ti
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{_unitdir}/%{service_name}.service
 %{_unitdir}/%{service_name}.timer
 
@@ -117,6 +114,9 @@ install -Dp -m0644 %{buildroot}%{gem_instdir}/contrib/systemd/%{service_name}.ti
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 2.0.0-2
+- Stop generaing apipie cache
+
 * Wed Mar 02 2022 Manuel Laug <laugmanuel@gmail.com> - 2.0.0-1
 - Update foreman_dlm to 2.0.0
 

--- a/packages/plugins/rubygem-foreman_expire_hosts/rubygem-foreman_expire_hosts.spec
+++ b/packages/plugins/rubygem-foreman_expire_hosts/rubygem-foreman_expire_hosts.spec
@@ -9,7 +9,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 7.0.4
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Summary: Foreman plugin for limiting host lifetime
 Group: Applications/Systems
 License: GPLv3
@@ -78,7 +78,6 @@ cp -a .%{gem_dir}/* \
 mkdir -p %{buildroot}%{_root_sysconfdir}/cron.d/
 mv %{buildroot}%{gem_instdir}/extra/*.cron %{buildroot}%{_root_sysconfdir}/cron.d/%{gem_name}
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a
 
 %files
 %dir %{gem_instdir}
@@ -91,8 +90,6 @@ mv %{buildroot}%{gem_instdir}/extra/*.cron %{buildroot}%{_root_sysconfdir}/cron.
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %config(noreplace) %{_root_sysconfdir}/cron.d/%{gem_name}
 
 %files doc
@@ -101,6 +98,9 @@ mv %{buildroot}%{gem_instdir}/extra/*.cron %{buildroot}%{_root_sysconfdir}/cron.
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 7.0.4-3
+- Stop generaing apipie cache
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 7.0.4-2
 - Rebuild plugins for Ruby 2.7
 

--- a/packages/plugins/rubygem-foreman_fog_proxmox/rubygem-foreman_fog_proxmox.spec
+++ b/packages/plugins/rubygem-foreman_fog_proxmox/rubygem-foreman_fog_proxmox.spec
@@ -8,7 +8,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.14.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman plugin that adds Proxmox VE compute resource using fog-proxmox
 Group: Applications/Systems
 License: GPLv3
@@ -86,7 +86,7 @@ cp -pa .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -99,8 +99,6 @@ cp -pa .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 
 %files doc
@@ -118,6 +116,9 @@ if [ $1 -eq 0 ] ; then
 fi
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 0.14.0-2
+- Stop generaing apipie cache
+
 * Fri Jul 23 2021 Tristan Robert <tristan.robert.44@gmail.com> 0.14.0-1
 - Update to 0.14.0
 

--- a/packages/plugins/rubygem-foreman_host_reports/rubygem-foreman_host_reports.spec
+++ b/packages/plugins/rubygem-foreman_host_reports/rubygem-foreman_host_reports.spec
@@ -9,7 +9,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.2
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman reporting engine
 Group: Applications/Systems
 License: GPLv3
@@ -87,7 +87,7 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -102,8 +102,6 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_webpack_plugin}
 %{foreman_webpack_foreman}
 %exclude %{foreman_assets_plugin}
@@ -114,6 +112,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 1.0.2-2
+- Stop generaing apipie cache
+
 * Mon Mar 14 2022 Lukas Zapletal <lzap+rpm@redhat.com> 1.0.2-1
 - Update to 1.0.2
 

--- a/packages/plugins/rubygem-foreman_kubevirt/rubygem-foreman_kubevirt.spec
+++ b/packages/plugins/rubygem-foreman_kubevirt/rubygem-foreman_kubevirt.spec
@@ -9,7 +9,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.1.9
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Summary: Provision and manage Kubevirt Virtual Machines from Foreman
 Group: Applications/Systems
 License: GPLv3
@@ -79,7 +79,7 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -91,8 +91,6 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 
 %files doc
@@ -102,6 +100,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 0.1.9-3
+- Stop generaing apipie cache
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 0.1.9-2
 - Rebuild plugins for Ruby 2.7
 

--- a/packages/plugins/rubygem-foreman_monitoring/rubygem-foreman_monitoring.spec
+++ b/packages/plugins/rubygem-foreman_monitoring/rubygem-foreman_monitoring.spec
@@ -8,7 +8,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 2.1.0
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Summary: Foreman plugin for monitoring system integration
 Group: Applications/Systems
 License: GPLv3
@@ -73,7 +73,6 @@ cp -pa .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a
 
 %files
 %dir %{gem_instdir}
@@ -86,8 +85,6 @@ cp -pa .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 
 %files doc
 %doc %{gem_docdir}
@@ -96,6 +93,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 2.1.0-3
+- Stop generaing apipie cache
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 2.1.0-2
 - Rebuild plugins for Ruby 2.7
 

--- a/packages/plugins/rubygem-foreman_omaha/rubygem-foreman_omaha.spec
+++ b/packages/plugins/rubygem-foreman_omaha/rubygem-foreman_omaha.spec
@@ -8,7 +8,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 4.0.1
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Summary: This plug-in adds support for the Omaha procotol to The Foreman
 Group: Applications/Systems
 License: GPLv3
@@ -76,7 +76,7 @@ cp -pa .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -89,8 +89,6 @@ cp -pa .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 
 %files doc
@@ -100,6 +98,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 4.0.1-3
+- Stop generaing apipie cache
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 4.0.1-2
 - Rebuild plugins for Ruby 2.7
 

--- a/packages/plugins/rubygem-foreman_puppet/rubygem-foreman_puppet.spec
+++ b/packages/plugins/rubygem-foreman_puppet/rubygem-foreman_puppet.spec
@@ -6,7 +6,7 @@
 %global gem_name foreman_puppet
 %global plugin_name puppet
 %global foreman_min_version 3.0
-%global release 1
+%global release 2
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.0.5
@@ -85,7 +85,7 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -100,8 +100,6 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 %{foreman_webpack_plugin}
 %{foreman_webpack_foreman}
@@ -113,6 +111,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 3.0.5-2
+- Stop generaing apipie cache
+
 * Fri Mar 11 2022 Foreman Packaging Automation <packaging@theforeman.org> 3.0.5-1
 - Update to 3.0.5
 

--- a/packages/plugins/rubygem-foreman_remote_execution/rubygem-foreman_remote_execution.spec
+++ b/packages/plugins/rubygem-foreman_remote_execution/rubygem-foreman_remote_execution.spec
@@ -11,7 +11,7 @@
 Summary:    Plugin that brings remote execution capabilities to Foreman
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    6.2.0
-Release:    1%{?foremandist}%{?dist}
+Release:    2%{?foremandist}%{?dist}
 Group:      Applications/Systems
 License:    GPLv3
 URL:        https://github.com/theforeman/foreman_remote_execution
@@ -111,7 +111,7 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 mkdir -p %{buildroot}%{_root_sbindir}
 ln -sv %{gem_instdir}/extra/cockpit/foreman-cockpit-session %{buildroot}%{_root_sbindir}/foreman-cockpit-session
@@ -142,8 +142,6 @@ install -Dp -m0644 %{buildroot}%{gem_instdir}/extra/cockpit/settings.yml.example
 %{gem_instdir}/locale
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 %{foreman_webpack_plugin}
 %{foreman_webpack_foreman}
@@ -165,6 +163,9 @@ install -Dp -m0644 %{buildroot}%{gem_instdir}/extra/cockpit/settings.yml.example
 %{_unitdir}/foreman-cockpit.service
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 6.2.0-2
+- Stop generaing apipie cache
+
 * Tue Apr 19 2022 Adam Ruzicka <aruzicka@redhat.com> 6.2.0-1
 - Update to 6.2.0
 

--- a/packages/plugins/rubygem-foreman_salt/rubygem-foreman_salt.spec
+++ b/packages/plugins/rubygem-foreman_salt/rubygem-foreman_salt.spec
@@ -9,7 +9,7 @@
 Summary:    Foreman Plug-in for Salt
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    15.1.0
-Release:    1%{?foremandist}%{?dist}
+Release:    2%{?foremandist}%{?dist}
 Group:      Applications/Systems
 License:    GPLv3
 URL:        https://github.com/theforeman/foreman_salt
@@ -80,7 +80,7 @@ cp -pa .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -93,8 +93,6 @@ cp -pa .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 
 %files doc
@@ -104,6 +102,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 15.1.0-2
+- Stop generaing apipie cache
+
 * Fri Apr 08 2022 Bernhard Suttner <suttner@atix.de> 15.1.0-1
 - Update to 15.1.0
 

--- a/packages/plugins/rubygem-foreman_statistics/rubygem-foreman_statistics.spec
+++ b/packages/plugins/rubygem-foreman_statistics/rubygem-foreman_statistics.spec
@@ -9,7 +9,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 2.0.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Add Statistics and Trends
 Group: Applications/Systems
 License: GPLv3
@@ -88,7 +88,7 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -103,8 +103,6 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 %{foreman_webpack_plugin}
 %{foreman_webpack_foreman}
@@ -116,6 +114,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 2.0.1-2
+- Stop generaing apipie cache
+
 * Mon Feb 14 2022 Ondřej Ezr <oezr@redhat.com> 2.0.1-1
 - Update to 2.0.1
 

--- a/packages/plugins/rubygem-foreman_templates/rubygem-foreman_templates.spec
+++ b/packages/plugins/rubygem-foreman_templates/rubygem-foreman_templates.spec
@@ -9,7 +9,7 @@
 Summary:    Template-syncing engine for Foreman
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    9.2.0
-Release:    1%{?foremandist}%{?dist}
+Release:    2%{?foremandist}%{?dist}
 Group:      Applications/Systems
 License:    GPLv3
 URL:        https://github.com/theforeman/foreman_templates
@@ -91,7 +91,7 @@ cp -pa .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -107,8 +107,6 @@ cp -pa .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 %{foreman_webpack_plugin}
 %{foreman_webpack_foreman}
@@ -119,6 +117,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/Rakefile
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 9.2.0-2
+- Stop generaing apipie cache
+
 * Thu Feb 10 2022 Oleh Fedorenko <ofedoren@redhat.com> 9.2.0-1
 - Update to 9.2.0
 

--- a/packages/plugins/rubygem-foreman_vault/rubygem-foreman_vault.spec
+++ b/packages/plugins/rubygem-foreman_vault/rubygem-foreman_vault.spec
@@ -9,7 +9,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.1.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Adds support for using credentials from Hashicorp Vault
 Group: Applications/Systems
 License: GPLv3
@@ -76,7 +76,6 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a
 
 %files
 %dir %{gem_instdir}
@@ -89,8 +88,6 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 
 %files doc
 %doc %{gem_docdir}
@@ -99,6 +96,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 1.1.0-2
+- Stop generaing apipie cache
+
 * Thu Oct 21 2021 Manuel Laug <laugmanuel@gmail.com> - 1.1.0-1
 - Update to 1.1.0
 

--- a/packages/plugins/rubygem-foreman_webhooks/rubygem-foreman_webhooks.spec
+++ b/packages/plugins/rubygem-foreman_webhooks/rubygem-foreman_webhooks.spec
@@ -9,7 +9,7 @@
 Summary:    Plugin for Foreman that allows to configure Webhooks
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    3.0.1
-Release:    1%{?foremandist}%{?dist}
+Release:    2%{?foremandist}%{?dist}
 Group:      Applications/Systems
 License:    GPLv3
 URL:        https://github.com/theforeman/foreman_webhooks
@@ -81,7 +81,7 @@ cp -pa .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a -s
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -96,8 +96,6 @@ cp -pa .%{gem_dir}/* \
 %exclude %{gem_instdir}/Rakefile
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 %{foreman_assets_plugin}
 %{foreman_webpack_plugin}
 %{foreman_webpack_foreman}
@@ -108,6 +106,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 3.0.1-2
+- Stop generaing apipie cache
+
 * Mon Mar 07 2022 Ron Lavi <1ronlavi@gmail.com> 3.0.1-1
 - Update to 3.0.1
 

--- a/packages/plugins/rubygem-puppetdb_foreman/rubygem-puppetdb_foreman.spec
+++ b/packages/plugins/rubygem-puppetdb_foreman/rubygem-puppetdb_foreman.spec
@@ -17,7 +17,7 @@
 Summary:    Foreman plugin to interact with PuppetDB
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    5.0.0
-Release:    3%{?foremandist}%{?dist}
+Release:    4%{?foremandist}%{?dist}
 Group:      Applications/System
 License:    GPLv3
 URL:        https://github.com/theforeman/puppetdb_foreman
@@ -81,7 +81,6 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin -a
 
 %files
 %dir %{gem_instdir}
@@ -93,8 +92,6 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%{foreman_apipie_cache_foreman}
-%{foreman_apipie_cache_plugin}
 
 %files doc
 %doc %{gem_docdir}
@@ -103,6 +100,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Apr 22 2022 Eric D. Helms <ericdhelms@gmail.com> - 5.0.0-4
+- Stop generaing apipie cache
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 5.0.0-3
 - Rebuild for Ruby 2.7
 


### PR DESCRIPTION
Plugins that won't build

- rubygem-foreman_openscap
- rubygem-foreman_acd
- rubygem-foreman_snapshot_management
- rubygem-foreman_leapp