### PR TITLE
Updated hammer_cli_foreman_webhooks to 0.0.4

### DIFF
--- a/dependencies/bullseye/hammer_cli_foreman_webhooks/changelog
+++ b/dependencies/bullseye/hammer_cli_foreman_webhooks/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-webhooks (0.0.4-1) stable; urgency=low
+
+  * 0.0.4 released
+
+ -- Evgeni Golov <evgeni@debian.org>  Tue, 18 Oct 2022 10:44:53 +0200
+
 ruby-hammer-cli-foreman-webhooks (0.0.3-1) stable; urgency=low
 
   * 0.0.3 released

--- a/dependencies/bullseye/hammer_cli_foreman_webhooks/changelog
+++ b/dependencies/bullseye/hammer_cli_foreman_webhooks/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-webhooks (0.0.3-1) stable; urgency=low
+
+  * 0.0.3 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Wed, 01 Jun 2022 13:41:29 +0000
+
 ruby-hammer-cli-foreman-webhooks (0.0.2-1) UNRELEASED; urgency=medium
 
   * Initial release

--- a/dependencies/focal/hammer_cli_foreman_webhooks/changelog
+++ b/dependencies/focal/hammer_cli_foreman_webhooks/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-webhooks (0.0.4-1) stable; urgency=low
+
+  * 0.0.4 released
+
+ -- Evgeni Golov <evgeni@debian.org>  Tue, 18 Oct 2022 10:44:53 +0200
+
 ruby-hammer-cli-foreman-webhooks (0.0.3-1) stable; urgency=low
 
   * 0.0.3 released

--- a/dependencies/focal/hammer_cli_foreman_webhooks/changelog
+++ b/dependencies/focal/hammer_cli_foreman_webhooks/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-webhooks (0.0.3-1) stable; urgency=low
+
+  * 0.0.3 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Wed, 01 Jun 2022 13:41:29 +0000
+
 ruby-hammer-cli-foreman-webhooks (0.0.2-1) UNRELEASED; urgency=medium
 
   * Initial release


### PR DESCRIPTION
Supported Versions:

 * Nightly
 * 3.3