### PR TITLE
Fixes #34896 - properly detect default_program in k-c-h

### DIFF
--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -17,12 +17,14 @@ module KatelloUtilities
 
     def initialize(init_options)
       @last_scenario = self.last_scenario
-      @default_program = self.get_default_program
+
       @proxy = init_options.fetch(:proxy)
       @plural_proxy = init_options.fetch(:plural_proxy)
       @proxy_hyphenated = init_options.fetch(:proxy_hyphenated)
       @command_prefix = init_options.fetch(:command_prefix)
       @accepted_scenarios = init_options.fetch(:accepted_scenarios, nil)
+
+      @default_program = self.get_default_program
 
       @options = {}
       @options[:program] = init_options.fetch(:program, @default_program)

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,7 +5,7 @@
 %global confdir common
 %global prereleasesource master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 1
+%global release 2
 
 Name:       katello
 Version:    4.6.0
@@ -132,6 +132,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Fri May 13 2022 Evgeni Golov - 4.6.0-0.2.master
+- Fixes #34896 - properly detect default_program in k-c-h
+
 * Thu May 12 2022 Partha Aji <paji@redhat.com> 4.6.0-0.1.master
 - bump for 4.6
 


### PR DESCRIPTION
`get_default_program` needs `@proxy_hyphenated` to be properly defined
to work, so it needs to be called *after* the option parse block

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
