### PR TITLE
Release hammer-cli and hammer-cli-foreman 3.3.0

### DIFF
--- a/packages/foreman/rubygem-hammer_cli/hammer_cli-3.3.0.gem
+++ b/packages/foreman/rubygem-hammer_cli/hammer_cli-3.3.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/QW/fZ/SHA256E-s205312--d373e5b4c12b6fb0b5fe0c1fcea0bb37e27d6a5591c0c594ddc22a3fd46a05f3.0.gem/SHA256E-s205312--d373e5b4c12b6fb0b5fe0c1fcea0bb37e27d6a5591c0c594ddc22a3fd46a05f3.0.gem

--- a/packages/foreman/rubygem-hammer_cli/rubygem-hammer_cli.spec
+++ b/packages/foreman/rubygem-hammer_cli/rubygem-hammer_cli.spec
@@ -5,8 +5,6 @@
 %global gem_name hammer_cli
 
 %global release 1
-%global prereleasesource pre.develop
-%global prerelease %{?prereleasesource:.}%{?prereleasesource}
 
 %{!?_root_bindir:%global _root_bindir %{_bindir}}
 %{!?_root_mandir:%global _root_mandir %{_mandir}}
@@ -35,7 +33,7 @@ Requires: %{?scl_prefix}rubygem(amazing_print)
 Requires: %{?scl_prefix}rubygem(highline)
 Requires: %{?scl_prefix}rubygem(fast_gettext)
 Requires: %{?scl_prefix}rubygem(locale) >= 2.0.6
-Requires: %{?scl_prefix}rubygem(apipie-bindings) >= 0.2.0
+Requires: %{?scl_prefix}rubygem(apipie-bindings) >= 0.5.0
 BuildRequires: %{?scl_prefix_ruby}ruby(release)
 BuildRequires: %{?scl_prefix_ruby}ruby
 BuildRequires: %{?scl_prefix_ruby}rubygems-devel
@@ -124,6 +122,9 @@ install -m 0644 .%{gem_instdir}/config/cli_config.template.yml \
 %{gem_instdir}/test
 
 %changelog
+* Tue May 10 2022 Oleh Fedorenko <ofedoren@redhat.com> - 3.3.0-1
+- Release rubygem-hammer_cli 3.3.0
+
 * Thu Feb 10 2022 Zach Huntington-Meath <zhunting@redhat.com> - 3.3.0-0.1.pre.develop
 - Bump version to 3.3-develop
 

--- a/packages/foreman/rubygem-hammer_cli_foreman/hammer_cli_foreman-3.3.0.gem
+++ b/packages/foreman/rubygem-hammer_cli_foreman/hammer_cli_foreman-3.3.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/gM/qq/SHA256E-s747008--d0680801cf1d99189dd7204211a598debea15cb5aa6d1ed5bffb3578dab41c82.0.gem/SHA256E-s747008--d0680801cf1d99189dd7204211a598debea15cb5aa6d1ed5bffb3578dab41c82.0.gem

--- a/packages/foreman/rubygem-hammer_cli_foreman/rubygem-hammer_cli_foreman.spec
+++ b/packages/foreman/rubygem-hammer_cli_foreman/rubygem-hammer_cli_foreman.spec
@@ -6,8 +6,6 @@
 %global plugin_name foreman
 
 %global release 1
-%global prereleasesource pre.develop
-%global prerelease %{?prereleasesource:.}%{?prereleasesource}
 
 %{!?_root_sysconfdir:%global _root_sysconfdir %{_sysconfdir}}
 %global hammer_confdir %{_root_sysconfdir}/hammer
@@ -26,7 +24,7 @@ Requires: %{?scl_prefix_ruby}ruby(release)
 Requires: %{?scl_prefix_ruby}ruby
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
 Requires: %{?scl_prefix}rubygem(hammer_cli) >= 2.1.0
-Requires: %{?scl_prefix}rubygem(apipie-bindings) >= 0.3.0
+Requires: %{?scl_prefix}rubygem(apipie-bindings) >= 0.5.0
 Requires: %{?scl_prefix}rubygem(rest-client) >= 1.8.0
 Requires: %{?scl_prefix}rubygem(rest-client) < 3.0.0
 Requires: %{?scl_prefix}rubygem(jwt) >= 2.2.1
@@ -99,6 +97,9 @@ install -m 0644 .%{gem_instdir}/config/%{plugin_name}.yml \
 %{gem_instdir}/test
 
 %changelog
+* Tue May 10 2022 Oleh Fedorenko <ofedoren@redhat.com> - 3.3.0-1
+- Release rubygem-hammer_cli_foreman 3.3.0
+
 * Thu Feb 10 2022 Zach Huntington-Meath <zhunting@redhat.com> - 3.3.0-0.1.pre.develop
 - Bump version to 3.3-develop
 


### PR DESCRIPTION
Needs ~https://github.com/theforeman/foreman-packaging/pull/7879~ https://github.com/theforeman/foreman-packaging/pull/7886.

Supported Versions:

 * Nightly
 * 3.3