### PR TITLE
Update rubygem-smart_proxy_monitoring to 0.2.0

### DIFF
--- a/plugins/smart_proxy_monitoring/changelog
+++ b/plugins/smart_proxy_monitoring/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-monitoring (0.2.0) stable; urgency=low
+
+  * 0.2.0 released
+
+ -- Dirk Goetz <dirk.goetz@netways.de>  Mon, 02 May 2022 13:22:31 +0200
+
 ruby-smart-proxy-monitoring (0.1.1-1) stable; urgency=low
 
   * 0.1.1 released


### PR DESCRIPTION
(cherry picked from commit 19d0af7e275f4f419f43d716c58db7a04d82f8a0)