### PR TITLE
Fixes #35461 - Require /usr/sbin/sendmail to be available

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -4,7 +4,7 @@
 %global dynflow_sidekiq_service_name dynflow-sidekiq@
 %global rake /usr/bin/rake
 
-%global release 7
+%global release 8
 %global prereleasesource rc2
 %global prerelease %{?prereleasesource}
 
@@ -30,6 +30,8 @@ Requires: rubygem(bundler_ext)
 Requires: wget
 Requires: /etc/cron.d
 Requires: gawk
+Requires: /usr/sbin/sendmail
+
 Requires(pre):  shadow-utils
 Requires(post): systemd-sysv
 Requires(post): systemd-units
@@ -1010,6 +1012,9 @@ exit 0
 %systemd_postun %{name}.socket
 
 %changelog
+* Wed Aug 31 2022 Evgeni Golov - 3.4.0-0.8.rc2
+- Fixes #35461 - Require /usr/sbin/sendmail to be available
+
 * Thu Aug 25 2022 Patrick Creech <pcreech@redhat.com> - 3.4.0-0.7.rc2
 - Release foreman 3.4.0rc2
 


### PR DESCRIPTION
Foreman uses sendmail as the default mail handler, but modern systems
might not have it available by default.

Only depend on the path, not an explicit package, as there might be
different packages providing a sendmail binary (e.g. on EL8 there are at
least Postfix and Sendmail doing so).

(cherry picked from commit 0869b371150b168693470a9cc96a038ed657d8db)

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
