### PR TITLE
Enable building directly through Koji CLI

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -11,6 +11,7 @@ all:
 packages:
   vars:
     rpmlint_rc_file: "{{ inventory_dir }}/.rpmlintrc"
+    build_package_use_koji_build: true
   children:
     foreman_packages: {}
     plugin_packages: {}


### PR DESCRIPTION
This drops the need for use of tito to handle building scratch or
release builds of RPMs and uses Koji directly through the CLI in Obal
commands. This will allow dropping the tito functionality and relying
on the package manifest as the source for all configuration and
for doing invidualized builds based on tag. This also paves the way
to make tagging of existing builds a part of the workflow.

Requires:

- [x] https://github.com/theforeman/obal/pull/303
- [x] https://github.com/theforeman/obal/pull/272