### PR TITLE
Refs #35418 - Depend on websockify if needed

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -4,7 +4,7 @@
 %global dynflow_sidekiq_service_name dynflow-sidekiq@
 %global rake /usr/bin/rake
 
-%global release 5
+%global release 6
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -338,6 +338,7 @@ Requires: rubygem(ruby-libvirt) < 1.0
 # end specfile libvirt Requires
 Requires: %{name} = %{version}-%{release}
 Requires: genisoimage
+Requires: python3-websockify
 Obsoletes: foreman-virt < 1.0.0
 Provides: foreman-virt = 1.0.0
 
@@ -370,6 +371,7 @@ Requires: rubygem(fog-ovirt) >= 2.0.1
 Requires: rubygem(fog-ovirt) < 3
 # end specfile ovirt Requires
 Requires: %{name} = %{version}-%{release}
+Requires: python3-websockify
 
 %description ovirt
 Meta package to install requirements for oVirt compute resource support.
@@ -402,6 +404,7 @@ Requires: rubygem(rbvmomi) >= 2.0
 Requires: rubygem(rbvmomi) < 3.0
 # end specfile vmware Requires
 Requires: %{name} = %{version}-%{release}
+Requires: python3-websockify
 
 %description vmware
 Meta package to install requirements for VMware compute resource support.
@@ -1008,6 +1011,9 @@ exit 0
 %systemd_postun %{name}.socket
 
 %changelog
+* Mon Aug 29 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.5.0-0.6.develop
+- Depend on websockify if needed
+
 * Sat Aug 27 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.5.0-0.5.develop
 - Update rails-i18n dependency
 


### PR DESCRIPTION
Websockify used to be vendored to show a console for some compute
resources:

    $ rg -i wsproxy.start -l
    app/models/compute_resources/foreman/model/ovirt.rb
    app/models/compute_resources/foreman/model/vmware.rb
    app/models/compute_resources/foreman/model/libvirt.rb

Now it's using a proper package.

Currently a draft since the change in core should still go in. This is just to show what needs to be done later. We should also import the websockify package. Today it's in EPEL8, but we want to be able to run without EPEL.