### PR TITLE
send one notification if bumping failed

### DIFF
--- a/.github/workflows/bump_packages.yml
+++ b/.github/workflows/bump_packages.yml
@@ -60,19 +60,6 @@ jobs:
         title: "Update ${{ matrix.package_name }} to ${{ matrix.new_version }}"
         body: ''
         delete-branch: true
-    - name: Send email to Discourse on failure
-      if: failure()
-      uses: dawidd6/action-send-mail@v3
-      with:
-        server_address: community.theforeman.org
-        server_port: 25
-        subject: "foreman-packaging update RPM packages Github Action failed"
-        to: ci@community.theforeman.org
-        from: Foreman Github Actions <github@theforeman.org>
-        body: |
-          foreman-packaging update RPM packages Github Action failed
-
-          $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
 
   deb_list:
     name: 'Gather debs'
@@ -112,16 +99,24 @@ jobs:
         title: "Update ${{ matrix.package_name }} to ${{ matrix.new_version }}"
         body: ''
         delete-branch: true
+
+  report:
+    name: Report failure to Discourse
+    needs:
+      - bump_plugin_deb
+      - bump_rpm
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
     - name: Send email to Discourse on failure
-      if: failure()
       uses: dawidd6/action-send-mail@v3
       with:
         server_address: community.theforeman.org
         server_port: 25
-        subject: "foreman-packaging update Debian packages Github Action failed"
+        subject: "foreman-packaging update packages Github Action failed"
         to: ci@community.theforeman.org
         from: Foreman Github Actions <github@theforeman.org>
         body: |
-          foreman-packaging update Debian packages Github Action failed
+          foreman-packaging update packages Github Action failed
 
-          $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+          ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}


### PR DESCRIPTION
also correct the link to actually render properly

based on the example in https://docs.github.com/en/actions/learn-github-actions/contexts#example-usage-of-the-needs-context

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
