### PR TITLE
Drop PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,0 @@
-For plugin updates, please indicate which repos this should be built into:
-
-* Nightly
-
-See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-
----


### PR DESCRIPTION
It is now requested to submit PRs to the correct branches, rather than relying on the maintainers to build it into multiple branches. That means the template is meaningless and only adds noise.