### PR TITLE
Refs #29539 - Depend on websockify if needed

### DIFF
--- a/debian/bullseye/foreman/control
+++ b/debian/bullseye/foreman/control
@@ -92,7 +92,7 @@ Package: foreman-libvirt
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman (= ${binary:Version}), pkg-config, libvirt-dev, ${misc:Depends}
+Depends: foreman (= ${binary:Version}), python3-websockify, pkg-config, libvirt-dev, ${misc:Depends}
 Recommends: genisoimage
 Description: metapackage providing libvirt dependencies for Foreman
  This package provides libvirt dependencies for Foreman, a
@@ -115,7 +115,7 @@ Package: foreman-ovirt
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman (= ${binary:Version}), libcurl4-openssl-dev, libxml2-dev, ${misc:Depends}
+Depends: foreman (= ${binary:Version}), python3-websockify, libcurl4-openssl-dev, libxml2-dev, ${misc:Depends}
 Description: metapackage providing ovirt dependencies for Foreman
  This package provides ovirt dependencies for Foreman, a
  flexible systems management web application.
@@ -137,7 +137,7 @@ Package: foreman-vmware
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman (= ${binary:Version}), ${misc:Depends}
+Depends: foreman (= ${binary:Version}), python3-websockify, ${misc:Depends}
 Description: metapackage providing vmware dependencies for Foreman
  This package provides vmware dependencies for Foreman, a
  flexible systems management web application.

--- a/debian/focal/foreman/control
+++ b/debian/focal/foreman/control
@@ -92,7 +92,7 @@ Package: foreman-libvirt
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman (= ${binary:Version}), pkg-config, libvirt-dev, ${misc:Depends}
+Depends: foreman (= ${binary:Version}), python3-websockify, pkg-config, libvirt-dev, ${misc:Depends}
 Recommends: genisoimage
 Description: metapackage providing libvirt dependencies for Foreman
  This package provides libvirt dependencies for Foreman, a
@@ -115,7 +115,7 @@ Package: foreman-ovirt
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman (= ${binary:Version}), libcurl4-openssl-dev, libxml2-dev, ${misc:Depends}
+Depends: foreman (= ${binary:Version}), python3-websockify, libcurl4-openssl-dev, libxml2-dev, ${misc:Depends}
 Description: metapackage providing ovirt dependencies for Foreman
  This package provides ovirt dependencies for Foreman, a
  flexible systems management web application.
@@ -137,7 +137,7 @@ Package: foreman-vmware
 Architecture: all
 Section: web
 Priority: extra
-Depends: foreman (= ${binary:Version}), ${misc:Depends}
+Depends: foreman (= ${binary:Version}), python3-websockify, ${misc:Depends}
 Description: metapackage providing vmware dependencies for Foreman
  This package provides vmware dependencies for Foreman, a
  flexible systems management web application.


### PR DESCRIPTION
Websockify used to be vendored to show a console for some compute resources:

```console
$ rg -i wsproxy.start -l
app/models/compute_resources/foreman/model/ovirt.rb
app/models/compute_resources/foreman/model/vmware.rb
app/models/compute_resources/foreman/model/libvirt.rb
```

Now it's using a proper package.

Draft until the core PR is merged: https://github.com/theforeman/foreman/pull/9392