### PR TITLE
Only run package bumping on theforeman

### DIFF
--- a/.github/workflows/bump_packages.yml
+++ b/.github/workflows/bump_packages.yml
@@ -13,6 +13,7 @@ jobs:
   rpm_list:
     name: 'Gather RPMs'
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'theforeman'
     outputs:
       matrix: ${{ steps.set_list.outputs.matrix }}
     steps:
@@ -64,6 +65,7 @@ jobs:
   deb_list:
     name: 'Gather debs'
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'theforeman'
     outputs:
       matrix: ${{ steps.set_list.outputs.matrix }}
     steps:


### PR DESCRIPTION
Otherwise forks also run the same, which is wasting a lot of resources and sending failure messages to Discourse.