### PR TITLE
Add dracut config as discovery subpackage

### DIFF
--- a/comps/comps-foreman-plugins-el8.xml
+++ b/comps/comps-foreman-plugins-el8.xml
@@ -16,6 +16,7 @@
       <packagereq type="default">cjson-devel</packagereq>
       <packagereq type="default">foreman-discovery-image-service</packagereq>
       <packagereq type="default">foreman-discovery-image-service-tui</packagereq>
+      <packagereq type="default">foreman-discovery-image-service-dracut</packagereq>
       <packagereq type="default">mosquitto</packagereq>
       <packagereq type="default">nodejs-babel-plugin-module-resolver</packagereq>
       <packagereq type="default">nodejs-patternfly-react-catalog-view-extension</packagereq>

--- a/comps/comps-foreman-plugins-rhel7.xml
+++ b/comps/comps-foreman-plugins-rhel7.xml
@@ -16,6 +16,7 @@
       <packagereq type="default">cjson-devel</packagereq>
       <packagereq type="default">foreman-discovery-image-service</packagereq>
       <packagereq type="default">foreman-discovery-image-service-tui</packagereq>
+      <packagereq type="default">foreman-discovery-image-service-dracut</packagereq>
       <packagereq type="default">mosquitto</packagereq>
       <packagereq type="default">puppet-foreman_scap_client</packagereq>
       <packagereq type="default">puppetlabs-stdlib</packagereq>

--- a/packages/plugins/foreman-discovery-image-service/foreman-discovery-image-service.spec
+++ b/packages/plugins/foreman-discovery-image-service/foreman-discovery-image-service.spec
@@ -1,14 +1,14 @@
 Name: foreman-discovery-image-service
 Version: 1.0.0
-Release: 4%{?dist}
+Release: 5%{?dist}
 Summary: Metapackage with dependencies for FDI
 
 Group: Applications/System
 License: GPLv2+
 URL: https://github.com/theforeman/foreman-discovery-image
 
-# explicitly define, as we build on top of an scl, not inside with scl_package 
-%{?scl:%global scl_prefix %{scl}-} 
+# explicitly define, as we build on top of an scl, not inside with scl_package
+%{?scl:%global scl_prefix %{scl}-}
 
 Requires:	foreman-proxy
 Requires:	%{?scl_prefix}rubygem-smart_proxy_discovery_image
@@ -30,6 +30,13 @@ BuildRequires: %{?scl_prefix_ruby}rubygems-devel
 %description tui
 Metapackage with dependencies for FDI text-user interface
 
+%package dracut
+Summary: Metapackage with dracut config
+Requires: dracut
+
+%description dracut
+Metapackage with dracut configuration
+
 %prep
 
 %build
@@ -40,7 +47,20 @@ Metapackage with dependencies for FDI text-user interface
 
 %files tui
 
+%files dracut
+%ghost %{_sysconfdir}/dracut.conf.d/99-discovery.conf
+
+%triggerprein dracut -- kernel
+# Because livecd-creator executes %post scriptlets after it copies initramdisk out of the
+# image, it is not possible to rebuild kernel ramdisk with extra drivers for VMWare and
+# MS Hyper-V. Therefore the configuration must be dropped before the kernel package
+# executes its %post scriptlet.
+echo 'add_drivers="mptbase mptscsih mptspi hv_storvsc hid_hyperv hv_netvsc hv_vmbus"' > %{_sysconfdir}/dracut.conf.d/99-discovery.conf
+
 %changelog
+* Fri Jun 10 2022 Lukas Zapletal <lzap+rpm@redhat.com> 1.0.0-5
+- added dracut metapackage
+
 * Wed Aug 26 2020 Lukas Zapletal <lzap+rpm@redhat.com - 1.0.0-4
 - TUI requires SCL dependencies
 


### PR DESCRIPTION
We are unable to regenerate dracut image via livecd-creator due to ordering issues. A BZ was raised that keyboard driver is missing for MS Hyper-V VMs. The missing drivers can be only configured before kernel installs, unless I am wrong doing this in %pre should do the trick.

More info at https://issues.redhat.com/browse/SPMM-9540

This is nightly only change, upstream we do not build FDI this way (we use lorax nowdays). Therefore this new subpackage does not need to be whitelisted at all upstream, we need to pull it downstream to fix the problem in brew.