### PR TITLE
automatically set revision to 1 when bumping packages

### DIFF
--- a/scripts/changelog.rb
+++ b/scripts/changelog.rb
@@ -47,6 +47,8 @@ ARGV.each do |path|
     version = "#{current_version}-#{current_release.to_i + 1}"
   end
 
+  version += '-1' unless version.include?('-')
+
   logs = File.read(path)
   entry = "#{project} (#{version}) stable; urgency=low\n\n"
   options[:message].each { |m| entry += "  * #{m}\n" }


### PR DESCRIPTION
Fixes: 4810c1de51c9c1b198e275abf2cc971348c241f2

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
