### PR TITLE
Update rubygem-pulpcore_client to 3.18.5

### DIFF
--- a/packages/katello/rubygem-pulpcore_client/pulpcore_client-3.17.7.gem
+++ b/packages/katello/rubygem-pulpcore_client/pulpcore_client-3.17.7.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/MJ/f4/SHA256E-s124416--2cdeb8de3cb2f32860060daa2769100b4aaf7f66a07f27f6d06939e18fe9b4d0.7.gem/SHA256E-s124416--2cdeb8de3cb2f32860060daa2769100b4aaf7f66a07f27f6d06939e18fe9b4d0.7.gem

--- a/packages/katello/rubygem-pulpcore_client/pulpcore_client-3.18.5.gem
+++ b/packages/katello/rubygem-pulpcore_client/pulpcore_client-3.18.5.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/Xw/vV/SHA256E-s129536--38dc46eab58a027c8985387ba87a91fb60b58d506ecd1b9c938dda5e92782dd8.5.gem/SHA256E-s129536--38dc46eab58a027c8985387ba87a91fb60b58d506ecd1b9c938dda5e92782dd8.5.gem

--- a/packages/katello/rubygem-pulpcore_client/rubygem-pulpcore_client.spec
+++ b/packages/katello/rubygem-pulpcore_client/rubygem-pulpcore_client.spec
@@ -6,7 +6,7 @@
 %global gem_name pulpcore_client
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 3.17.7
+Version: 3.18.5
 Release: 1%{?dist}
 Epoch: 1
 Summary: Pulp 3 API Ruby Gem
@@ -100,6 +100,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Wed May 18 2022 ianballou <ianballou67@gmail.com> 1:3.18.5-1
+- Update to 3.18.5
+
 * Thu Apr 21 2022 ianballou <ianballou67@gmail.com> 1:3.17.7-1
 - Update to 3.17.7
 


### PR DESCRIPTION
Updates pulpcore_client to 3.18.5. Don't merge until the Katello 4.5.0 gemspec asks for pulpcore_client 3.18 (https://github.com/Katello/katello/blob/KATELLO-4.5/katello.gemspec#L57)