### PR TITLE
Split lines at most 2 times

### DIFF
--- a/list_updatable_packages
+++ b/list_updatable_packages
@@ -32,7 +32,7 @@ class Spec:
     def template(self) -> Optional[str]:
         for line in self.lines:
             if line.startswith('# template:'):
-                _, _, template = line.split(None, 3)
+                _, _, template = line.split(None, 2)
                 return template
 
         return None
@@ -46,7 +46,7 @@ class Spec:
             self._globals = {}
             for line in self.lines:
                 if line.startswith('%global'):
-                    definition, name, value = line.split(None, 3)
+                    definition, name, value = line.split(None, 2)
                     if definition == '%global':
                         self._globals[name] = value
 


### PR DESCRIPTION
In Ruby split wants the number of resulting values while Python wants
the amount of times to split. Or in other words

```
>>> "# template: mytemplate".split(None, 2)
['#', 'template:', 'mytemplate']
>>> '%global %mymacro "Something with spaces"'.split(None, 2)
['%global', '%mymacro', '"Something with spaces"']
```