### PR TITLE
explicitly vendor sinatra

### DIFF
--- a/debian/bullseye/foreman/changelog
+++ b/debian/bullseye/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (3.5.0-2) stable; urgency=low
+
+  * explicitly vendor sinatra
+
+ -- Evgeni Golov <evgeni@debian.org>  Thu, 18 Aug 2022 14:14:39 +0200
+
 foreman (3.5.0-1) stable; urgency=low
 
   * Bump changelog to 3.5.0 to match VERSION

--- a/debian/bullseye/foreman/rules
+++ b/debian/bullseye/foreman/rules
@@ -22,6 +22,10 @@ build:
 	/bin/cp config/dynflow/worker.yml.example config/dynflow/worker.yml
 	/bin/mkdir -p ./vendor/cache
 	echo 'gem "thor", "1.1.0"' >> Gemfile
+	# rack-protection and sinatra have to be the same version
+	# foreman pulls in rack-protection via sidekiq, f-tasks needs sinatra
+	# let foreman.deb provide both gems in the cache, so that they always match
+	echo 'gem "sinatra"' >> bundler.d/debian.rb
 	/bin/rm -f bundler.d/test.rb bundler.d/development.rb
 	/bin/sed -i '2i  gem "puma-status"' bundler.d/service.rb
 	$(BUNDLE) install

--- a/debian/focal/foreman/changelog
+++ b/debian/focal/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (3.5.0-2) stable; urgency=low
+
+  * explicitly vendor sinatra
+
+ -- Evgeni Golov <evgeni@debian.org>  Thu, 18 Aug 2022 14:14:39 +0200
+
 foreman (3.5.0-1) stable; urgency=low
 
   * Bump changelog to 3.5.0 to match VERSION

--- a/debian/focal/foreman/rules
+++ b/debian/focal/foreman/rules
@@ -22,6 +22,10 @@ build:
 	/bin/cp config/dynflow/worker.yml.example config/dynflow/worker.yml
 	/bin/mkdir -p ./vendor/cache
 	echo 'gem "thor", "1.1.0"' >> Gemfile
+	# rack-protection and sinatra have to be the same version
+	# foreman pulls in rack-protection via sidekiq, f-tasks needs sinatra
+	# let foreman.deb provide both gems in the cache, so that they always match
+	echo 'gem "sinatra"' >> bundler.d/debian.rb
 	/bin/rm -f bundler.d/test.rb bundler.d/development.rb
 	/bin/sed -i '2i  gem "puma-status"' bundler.d/service.rb
 	$(BUNDLE) install


### PR DESCRIPTION
rack-protection and sinatra have to be the same version
foreman pulls in rack-protection via sidekiq, f-tasks needs sinatra
let foreman.deb provide both gems in the cache, so that they always match

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
