### PR TITLE
Warn about conflicts in updating spec files

### DIFF
--- a/list_updatable_packages
+++ b/list_updatable_packages
@@ -22,7 +22,7 @@ class Spec:
         self.path = path
         spec = path.read_text()
         self.lines = spec.splitlines()
-        self._globals = None
+        self._globals: Optional[dict] = None
 
     @property
     def directory(self) -> str:
@@ -61,7 +61,7 @@ class Spec:
         return 'prereleasesource' in self.globals
 
     @property
-    def gem_name(self) -> str:
+    def gem_name(self) -> Optional[str]:
         return self.globals.get('gem_name')
 
     @property
@@ -77,7 +77,7 @@ def find_specs() -> Generator[Spec, None, None]:
         if spec.template in SUPPORTED_TEMPLATES and not spec.is_nightly:
             yield spec
 
-def parse_gemfile_lock(project: str) -> dict:
+def parse_gemfile_lock(project: str) -> list[dict]:
     gemfile_lock = fetch_gemfile_lock(project)
 
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -136,7 +136,7 @@ def build_plugin_matrix(specs: Iterable[Spec]) -> Generator[dict, None, None]:
                 }
                 yield entry
 
-def build_dependency_matrix(gems: dict, project: str='foreman') -> Generator[dict, None, None]:
+def build_dependency_matrix(gems: list[dict], project: str='foreman') -> Generator[dict, None, None]:
     if DEBUG: print(f'Building dependency matrix for {project}')
     for gem in gems:
         name = gem['name']

--- a/list_updatable_packages
+++ b/list_updatable_packages
@@ -67,6 +67,12 @@ class Spec:
         cmd = ['rpmspec', '--srpm', '--query', '--queryformat=%{version}', self.path.as_posix()]
         return subprocess.check_output(cmd, stderr=subprocess.DEVNULL, universal_newlines=True)
 
+    def __eq__(self, other):
+        return self.path == other.path
+
+    def __hash__(self):
+        return hash(self.path)
+
 
 def find_gemfile_lock_specs(ci_job: str, subdir: str) -> Generator[Tuple[Spec, str], None, None]:
     """
@@ -124,8 +130,27 @@ def latest_version(spec: Spec) -> str:
     raise ValueError('Unable to determine latest version', spec)
 
 
-def build_matrix(specs: Iterable[Tuple[Spec, Optional[str]]]) -> Generator[dict, None, None]:
+def merge_specs(specs: Iterable[Tuple[Spec, Optional[str]]]) -> dict[Spec, Optional[str]]:
+    """
+    Merge specs
+
+    This can process the same spec file multiple times. If a spec is already listed but without a
+    version, it will take the more specific constraint. The last entry is used if a constraint was
+    already given while a warning is printed.
+    """
+    result: dict[Spec, Optional[str]] = {}
     for spec, new_version in specs:
+        if result.get(spec) not in (None, new_version):
+            # TODO: GH annotation?
+            print(f'Found conflict for {spec.package_name}: {result[spec]} != {new_version}', file=sys.stderr)
+            result[spec] = 'CONFLICT'
+        else:
+            result[spec] = new_version
+    return result
+
+
+def build_matrix(specs: dict[Spec, Optional[str]]) -> Generator[dict, None, None]:
+    for spec, new_version in specs.items():
         try:
             current_version = spec.version
         except subprocess.CalledProcessError as e:  # pylint: disable=invalid-name
@@ -153,7 +178,7 @@ def main() -> None:
         find_gemfile_lock_specs('katello-master-source-release', 'katello'),
     )
 
-    matrix = list(build_matrix(specs))
+    matrix = list(build_matrix(merge_specs(specs)))
 
     if 'GITHUB_ACTION' in os.environ:
         directories = [entry['directory'] for entry in matrix]

--- a/list_updatable_packages
+++ b/list_updatable_packages
@@ -4,17 +4,15 @@ import json
 import os
 import subprocess
 import sys
+from itertools import chain
 from pathlib import Path
-from typing import Generator, Iterable, Mapping, Optional
+from typing import Generator, Iterable, Mapping, Optional, Tuple
 
 import requests
 import tempfile
 
 SUPPORTED_TEMPLATES = ('foreman_plugin', 'hammer_plugin', 'smart_proxy_plugin')
 SESSION = requests.Session()
-FOREMAN_GEMFILE_LOCK_URL = 'https://ci.theforeman.org/job/foreman-develop-source-release/lastSuccessfulBuild/artifact/Gemfile.lock'
-FOREMAN_PROXY_GEMFILE_LOCK_URL = 'https://ci.theforeman.org/job/smart-proxy-develop-source-release/lastSuccessfulBuild/artifact/Gemfile.lock'
-KATELLO_GEMFILE_LOCK_URL = 'https://ci.theforeman.org/job/katello-master-source-release/lastSuccessfulBuild/artifact/Gemfile.lock'
 DEBUG = (len(sys.argv) == 2 and sys.argv[1] == 'debug')
 
 class Spec:
@@ -70,16 +68,32 @@ class Spec:
         return subprocess.check_output(cmd, stderr=subprocess.DEVNULL, universal_newlines=True)
 
 
-def find_specs() -> Generator[Spec, None, None]:
+def find_gemfile_lock_specs(ci_job: str, subdir: str) -> Generator[Tuple[Spec, str], None, None]:
+    """
+    Find all specs based on what's in the bundler lockfile. This Gemfile.lock is retrieved from
+    the last successful build in CI.
+    """
+    url = f'https://ci.theforeman.org/job/{ci_job}/lastSuccessfulBuild/artifact/Gemfile.lock'
+    base_path = Path('packages') / subdir
+
+    for gem in parse_gemfile_lock(fetch_gemfile_lock(url)):
+        package_name = f'rubygem-{gem["name"]}'
+        path = base_path / package_name / f'{package_name}.spec'
+        if path.is_file():
+            spec = Spec(path)
+            if not spec.is_nightly:
+                yield spec, gem['version']
+
+
+def find_packaged_specs() -> Generator[Tuple[Spec, None], None, None]:
     if DEBUG: print('Finding plugin specs')
     for path in Path('packages').glob('*/*/*.spec'):
         spec = Spec(path)
         if spec.template in SUPPORTED_TEMPLATES and not spec.is_nightly:
-            yield spec
+            yield spec, None
 
-def parse_gemfile_lock(project: str) -> list[dict]:
-    gemfile_lock = fetch_gemfile_lock(project)
 
+def parse_gemfile_lock(gemfile_lock: str) -> list[dict]:
     with tempfile.TemporaryDirectory() as tmpdirname:
         with open(f'{tmpdirname}/Gemfile.lock', 'w') as fp:
             fp.write(gemfile_lock)
@@ -87,26 +101,19 @@ def parse_gemfile_lock(project: str) -> list[dict]:
         with open(f'{tmpdirname}/Gemfile', 'w') as fp:
             pass
 
-        if DEBUG: print(f'Parsing Gemfile.lock for {project}')
+        if DEBUG: print('Parsing Gemfile.lock')
         script = Path(__file__).absolute().parent / 'parse-gemfile-lock'
         return json.loads(subprocess.check_output([script], universal_newlines=True, cwd=tmpdirname))
 
     return {}
 
-def fetch_gemfile_lock(project: str) -> str:
-    if project == 'foreman':
-        url = FOREMAN_GEMFILE_LOCK_URL
-    elif project == 'katello':
-        url = KATELLO_GEMFILE_LOCK_URL
-    elif project == 'foreman-proxy':
-        url = FOREMAN_PROXY_GEMFILE_LOCK_URL
-    else:
-        raise RuntimeError(f'Do not know how to fetch Gemfile.lock for project ({project})')
 
-    if DEBUG: print(f'Fetching Gemfile.lock for {project}')
+def fetch_gemfile_lock(url) -> str:
+    if DEBUG: print(f'Fetching Gemfile.lock from {url}')
     response = SESSION.get(url)
     response.raise_for_status()
     return response.text
+
 
 def latest_version(spec: Spec) -> str:
     if spec.gem_name:
@@ -117,15 +124,16 @@ def latest_version(spec: Spec) -> str:
     raise ValueError('Unable to determine latest version', spec)
 
 
-def build_plugin_matrix(specs: Iterable[Spec]) -> Generator[dict, None, None]:
-    if DEBUG: print('Building plugin matrix')
-    for spec in specs:
+def build_matrix(specs: Iterable[Tuple[Spec, Optional[str]]]) -> Generator[dict, None, None]:
+    for spec, new_version in specs:
         try:
             current_version = spec.version
         except subprocess.CalledProcessError as e:  # pylint: disable=invalid-name
             print('Failed to determine version for', spec.path.as_posix(), str(e), file=sys.stderr)
         else:
-            new_version = latest_version(spec)
+            if not new_version:
+                new_version = latest_version(spec)
+
             if current_version != new_version:
                 entry = {
                     'directory': spec.directory,
@@ -136,43 +144,16 @@ def build_plugin_matrix(specs: Iterable[Spec]) -> Generator[dict, None, None]:
                 }
                 yield entry
 
-def build_dependency_matrix(gems: list[dict], project: str='foreman') -> Generator[dict, None, None]:
-    if DEBUG: print(f'Building dependency matrix for {project}')
-    for gem in gems:
-        name = gem['name']
-        path = Path('packages') / project / f'rubygem-{name}' / f'rubygem-{name}.spec'
-        if path.is_file():
-            spec = Spec(path)
-
-            if spec.is_nightly:
-                continue
-
-            try:
-                current_version = spec.version
-            except subprocess.CalledProcessError as e:  # pylint: disable=invalid-name
-                print('Failed to determine version for', spec.path.as_posix(), str(e), file=sys.stderr)
-            except FileNotFoundError as e:
-                print(f'No path for dependency found: {name}', spec.path.as_posix(), str(e), file=sys.stderr)
-            else:
-                new_version = gem['version']
-                if current_version != new_version:
-                    entry = {
-                        'directory': spec.directory,
-                        'package_name': spec.package_name,
-                        'gem_name': spec.gem_name,
-                        'current_version': current_version,
-                        'new_version': new_version,
-                    }
-                    yield entry
-
 
 def main() -> None:
-    foreman_dependencies = list(build_dependency_matrix(gems=parse_gemfile_lock('foreman'), project='foreman'))
-    katello_dependencies = list(build_dependency_matrix(gems=parse_gemfile_lock('katello'), project='katello'))
-    foreman_proxy_dependencies = list(build_dependency_matrix(gems=parse_gemfile_lock('foreman-proxy'), project='foreman'))
-    plugins = list(build_plugin_matrix(find_specs()))
+    specs = chain(
+        find_packaged_specs(),
+        find_gemfile_lock_specs('foreman-develop-source-release', 'foreman'),
+        find_gemfile_lock_specs('smart-proxy-develop-source-release', 'foreman'),
+        find_gemfile_lock_specs('katello-master-source-release', 'katello'),
+    )
 
-    matrix = plugins + foreman_dependencies + katello_dependencies + foreman_proxy_dependencies
+    matrix = list(build_matrix(specs))
 
     if 'GITHUB_ACTION' in os.environ:
         directories = [entry['directory'] for entry in matrix]


### PR DESCRIPTION
This rewrites the code to deal with lock files in order to handle all sources equally. This allows merging them and warning about conflicts. Currently that's:

```
Found conflict for rubygem-jwt: 2.2.3 != 2.4.1
Found conflict for rubygem-rack-test: 1.1.0 != 2.0.2
Found conflict for rubygem-unicode-display_width: 1.8.0 != 1.6.1
```