### PR TITLE
set non-empty sender address

### DIFF
--- a/.github/workflows/bump_packages.yml
+++ b/.github/workflows/bump_packages.yml
@@ -68,7 +68,7 @@ jobs:
         server_port: 25
         subject: "foreman-packaging update RPM packages Github Action failed"
         to: ci@community.theforeman.org
-        from: Github Actions
+        from: Foreman Github Actions <github@theforeman.org>
         body: |
           foreman-packaging update RPM packages Github Action failed
 
@@ -120,7 +120,7 @@ jobs:
         server_port: 25
         subject: "foreman-packaging update Debian packages Github Action failed"
         to: ci@community.theforeman.org
-        from: Github Actions
+        from: Foreman Github Actions <github@theforeman.org>
         body: |
           foreman-packaging update Debian packages Github Action failed
 


### PR DESCRIPTION
discourse doesn't like mail w/o from address

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
