### PR TITLE
Remove jsoncpp and qpid-proton from f-client-el9

### DIFF
--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -507,11 +507,9 @@ whitelist =
   foreman-release
   foreman_ygg_worker
   gofer
-  jsoncpp
   katello-host-tools
   katello-pull-transport-migrate
   python-psutil
-  qpid-proton
   rubygem-foreman_scap_client
   tracer
   yggdrasil


### PR DESCRIPTION
These packages are allowed to by built in koji so this change aligns the git repo with koji.

It still leaves 2 issues I'm unsure how to deal with:

# Packages not expected in foreman-plugins-nightly-el8
 * [x] yggdrasil
```shell
koji remove-pkg foreman-plugins-nightly-el8 yggdrasil
```

This package is also in the client tools. Is it intentional that it's in both plugins and client?

# Packages not expected in foreman-client-nightly-rhel7
 * [x] gofer
```shell
koji remove-pkg foreman-client-nightly-rhel7 gofer
```

I don't know the status of this either.