### PR TITLE
Fixes #35461 - Require /usr/sbin/sendmail to be available

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -9,7 +9,7 @@
 %global scl_ruby_bin /usr/bin/%{?scl:%{scl_prefix}}ruby
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 1
+%global release 2
 
 Name:    foreman
 Version: 3.3.0
@@ -46,6 +46,8 @@ Requires: %{scl}-runtime < 8
 Requires: wget
 Requires: /etc/cron.d
 Requires: gawk
+Requires: /usr/sbin/sendmail
+
 Requires(pre):  shadow-utils
 Requires(post): chkconfig
 Requires(post): systemd-sysv
@@ -1047,6 +1049,9 @@ exit 0
 %systemd_postun %{name}.socket
 
 %changelog
+* Wed Aug 31 2022 Evgeni Golov - 3.3.0-2
+- Fixes #35461 - Require /usr/sbin/sendmail to be available
+
 * Thu Jun 09 2022 Odilon Sousa <osousa@redhat.com> - 3.3.0-1
 - Release foreman 3.3.0
 


### PR DESCRIPTION
Foreman uses sendmail as the default mail handler, but modern systems
might not have it available by default.

Only depend on the path, not an explicit package, as there might be
different packages providing a sendmail binary (e.g. on EL8 there are at
least Postfix and Sendmail doing so).

(cherry picked from commit 0869b371150b168693470a9cc96a038ed657d8db)

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
