### PR TITLE
Add katello-pull-transport-migrate RPM

### DIFF
--- a/comps/comps-foreman-client-el8.xml
+++ b/comps/comps-foreman-client-el8.xml
@@ -16,6 +16,7 @@
       <packagereq type="default">katello-agent</packagereq>
       <packagereq type="default">katello-host-tools</packagereq>
       <packagereq type="default">katello-host-tools-tracer</packagereq>
+      <packagereq type="default">katello-pull-transport-migrate</packagereq>
       <packagereq type="default">python3-gofer</packagereq>
       <packagereq type="default">python3-gofer-proton</packagereq>
       <packagereq type="default">python3-qpid-proton</packagereq>

--- a/comps/comps-foreman-client-rhel7.xml
+++ b/comps/comps-foreman-client-rhel7.xml
@@ -17,6 +17,7 @@
       <packagereq type="default">katello-host-tools</packagereq>
       <packagereq type="default">katello-host-tools-fact-plugin</packagereq>
       <packagereq type="default">katello-host-tools-tracer</packagereq>
+      <packagereq type="default">katello-pull-transport-migrate</packagereq>
       <packagereq type="default">python-gofer</packagereq>
       <packagereq type="default">python-gofer-proton</packagereq>
       <packagereq type="default">python2-psutil</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -753,6 +753,7 @@ foreman_client_packages:
     foreman_ygg_worker: {}
     gofer: {}
     katello-host-tools: {}
+    katello-pull-transport-migrate: {}
     python-psutil: {}
     rubygem-foreman_scap_client: {}
     tracer: {}

--- a/packages/client/katello-pull-transport-migrate/katello-pull-transport-migrate-1.0.1.tar.gz
+++ b/packages/client/katello-pull-transport-migrate/katello-pull-transport-migrate-1.0.1.tar.gz
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/G3/g9/SHA256E-s25716--72751d53a93cbb9ffecbad54865f5c69cfdb38c055bee3ef9ce2dcdf6f22b430.tar.gz/SHA256E-s25716--72751d53a93cbb9ffecbad54865f5c69cfdb38c055bee3ef9ce2dcdf6f22b430.tar.gz

--- a/packages/client/katello-pull-transport-migrate/katello-pull-transport-migrate.spec
+++ b/packages/client/katello-pull-transport-migrate/katello-pull-transport-migrate.spec
@@ -1,0 +1,40 @@
+Name:           katello-pull-transport-migrate
+Version:        1.0.1
+Release:        1%{?dist}
+Summary:        An RPM that migrates katello-agent users to the new pull transport
+BuildArch:      noarch
+
+License:        LGPLv2
+URL:            https://github.com/theforeman/foreman-packaging/tree/rpm/develop/packages/client/katello-pull-transport-migrate
+Source0:        https://github.com/theforeman/%{name}/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+
+Requires:       yggdrasil
+Requires:       foreman_ygg_worker
+
+%description
+An RPM that migrates katello-agent users to the new pull transport.
+
+Relies on the existing Red Hat Subscription Manager configuration to know which Katello server it should communicate with.
+The scriptlet will fail if the client is not registered to a Foreman server with the Katello plugin.
+This RPM obtains the relevant values from the existing RHSM configuration, writes the configuration to yggdrasil's config.toml,
+and starts the pull transport agent.
+
+%prep
+%setup -q
+
+%build
+
+%install
+mkdir -p  %{buildroot}%{_sbindir}
+cp %{name} %{buildroot}%{_sbindir}
+
+%post
+SYSCONFDIR=%{_sysconfdir} SBINDIR=%{_sbindir} %{_sbindir}/%{name}
+
+%files
+%{_sbindir}/%{name}
+%license LICENSE.md
+
+%changelog
+* Wed May 25 2022 Eric D. Helms <ericdhelms@gmail.com> - 1.0.1-1
+- Release 1.0.1

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -980,6 +980,7 @@ whitelist =
   gofer
   jsoncpp
   katello-host-tools
+  katello-pull-transport-migrate
   python-psutil
   qpid-proton
   rubygem-foreman_scap_client
@@ -992,6 +993,7 @@ disttag = .el7
 whitelist =
   foreman_ygg_worker
   katello-host-tools
+  katello-pull-transport-migrate
   python-psutil
   rubygem-foreman_scap_client
   tracer


### PR DESCRIPTION
The intended workflow for this RPM is to take a katello-agent connected host and turn it into a pull transport connected host. This can be done either manually or through a katello-agent triggered package installation. This does not currently turn off or cleanup katello-agent.

However, I wonder if it should? If the intent is to convert, why leave a dangling katello-agent around? If so, I think this RPM could obsolete katello-agent?
