### PR TITLE
Depend on /usr/bin/websockify instead of the python package

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -4,7 +4,7 @@
 %global dynflow_sidekiq_service_name dynflow-sidekiq@
 %global rake /usr/bin/rake
 
-%global release 8
+%global release 9
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -336,7 +336,7 @@ Requires: rubygem(ruby-libvirt) < 1.0
 # end specfile libvirt Requires
 Requires: %{name} = %{version}-%{release}
 Requires: genisoimage
-Requires: python3-websockify
+Requires: /usr/bin/websockify
 Obsoletes: foreman-virt < 1.0.0
 Provides: foreman-virt = 1.0.0
 
@@ -369,7 +369,7 @@ Requires: rubygem(fog-ovirt) >= 2.0.1
 Requires: rubygem(fog-ovirt) < 3
 # end specfile ovirt Requires
 Requires: %{name} = %{version}-%{release}
-Requires: python3-websockify
+Requires: /usr/bin/websockify
 
 %description ovirt
 Meta package to install requirements for oVirt compute resource support.
@@ -402,7 +402,7 @@ Requires: rubygem(rbvmomi) >= 2.0
 Requires: rubygem(rbvmomi) < 3.0
 # end specfile vmware Requires
 Requires: %{name} = %{version}-%{release}
-Requires: python3-websockify
+Requires: /usr/bin/websockify
 
 %description vmware
 Meta package to install requirements for VMware compute resource support.
@@ -1004,6 +1004,9 @@ exit 0
 %systemd_postun %{name}.socket
 
 %changelog
+* Fri Sep 02 2022 Eric D. Helms <ericdhelms@gmail.com> - 3.5.0-0.9.develop
+- Depend on /usr/bin/websockify
+
 * Wed Aug 31 2022 Evgeni Golov - 3.5.0-0.8.develop
 - Fixes #35461 - Require /usr/sbin/sendmail to be available
 


### PR DESCRIPTION
On EL 8 and above, python packages often get built with the version
of python they were built against in the name of the package. This
prevents having to update the spec file everytime websockify package
changes.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
