### PR TITLE
Update ruby-smart-proxy-remote-execution-ssh to 0.8.0

### DIFF
--- a/plugins/smart_proxy_remote_execution_ssh/changelog
+++ b/plugins/smart_proxy_remote_execution_ssh/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-remote-execution-ssh (0.8.0-1) stable; urgency=low
+
+  * 0.8.0 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Sun, 28 Aug 2022 04:32:43 +0000
+
 ruby-smart-proxy-remote-execution-ssh (0.7.0) stable; urgency=low
 
   * 0.7.0 released

--- a/plugins/smart_proxy_remote_execution_ssh/remote_execution_ssh.rb
+++ b/plugins/smart_proxy_remote_execution_ssh/remote_execution_ssh.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_remote_execution_ssh', '0.7.0'
+gem 'smart_proxy_remote_execution_ssh', '0.8.0'


### PR DESCRIPTION
(cherry picked from commit bb61ee89b83bc2146bb66612dfc540cf17d7aef5)
