### PR TITLE
Fetch gems for Ruby platform when adding

### DIFF
--- a/add_gem_package.sh
+++ b/add_gem_package.sh
@@ -15,7 +15,7 @@ generate_gem_package() {
 	fi
 	mkdir $PACKAGE_DIR
 	pushd $PACKAGE_DIR
-	GEM_FILE_NAME=( $( gem fetch $GEM_NAME -q ${GEM_VERSION:+-v $GEM_VERSION} ) ) # the output of gem fetch is "Downloaded foo-1.2.3" we need to extract only the second word
+	GEM_FILE_NAME=( $( gem fetch $GEM_NAME -q ${GEM_VERSION:+-v $GEM_VERSION} --platform=ruby ) ) # the output of gem fetch is "Downloaded foo-1.2.3" we need to extract only the second word
 	gem2rpm -o $SPEC_FILE "${GEM_FILE_NAME[1]}.gem" -t $TEMPLATE
 	sed -i 's/\s\+$//' $SPEC_FILE
 	git annex add *.gem


### PR DESCRIPTION
This avoids downloading Linux optimized versions, which we can't deal with.

Taken from https://github.com/fedora-ruby/gem2rpm/issues/97