### PR TITLE
Refs #29539 - Unbundle websockify

### DIFF
--- a/comps/comps-foreman-el8.xml
+++ b/comps/comps-foreman-el8.xml
@@ -121,6 +121,7 @@
       <packagereq type="default">puppet-agent-rgen</packagereq>
       <packagereq type="default">puppet-agent-yard</packagereq>
       <packagereq type="default">python3-keycloak-httpd-client-install</packagereq>
+      <packagereq type="default">python3-websockify</packagereq>
       <packagereq type="default">rubygem-actioncable</packagereq>
       <packagereq type="default">rubygem-actionmailbox</packagereq>
       <packagereq type="default">rubygem-actionmailer</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -108,6 +108,7 @@ foreman_core_packages:
     foreman-bootloaders-redhat: {}
     keycloak-httpd-client-install: {}
     pcp-mmvstatsd: {}
+    python-websockify: {}
     rubygem-activerecord-nulldb-adapter: {}
     rubygem-activerecord-session_store: {}
     rubygem-addressable: {}

--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -4,7 +4,7 @@
 %global dynflow_sidekiq_service_name dynflow-sidekiq@
 %global rake /usr/bin/rake
 
-%global release 6
+%global release 7
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -334,6 +334,7 @@ Requires: rubygem(ruby-libvirt) < 1.0
 # end specfile libvirt Requires
 Requires: %{name} = %{version}-%{release}
 Requires: genisoimage
+Requires: python3-websockify
 Obsoletes: foreman-virt < 1.0.0
 Provides: foreman-virt = 1.0.0
 
@@ -366,6 +367,7 @@ Requires: rubygem(fog-ovirt) >= 2.0.1
 Requires: rubygem(fog-ovirt) < 3
 # end specfile ovirt Requires
 Requires: %{name} = %{version}-%{release}
+Requires: python3-websockify
 
 %description ovirt
 Meta package to install requirements for oVirt compute resource support.
@@ -398,6 +400,7 @@ Requires: rubygem(rbvmomi) >= 2.0
 Requires: rubygem(rbvmomi) < 3.0
 # end specfile vmware Requires
 Requires: %{name} = %{version}-%{release}
+Requires: python3-websockify
 
 %description vmware
 Meta package to install requirements for VMware compute resource support.
@@ -703,11 +706,6 @@ webpack --bail --config config/webpack.config.js
 rm db/schema.rb
 
 %install
-%if 0%{?fedora} || 0%{?rhel} >= 8
-sed -i 's|#!/usr/bin/python|#!/usr/bin/python3|g' extras/noVNC/*.py
-sed -i 's|#!/usr/bin/env python|#!/usr/bin/python3|g' extras/noVNC/websockify/*.py
-%endif
-
 rm -rf %{buildroot}
 
 #install man pages
@@ -1004,6 +1002,9 @@ exit 0
 %systemd_postun %{name}.socket
 
 %changelog
+* Tue Aug 30 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.5.0-0.7.develop
+- Depend on websockify if needed
+
 * Mon Aug 29 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.5.0-0.6.develop
 - Update Gem and NPM dependencies
 

--- a/packages/foreman/python-websockify/python-websockify.spec
+++ b/packages/foreman/python-websockify/python-websockify.spec
@@ -1,0 +1,189 @@
+%global pkgname websockify
+%global summary WSGI based adapter for the Websockets protocol
+Name:           python-%{pkgname}
+Version:        0.10.0
+Release:        3%{?dist}
+Summary:        %{summary}
+
+License:        LGPLv3
+URL:            https://github.com/novnc/websockify
+Source0:        %{url}/archive/v%{version}/websockify-%{version}.tar.gz
+BuildArch:      noarch
+
+%description
+Python WSGI based adapter for the Websockets protocol
+
+%package -n python3-%{pkgname}
+Summary:        %{summary} - Python 3 version
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+
+Requires:       python3-setuptools
+
+%{?python_provide:%python_provide python3-%{pkgname}}
+
+%description -n python3-%{pkgname}
+Python WSGI based adapter for the Websockets protocol - Python 3 version
+
+%package doc
+Summary:        %{summary} - documentation
+
+%description doc
+Python WSGI based adapter for the Websockets protocol - documentation
+
+%prep
+%autosetup -n %{pkgname}-%{version}
+
+# TODO: Have the following handle multi line entries
+# numpy is listed as install_requires in setup.py however it is optional
+sed -i '/setup_requires/d; /install_requires/d; /dependency_links/d' setup.py
+
+%build
+%py3_build
+
+%install
+%py3_install
+
+rm -Rf %{buildroot}/usr/share/websockify
+mkdir -p %{buildroot}%{_mandir}/man1/
+install -m 444 docs/websockify.1 %{buildroot}%{_mandir}/man1/
+
+%files -n python3-%{pkgname}
+%license COPYING
+%{_mandir}/man1/websockify.1*
+%{python3_sitelib}/websockify/
+%{python3_sitelib}/websockify-%{version}-py%{python3_version}.egg-info
+%{_bindir}/websockify
+
+%files doc
+%license COPYING
+%doc docs
+
+%changelog
+* Fri Jul 22 2022 Fedora Release Engineering <releng@fedoraproject.org> - 0.10.0-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_37_Mass_Rebuild
+
+* Mon Jun 13 2022 Python Maint <python-maint@redhat.com> - 0.10.0-2
+- Rebuilt for Python 3.11
+
+* Fri Feb 04 2022 Neal Gompa <ngompa@fedoraproject.org> - 0.10.0-1
+- Update to 0.10.0
+
+* Fri Jan 21 2022 Fedora Release Engineering <releng@fedoraproject.org> - 0.9.0-7
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_36_Mass_Rebuild
+
+* Fri Jul 23 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.9.0-6
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_35_Mass_Rebuild
+
+* Fri Jun 04 2021 Python Maint <python-maint@redhat.com> - 0.9.0-5
+- Rebuilt for Python 3.10
+
+* Wed Jan 27 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.9.0-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_34_Mass_Rebuild
+
+* Wed Jul 29 2020 Fedora Release Engineering <releng@fedoraproject.org> - 0.9.0-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_33_Mass_Rebuild
+
+* Tue May 26 2020 Miro Hrončok <mhroncok@redhat.com> - 0.9.0-2
+- Rebuilt for Python 3.9
+
+* Thu Mar 26 2020 Yatin Karel <ykarel@redhat.com> - 0.9.0-1
+- Update to 0.9.0 (Resolves #1816608)
+
+* Thu Jan 30 2020 Fedora Release Engineering <releng@fedoraproject.org> - 0.8.0-16
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_32_Mass_Rebuild
+
+* Thu Oct 03 2019 Miro Hrončok <mhroncok@redhat.com> - 0.8.0-15
+- Rebuilt for Python 3.8.0rc1 (#1748018)
+
+* Mon Aug 19 2019 Miro Hrončok <mhroncok@redhat.com> - 0.8.0-14
+- Rebuilt for Python 3.8
+
+* Sun Aug 11 2019 Miro Hrončok <mhroncok@redhat.com> - 0.8.0-13
+- Subpackage python2-websockify has been removed
+  See https://fedoraproject.org/wiki/Changes/Mass_Python_2_Package_Removal
+
+* Fri Jul 26 2019 Fedora Release Engineering <releng@fedoraproject.org> - 0.8.0-12
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
+
+* Sat Feb 02 2019 Fedora Release Engineering <releng@fedoraproject.org> - 0.8.0-11
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_30_Mass_Rebuild
+
+* Sat Jul 14 2018 Fedora Release Engineering <releng@fedoraproject.org> - 0.8.0-10
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_29_Mass_Rebuild
+
+* Tue Jun 19 2018 Miro Hrončok <mhroncok@redhat.com> - 0.8.0-9
+- Rebuilt for Python 3.7
+
+* Fri Feb 16 2018 2018 Lumír Balhar <lbalhar@redhat.com> - 0.8.0-8
+- Fix directory ownership
+
+* Fri Feb 09 2018 Fedora Release Engineering <releng@fedoraproject.org> - 0.8.0-7
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_28_Mass_Rebuild
+
+* Thu Jul 27 2017 Fedora Release Engineering <releng@fedoraproject.org> - 0.8.0-6
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Mass_Rebuild
+
+* Sat Feb 11 2017 Fedora Release Engineering <releng@fedoraproject.org> - 0.8.0-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_26_Mass_Rebuild
+
+* Mon Dec 19 2016 Miro Hrončok <mhroncok@redhat.com> - 0.8.0-4
+- Rebuild for Python 3.6
+
+* Mon Aug 29 2016 Jan Beran <jberan@redhat.com> - 0.8.0-3
+- Python 3 subpackage
+
+* Tue Jul 19 2016 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.8.0-2
+- https://fedoraproject.org/wiki/Changes/Automatic_Provides_for_Python_RPM_Packages
+
+* Fri Feb 19 2016 Solly Ross <sross@redhat.com> - 0.8.0-1
+- Update to release 0.8.0
+
+* Thu Feb 04 2016 Fedora Release Engineering <releng@fedoraproject.org> - 0.6.0-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_24_Mass_Rebuild
+
+* Thu Jun 18 2015 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.6.0-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_23_Mass_Rebuild
+
+* Wed Apr 29 2015 Pádraig Brady <pbrady@redhat.com> - 0.6.0-2
+- Support big endian systems - rhbz#1216219
+
+* Mon Mar 23 2015 Nikola Đipanov <ndipanov@redhat.com> - 0.6.0-1
+- Update to release 0.6.0
+
+* Sun Jun 08 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.5.1-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_21_Mass_Rebuild
+
+* Tue Sep 10 2013 Nikola Đipanov <ndipanov@redhat.com> - 0.5.1-1
+- Update to release 0.5.1
+
+* Sun Aug 04 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.4.1-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_20_Mass_Rebuild
+
+* Thu Jun 20 2013 Pádraig Brady <P@draigBrady.com> - 0.4.1-1
+- Update to release 0.4.1
+
+* Tue Mar 12 2013 Pádraig Brady <P@draigBrady.com> - 0.2.0-4
+- Add runtime dependency on setuptools
+
+* Thu Feb 14 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.2.0-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_19_Mass_Rebuild
+
+* Wed Oct 31 2012 Pádraig Brady <P@draigBrady.com> - 0.2.0-2
+- Remove hard dependency on numpy
+
+* Mon Oct 22 2012 Nikola Đipanov <ndipanov@redhat.com> - 0.2.0-1
+- Moving to the upstream version 0.2.0
+
+* Sat Jul 21 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.1.0-6
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_18_Mass_Rebuild
+
+* Wed Jun 6 2012 Adam Young <ayoung@redhat.com> - 0.1.0-4
+- Added Description
+- Added Manpage
+
+* Fri May 11 2012 Matthias Runge <mrunge@matthias-runge.de> - 0.1.0-2
+- spec cleanup
+
+* Thu May 10 2012 Adam Young <ayoung@redhat.com> - 0.1.0-1
+- Initial RPM release.

--- a/packages/foreman/python-websockify/websockify-0.10.0.tar.gz
+++ b/packages/foreman/python-websockify/websockify-0.10.0.tar.gz
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/M9/J4/SHA256E-s53402--7bd99b727e0be230f6f47f65fbe4bd2ae8b2aa3568350148bdf5cf440c4c6b4a.tar.gz/SHA256E-s53402--7bd99b727e0be230f6f47f65fbe4bd2ae8b2aa3568350148bdf5cf440c4c6b4a.tar.gz

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -106,6 +106,7 @@ whitelist = dynflow-utils
   puppet-agent-puppet-strings
   puppet-agent-rgen
   puppet-agent-yard
+  python-websockify
   rubygem-actioncable
   rubygem-actionmailbox
   rubygem-actionmailer


### PR DESCRIPTION
This reflects the removal of a bundled websockify in favor of a system package. While it is in EPEL8 (and the spec is copied from that), Foreman doesn't support running with EPEL8 enabled.

Draft until the core PR is merged: https://github.com/theforeman/foreman/pull/9392