### PR TITLE
explicitly vendor sinatra

### DIFF
--- a/debian/bullseye/foreman/changelog
+++ b/debian/bullseye/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (3.4.0-2) stable; urgency=low
+
+  * explicitly vendor sinatra
+
+ -- Evgeni Golov <evgeni@debian.org>  Thu, 20 Sep 2022 14:14:39 +0200
+
 foreman (3.4.0-1) stable; urgency=low
 
   * 3.4.0 released

--- a/debian/bullseye/foreman/rules
+++ b/debian/bullseye/foreman/rules
@@ -22,6 +22,10 @@ build:
 	/bin/cp config/dynflow/worker.yml.example config/dynflow/worker.yml
 	/bin/mkdir -p ./vendor/cache
 	echo 'gem "thor", "1.1.0"' >> Gemfile
+	# rack-protection and sinatra have to be the same version
+	# foreman pulls in rack-protection via sidekiq, f-tasks needs sinatra
+	# let foreman.deb provide both gems in the cache, so that they always match
+	echo 'gem "sinatra"' >> bundler.d/debian.rb
 	/bin/rm -f bundler.d/test.rb bundler.d/development.rb
 	/bin/sed -i '2i  gem "puma-status"' bundler.d/service.rb
 	$(BUNDLE) install

--- a/debian/focal/foreman/changelog
+++ b/debian/focal/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (3.4.0-2) stable; urgency=low
+
+  * explicitly vendor sinatra
+
+ -- Evgeni Golov <evgeni@debian.org>  Thu, 20 Sep 2022 14:14:39 +0200
+
 foreman (3.4.0-1) stable; urgency=low
 
   * 3.4.0 released

--- a/debian/focal/foreman/rules
+++ b/debian/focal/foreman/rules
@@ -22,6 +22,10 @@ build:
 	/bin/cp config/dynflow/worker.yml.example config/dynflow/worker.yml
 	/bin/mkdir -p ./vendor/cache
 	echo 'gem "thor", "1.1.0"' >> Gemfile
+	# rack-protection and sinatra have to be the same version
+	# foreman pulls in rack-protection via sidekiq, f-tasks needs sinatra
+	# let foreman.deb provide both gems in the cache, so that they always match
+	echo 'gem "sinatra"' >> bundler.d/debian.rb
 	/bin/rm -f bundler.d/test.rb bundler.d/development.rb
 	/bin/sed -i '2i  gem "puma-status"' bundler.d/service.rb
 	$(BUNDLE) install


### PR DESCRIPTION
rack-protection and sinatra have to be the same version foreman pulls in rack-protection via sidekiq, f-tasks needs sinatra let foreman.deb provide both gems in the cache, so that they always match

(cherry picked from commit a195bc354b34f22a05a2e688aaa7471af2b08d3e)