### PR TITLE
Update REMOVE instructions to be current

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,15 +200,10 @@ the location of your packages.
 ## HOWTO: removing a package
 
 1. `git rm -r rubygem-example/`
-1. Remove all entries (both main package and doc) from `comps/` and
-   `rel-eng/tito.props`
-1. Add an `Obsoletes` entry to `tfm/tfm.spec` for `< Version-(Release+1)`
-   if the package is a dependency in either core or plugin repos
-1. On merge, untag all builds from nightly Koji tags (`untag-build --all`),
-   block the package (`block-pkg`) and rebuild `tfm` if applicable
-
-Leave the rel-eng/packages/ file in place so a permanent record of the last EVR
-is kept.
+1. Remove all entries (both main package and doc) from `package_manifest.yaml`,
+   `comps/` and `rel-eng/tito.props`
+1. On merge, untag all builds from nightly Koji tags (`untag-build --all`) and
+   block the package (`block-pkg`)
 
 ## How does this repo work?
 


### PR DESCRIPTION
The tfm package was EL7 only and is gone. The rel-eng/packages is long gone too. However, it should also be removed from the package manifest.