### PR TITLE
Fixes#34927 - incorrect argument error handling in katello-change-hos…

### DIFF
--- a/packages/katello/katello/hostname-change.rb
+++ b/packages/katello/katello/hostname-change.rb
@@ -292,7 +292,12 @@ If not done, all hosts will lose connection to #{@options[:scenario]} and discov
           exit
         end
       end
-      @opt_parser.parse!
+      begin
+        @opt_parser.parse!
+      rescue OptionParser::InvalidOption => error
+        self.fail_with_message("#{error}", @opt_parser)
+        exit
+      end
     end
 
     def dns_managed?

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,7 +5,7 @@
 %global confdir common
 %global prereleasesource master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 2
+%global release 3
 
 Name:       katello
 Version:    4.6.0
@@ -132,6 +132,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Tue May 17 2022 Nagoor Shaik <nshaik@redhat.com> - 4.6.0-0.3.master
+- Incorrect argument error handling in katello-change-hostname
+
 * Fri May 13 2022 Evgeni Golov - 4.6.0-0.2.master
 - Fixes #34896 - properly detect default_program in k-c-h
 


### PR DESCRIPTION
Error handling code added in `katello-change-hostname`

Before Patch
~~~
# katello-change-hostname --username admin --password changeme --hostname rhsat.example.com
/usr/share/katello/hostname-change.rb:293:in `setup_opt_parser': invalid option: --hostname (OptionParser::InvalidOption)
    from /usr/share/katello/hostname-change.rb:33:in `initialize'
    from /usr/sbin/satellite-change-hostname:20:in `new'
    from /usr/sbin/satellite-change-hostname:20:in `<main>'
~~~


After
~~~
# katello-change-hostname --username admin --password changeme --hostname rhsat.example.com
invalid option: --hostname
usage: katello-change-hostname hostname [options]

example:
katello-change-hostname newhost.example.com -u admin -p changeme

options
    -u, --username username          admin username (required)
    -p, --password password          admin password (required)
    -y, --assumeyes                  answer yes for all questions
        --skip-dns                   skip updating DNS records even if they are managed by satellite
    -h, --help                       help

~~~

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
