### PR TITLE
Make REX depend on Foreman >=3.4.0

### DIFF
--- a/plugins/ruby-foreman-remote-execution/debian/control
+++ b/plugins/ruby-foreman-remote-execution/debian/control
@@ -2,15 +2,15 @@ Source: ruby-foreman-remote-execution
 Section: ruby
 Priority: extra
 Maintainer: Stephen Benjamin <stephen@redhat.com>
-Build-Depends: debhelper (>= 8.0.0), git | git-core, foreman-assets (>= 3.2.0~rc1), foreman (>= 3.2.0~rc1),
-  foreman-nulldb (>= 3.2.0~rc1), ruby-foreman-tasks (>= 5.1.0), ruby-foreman-deface, python-dev,
+Build-Depends: debhelper (>= 8.0.0), git | git-core, foreman-assets (>= 3.4.0~rc1), foreman (>= 3.4.0~rc1),
+  foreman-nulldb (>= 3.4.0~rc1), ruby-foreman-tasks (>= 5.1.0), ruby-foreman-deface, python-dev,
   ruby-dynflow (>= 1.0.2), ruby-dynflow (< 2.0.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_remote_execution
 
 Package: ruby-foreman-remote-execution
 Architecture: all
-Depends: ${misc:Depends}, bundler, foreman (>= 3.2.0~rc1), ruby-foreman-tasks (>= 5.1.0),
+Depends: ${misc:Depends}, bundler, foreman (>= 3.4.0~rc1), ruby-foreman-tasks (>= 5.1.0),
   ruby-foreman-deface, ruby-dynflow (>= 1.0.2), ruby-dynflow (< 2.0.0)
 Description: Foreman Remote Execution Plugin
   A plugin bringing remote execution to the Foreman, completing the config management functionality with remote management functionality


### PR DESCRIPTION
https://github.com/theforeman/foreman-packaging/pull/8294 updated REX version but did not bump the dependency on Foreman
