### PR TITLE
Use rich dependencies when updating dependencies

### DIFF
--- a/get-gemfile-deps
+++ b/get-gemfile-deps
@@ -10,8 +10,29 @@ EXCLUDED_REQUIRES = {
   'Requires' => ['activerecord-nulldb-adapter']
 }
 
-def package(gem)
-  return "rubygem(#{gem})"
+def build_requirement(dependency)
+  name = "rubygem(#{dependency.name})"
+
+  requirements = []
+
+  dependency.requirement.requirements.each do |op, version|
+    if op == '~>'
+      requirements << "#{name} >= #{version}" << "#{name} < #{version.bump}.0"
+    elsif op == '>=' && version.to_s == '0'
+      # handled later
+    elsif op != '!=' # != is not supported in RPM
+      requirements << "#{name} #{op} #{version}"
+    end
+  end
+
+  case requirements.length
+  when 0
+    name
+  when 1
+    requirements.first
+  else
+    "(#{requirements.join(' with ')})"
+  end
 end
 
 unless File.file?(filename)
@@ -33,20 +54,7 @@ bundler.dependencies.each do |dependency|
       next if EXCLUDED_REQUIRES[req].include?(dependency.name)
 
       requires[group][req] = [] unless requires[group].key?(req)
-
-      target = requires[group][req]
-      name = package(dependency.name)
-
-      dependency.requirement.requirements.each do |op, version|
-        if op == '~>'
-          target << "#{name} >= #{version}"
-          target << "#{name} < #{version.bump}.0"
-        elsif op == '>=' && version.to_s == '0'
-          target << name
-        elsif op != '!=' # != is not supported in RPM
-          target << "#{name} #{op} #{version}"
-        end
-      end
+      requires[group][req] << build_requirement(dependency)
     end
   end
 end

--- a/update-requirements
+++ b/update-requirements
@@ -46,8 +46,12 @@ def get_requirement(version):
 def get_requirements(dependencies, fmt, excludes):
     for package, version in sorted(dependencies.items()):
         if not is_excluded(package, excludes):
-            for requirement in get_requirement(version):
-                yield fmt.format(package, requirement)
+            name = f"npm({package})"
+            requirements = [f'{name} {requirement}' for requirement in get_requirement(version)]
+            if len(requirements) > 1:
+                yield fmt.format(f'({" with ".join(requirements)})')
+            else:
+                yield fmt.format(requirements[0])
 
 
 def get_npm_sections(packages, excludes):
@@ -55,7 +59,7 @@ def get_npm_sections(packages, excludes):
         for requires in ('BuildRequires', 'Requires'):
             trigger = '{} {}\n'.format(section, requires)
             deps = packages.get(section, {})
-            requirements = list(get_requirements(deps, requires + ': npm({}) {}\n', excludes))
+            requirements = list(get_requirements(deps, requires + ': {}\n', excludes))
             yield trigger, requirements
 
 


### PR DESCRIPTION
Now that EL 7 has been dropped, rich dependencies can be used. This not only makes specs easier to read, they are also more accurate.

Also adds a commit that updates foreman, foreman-proxy and rubygem-katello. The SCL compatibility is also dropped since the new dependencies don't have SCL macros either. Partial SCL compatibility can only lead to confusion and bugs.

This is still a draft since the gem2rpm template doesn't generate rich dependencies yet.