### PR TITLE
Define a nightly macro with a nightly githash as input

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -12,6 +12,9 @@ packages:
   vars:
     rpmlint_rc_file: "{{ inventory_dir }}/.rpmlintrc"
     build_package_use_koji_build: true
+    macros:
+      foremandist: "{{ foremandist }}"
+      nightly: "{{ '.' + lookup('pipe', 'date +%Y%m%d%H%M%S') + 'git' + nightly_githash[:7] if nightly_githash is defined else omit }}"
   children:
     foreman_packages: {}
     plugin_packages: {}
@@ -25,8 +28,7 @@ foreman_packages:
     koji_tags:
       - name: "foreman-{{ foreman_version }}-el8"
         dist: '.el8'
-        macros:
-          foremandist: "{{ foremandist }}"
+        macros: "{{ macros }}"
     releasers:
       - koji-foreman
     nightly_releaser: koji-foreman-jenkins
@@ -53,8 +55,7 @@ plugin_packages:
     koji_tags:
       - name: "foreman-plugins-{{ foreman_version }}-el8"
         dist: '.el8'
-        macros:
-          foremandist: "{{ foremandist }}"
+        macros: "{{ macros }}"
     releasers:
       - koji-foreman-plugins
     nightly_releaser: koji-foreman-plugins-jenkins
@@ -544,8 +545,7 @@ katello_packages:
     koji_tags:
       - name: "katello-{{ katello_version }}-el8"
         dist: '.el8'
-        macros:
-          foremandist: "{{ foremandist }}"
+        macros: "{{ macros }}"
     releasers:
       - koji-katello
     nightly_releaser: koji-katello-jenkins


### PR DESCRIPTION
Requires https://github.com/theforeman/obal/pull/320 to work, as this allows us to define and control the nightly macro here in the project itself and allow Obal to be more generic.

Currently we run `obal nightly` on actual nightly jobs but `obal release` for packaging PRs, these have disjointed workflows and `obal nightly` (https://github.com/theforeman/obal/blob/master/obal/data/playbooks/nightly/nightly.yaml) is trying to do a lot that is not required anymore; it was working around tito whereas with tito out of the picture we have more direct control and methods.

This will allow us in our CI to simply set `-e nightly_githash=whateverweant` and it will get incorporated into the SRPM. Example: http://koji.katello.org/koji/taskinfo?taskID=530916
