### PR TITLE
Introduce an exceptions and default template for naming

### DIFF
--- a/gem2rpm/base.spec.erb
+++ b/gem2rpm/base.spec.erb
@@ -1,0 +1,153 @@
+<%-
+require 'json'
+root = `git rev-parse --show-toplevel`.strip
+LICENSES = JSON.load(File.read(File.join(root, 'licenses.json')))
+
+config.rules[:doc] << /\/?CHANGES/
+config.rules[:doc] << 'sample'
+config.rules[:doc] << /\/?SECURITY/
+
+config.rules[:ignore] << 'Guardfile'
+config.rules[:ignore] << '.document'
+config.rules[:ignore] << 'Appraisals'
+config.rules[:ignore] << 'gemfiles'
+config.rules[:ignore] << 'appveyor.yml'
+config.rules[:ignore] << 'TODO'
+config.rules[:ignore] << 'web'
+config.rules[:ignore] << '.github'
+config.rules[:ignore] << '.ruby-version'
+config.rules[:ignore] << '.coveralls.yml'
+-%>
+%global gem_name <%= spec.name %>
+<% unless spec.extensions.empty? -%>
+%global gem_require_name %{gem_name}
+<% end -%>
+
+Name: rubygem-%{gem_name}
+Version: <%= spec.version %>
+Release: 1%{?dist}
+Summary: <%= spec.summary.gsub(/\.$/, "") %>
+Group: Development/Languages
+License: <%= spec.licenses.empty? ? 'FIXME' : spec.licenses.map { |l| LICENSES.fetch(l, l) }.join(" and ") %>
+<% if spec.homepage -%>
+URL: <%= spec.homepage.gsub('http://', 'https://') %>
+<% end -%>
+Source0: <%= download_path %>%{gem_name}-%{version}.gem
+
+# start specfile generated dependencies
+<% for req in spec.required_ruby_version -%>
+Requires: ruby<%= " #{req}" unless req.empty? %>
+<% end -%>
+<% for req in spec.required_ruby_version -%>
+BuildRequires: <%= requirement "ruby#{'-devel' unless spec.extensions.empty?}", req %>
+<% end -%>
+<% for req in spec.required_rubygems_version -%>
+BuildRequires: <%= requirement 'rubygems-devel', req %>
+<% end -%>
+<% unless spec.extensions.empty? -%>
+<% for dep in runtime_dependencies.virtualize -%>
+<% for req in dep.requirement -%>
+BuildRequires: <%= requirement(dep.name, req) %>
+<% end -%>
+<% end -%>
+# Compiler is required for build of gem binary extension.
+# https://fedoraproject.org/wiki/Packaging:C_and_C++#BuildRequires_and_Requires
+BuildRequires: gcc
+<% end -%>
+<% if spec.extensions.empty? -%>
+BuildArch: noarch
+<% end -%>
+# end specfile generated dependencies
+
+%description
+<%= spec.description %>
+
+<% if doc_subpackage -%>
+%package doc
+Summary: Documentation for %{name}
+Group: Documentation
+Requires: %{name} = %{version}-%{release}
+BuildArch: noarch
+
+%description doc
+Documentation for %{name}.
+<% end # if doc_subpackage -%>
+
+%prep
+gem unpack %{SOURCE0}
+
+%setup -q -D -T -n  %{gem_name}-%{version}
+
+gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
+
+%build
+# Create the gem as gem install only works on a gem file
+gem build %{gem_name}.gemspec
+
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
+# by default, so that we can move it into the buildroot in %%install
+%gem_install
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -a .%{gem_dir}/* \
+        %{buildroot}%{gem_dir}/
+
+<% unless spec.extensions.empty? -%>
+mkdir -p %{buildroot}%{gem_extdir_mri}/%{gem_name}
+cp -a .%{gem_extdir_mri}/gem.build_complete %{buildroot}%{gem_extdir_mri}/
+cp -a .%{gem_extdir_mri}/%{gem_name}/*.so %{buildroot}%{gem_extdir_mri}/%{gem_name}
+
+<% for ext in spec.extensions -%>
+# Prevent dangling symlink in -debuginfo (rhbz#878863).
+rm -rf %{buildroot}%{gem_instdir}/<%= ext.split(File::SEPARATOR).first %>/
+<% end -%>
+
+<% end -%>
+<% unless spec.executables.empty? -%>
+mkdir -p %{buildroot}%{_bindir}
+cp -a .%{_bindir}/* \
+        %{buildroot}%{_bindir}/
+find %{buildroot}%{gem_instdir}/<%= spec.bindir %> -type f | xargs chmod a+x
+
+<% end -%>
+<% unless spec.extensions.empty? -%>
+%check
+# Ideally, this would be something like this:
+# GEM_PATH="%{buildroot}%{gem_dir}:$GEM_PATH" ruby -e "require '%{gem_require_name}'"
+# But that fails to find native extensions on EL8, so we fake the structure that ruby expects
+mkdir gem_ext_test
+cp -a %{buildroot}%{gem_dir} gem_ext_test/
+mkdir -p gem_ext_test/gems/extensions/%{_arch}-%{_target_os}/$(ruby -r rbconfig -e 'print RbConfig::CONFIG["ruby_version"]')/
+cp -a %{buildroot}%{gem_extdir_mri} gem_ext_test/gems/extensions/%{_arch}-%{_target_os}/$(ruby -r rbconfig -e 'print RbConfig::CONFIG["ruby_version"]')/
+GEM_PATH="./gem_ext_test/gems:$GEM_PATH" ruby -e "require '%{gem_require_name}'"
+rm -rf gem_ext_test
+
+<% end -%>
+%files
+%dir %{gem_instdir}
+<% unless spec.executables.nil? or spec.executables.empty? -%>
+<% for f in spec.executables -%>
+%{_bindir}/<%= f %>
+<% end -%>
+<% end -%>
+<% unless spec.extensions.empty? -%>
+%{gem_extdir_mri}
+<% end -%>
+<%= main_files.reject do |item|
+  spec.extensions.detect { |extension| item =~ /^#{extension.split(File::SEPARATOR).first}$/}
+end.to_rpm %>
+<% unless doc_subpackage -%>
+%doc %{gem_docdir}
+<%= doc_files.to_rpm %>
+<% end -%>
+%exclude %{gem_cache}
+%{gem_spec}
+
+<% if doc_subpackage -%>
+%files doc
+%doc %{gem_docdir}
+<%= doc_files.to_rpm %>
+<% end # if doc_subpackage -%>
+
+%changelog

--- a/gem2rpm/exception.spec.erb
+++ b/gem2rpm/exception.spec.erb
@@ -1,2 +1,2 @@
-# template: default
+# template: exceptions
 <%= File.read(File.join(__dir__, '/gem2rpm/base.spec.erb')) %>


### PR DESCRIPTION
This is a bit of a thought experiment better shown in code. Where we could use the template naming property to identify if a package is generated with the default and thereby safe to regenerate or if a package has exceptions and is generated with the exceptions template. That could then enable our code to choose whether to regenerate or not based upon the template name.


I'll note, as I played with this I also started thinking about using this approach for common fragments across the templates to align them. For example, across the templates the `%prep`, `%build`, `%install` are the same, the doc sub-package definition as well. Thus we could do things like:

```
<%= File.read(File.join(__dir__, '/gem2rpm/section/build.erb')) %>
<%= File.read(File.join(__dir__, '/gem2rpm/section/doc_subpackage.erb')) %>
```
