### PR TITLE
Add smart-proxy into dependency calculation

### DIFF
--- a/list_updatable_packages
+++ b/list_updatable_packages
@@ -13,6 +13,7 @@ import tempfile
 SUPPORTED_TEMPLATES = ('foreman_plugin', 'hammer_plugin', 'smart_proxy_plugin')
 SESSION = requests.Session()
 FOREMAN_GEMFILE_LOCK_URL = 'https://ci.theforeman.org/job/foreman-develop-source-release/lastSuccessfulBuild/artifact/Gemfile.lock'
+FOREMAN_PROXY_GEMFILE_LOCK_URL = 'https://ci.theforeman.org/job/smart-proxy-develop-source-release/lastSuccessfulBuild/artifact/Gemfile.lock'
 KATELLO_GEMFILE_LOCK_URL = 'https://ci.theforeman.org/job/katello-master-source-release/lastSuccessfulBuild/artifact/Gemfile.lock'
 DEBUG = (len(sys.argv) == 2 and sys.argv[1] == 'debug')
 
@@ -97,6 +98,8 @@ def fetch_gemfile_lock(project: str) -> str:
         url = FOREMAN_GEMFILE_LOCK_URL
     elif project == 'katello':
         url = KATELLO_GEMFILE_LOCK_URL
+    elif project == 'foreman-proxy':
+        url = FOREMAN_PROXY_GEMFILE_LOCK_URL
     else:
         raise RuntimeError(f'Do not know how to fetch Gemfile.lock for project ({project})')
 
@@ -162,9 +165,10 @@ def build_dependency_matrix(gems: dict, project: str='foreman') -> Generator[dic
 def main() -> None:
     foreman_dependencies = list(build_dependency_matrix(gems=parse_gemfile_lock('foreman'), project='foreman'))
     katello_dependencies = list(build_dependency_matrix(gems=parse_gemfile_lock('katello'), project='katello'))
+    foreman_proxy_dependencies = list(build_dependency_matrix(gems=parse_gemfile_lock('foreman-proxy'), project='foreman'))
     plugins = list(build_plugin_matrix(find_specs()))
 
-    matrix = plugins + foreman_dependencies + katello_dependencies
+    matrix = plugins + foreman_dependencies + katello_dependencies + foreman_proxy_dependencies
 
     if 'GITHUB_ACTION' in os.environ:
         directories = [entry['directory'] for entry in matrix]


### PR DESCRIPTION
At the time of this update here is the list, this shows it would catch the sinatra / mustermann issue:

```
ackages/foreman/rubygem-faraday 1.10.0
packages/foreman/rubygem-google-apis-compute_v1 0.44.0
packages/foreman/rubygem-google-apis-monitoring_v3 0.31.0
packages/foreman/rubygem-representable 3.2.0
packages/foreman/rubygem-rest-client 2.1.0
packages/katello/rubygem-katello 4.6.0.pre.master
packages/katello/rubygem-pulp_ostree_client 2.0.0a7.dev1658981930
packages/foreman/rubygem-gssapi 1.3.1
packages/foreman/rubygem-jwt 2.4.1
packages/foreman/rubygem-mustermann 2.0.2
packages/foreman/rubygem-rack-test 2.0.2
packages/foreman/rubygem-rake-compiler 1.2.0
packages/foreman/rubygem-redfish_client 0.5.4
packages/foreman/rubygem-rubyipmi 0.11.1
packages/foreman/rubygem-server_sent_events 0.1.3
packages/foreman/rubygem-sinatra 2.2.2
packages/foreman/rubygem-unicode-display_width 1.6.1
packages/foreman/rubygem-xmlrpc 0.3.2
packages/foreman/rubygem-clamp 1.3.0
packages/foreman/rubygem-faraday 0.17.5
packages/foreman/rubygem-fast_gettext 1.1.2
packages/foreman/rubygem-gettext 3.2.9
packages/foreman/rubygem-hashie 5.0.0
packages/foreman/rubygem-unicode-display_width 1.6.1
```