### PR TITLE
Fixes #35543 - Explicitly vendor sinatra in Foreman

### DIFF
--- a/plugins/ruby-foreman-tasks/debian/changelog
+++ b/plugins/ruby-foreman-tasks/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-tasks (7.0.0-2) stable; urgency=low
+
+  * Use foreman-plugin.mk
+
+ -- Evgeni Golov <evgeni@debian.org>  Thu, 18 Aug 2022 11:38:03 +0200
+
 ruby-foreman-tasks (7.0.0-1) stable; urgency=low
 
   * 7.0.0 released

--- a/plugins/ruby-foreman-tasks/debian/changelog
+++ b/plugins/ruby-foreman-tasks/debian/changelog
@@ -1,6 +1,7 @@
 ruby-foreman-tasks (7.0.0-2) stable; urgency=low
 
   * Use foreman-plugin.mk
+  * don't vendor sinatra and its gems, this is now provided by foreman
 
  -- Evgeni Golov <evgeni@debian.org>  Thu, 18 Aug 2022 11:38:03 +0200
 

--- a/plugins/ruby-foreman-tasks/debian/control
+++ b/plugins/ruby-foreman-tasks/debian/control
@@ -2,7 +2,7 @@ Source: ruby-foreman-tasks
 Section: ruby
 Priority: extra
 Maintainer: Michael Moll <mmoll@mmoll.at>
-Build-Depends: debhelper, git | git-core, foreman (>= 3.3.0~rc1), foreman-nulldb (>= 3.3.0~rc1), foreman-assets, python-dev
+Build-Depends: debhelper, git | git-core, foreman (>= 3.4.0-2), foreman-nulldb (>= 3.4.0-2), foreman-assets, python-dev
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-tasks
 
@@ -10,6 +10,6 @@ Package: ruby-foreman-tasks
 Architecture: all
 Conflicts: ruby-foreman-dynflow
 Replaces: ruby-foreman-dynflow
-Depends: ${misc:Depends}, bundler, foreman (>= 3.3.0~rc1), ruby-dynflow (>= 1.6.0)
+Depends: ${misc:Depends}, bundler, foreman (>= 3.4.0-2), ruby-dynflow (>= 1.6.0)
 Description: Tasks management engine for Foreman.
   Tasks management engine for Foreman. Gives you and overview of what's happening/happened in your Foreman instance.

--- a/plugins/ruby-foreman-tasks/debian/control
+++ b/plugins/ruby-foreman-tasks/debian/control
@@ -2,7 +2,7 @@ Source: ruby-foreman-tasks
 Section: ruby
 Priority: extra
 Maintainer: Michael Moll <mmoll@mmoll.at>
-Build-Depends: debhelper, git | git-core, foreman (>= 3.3.0~rc1), foreman-nulldb (>= 3.3.0~rc1), foreman-assets, python-dev, bundler
+Build-Depends: debhelper, git | git-core, foreman (>= 3.3.0~rc1), foreman-nulldb (>= 3.3.0~rc1), foreman-assets, python-dev
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-tasks
 

--- a/plugins/ruby-foreman-tasks/debian/gem.list
+++ b/plugins/ruby-foreman-tasks/debian/gem.list
@@ -1,6 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
 GEMS="https://rubygems.org/downloads/foreman-tasks-7.0.0.gem"
 GEMS="$GEMS https://rubygems.org/downloads/parse-cron-0.1.4.gem"
-GEMS="$GEMS https://rubygems.org/downloads/sinatra-2.2.2.gem"
-GEMS="$GEMS https://rubygems.org/downloads/mustermann-2.0.2.gem"
-GEMS="$GEMS https://rubygems.org/downloads/ruby2_keywords-0.0.5.gem"

--- a/plugins/ruby-foreman-tasks/debian/rules
+++ b/plugins/ruby-foreman-tasks/debian/rules
@@ -1,28 +1,16 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
-# Sample debian/rules that uses debhelper.
-# This file was originally written by Joey Hess and Craig Small.
-# As a special exception, when this file is copied by dh-make into a
-# dh-make output file, you may use that output file without restriction.
-# This special exception was added by Craig Small in version 0.37 of dh-make.
 
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
 PLUGIN = foreman-tasks
+PLUGIN_HAS_ASSETS = true
+PLUGIN_HAS_WEBPACK = true
+PLUGIN_HAS_PACKAGE_JSON = true
 
-build:
-	cp cache/* /usr/share/foreman/vendor/cache/
-	cp $(PLUGIN).rb /usr/share/foreman/bundler.d/
-	cd /usr/share/foreman && ( \
-		/usr/bin/foreman-ruby /usr/bin/bundle install --local && \
-		/usr/bin/npm install --no-audit --no-optional --unsafe-perm && \
-		/usr/bin/foreman-ruby /usr/bin/bundle exec rake plugin:assets:precompile[$(PLUGIN)] RAILS_ENV=production DATABASE_URL=nulldb://nohost \
-	)
-	GEM_PATH=$$(cd /usr/share/foreman && /usr/bin/foreman-ruby /usr/bin/bundle show $(PLUGIN)) && \
-	cp -rp $${GEM_PATH}/public/assets ./ && \
-	cp -rp $${GEM_PATH}/public/webpack ./ && \
-	cp -rp $${GEM_PATH}/extra ./
+include /usr/share/foreman/foreman-plugin.mk
 
-%:
-	dh $@
+override_dh_auto_install:
+	cp -r /usr/share/foreman/vendor/ruby/*/gems/foreman-tasks-*/extra ./
+	dh_auto_install


### PR DESCRIPTION
This cherry picks the changes from develop to avoid 2 packages shipping the same file. I don't know if I can submit this in one PR, given one depends on the other.