### PR TITLE
Include sidekiq web/ directory

### DIFF
--- a/packages/foreman/rubygem-sidekiq/rubygem-sidekiq.spec
+++ b/packages/foreman/rubygem-sidekiq/rubygem-sidekiq.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 6.3.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Simple, efficient background processing for Ruby
 License: LGPL-3.0
 URL: https://sidekiq.org
@@ -58,7 +58,7 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 %license %{gem_instdir}/LICENSE
 %{gem_instdir}/bin
 %{gem_libdir}
-%exclude %{gem_instdir}/web
+%{gem_instdir}/web
 %exclude %{gem_cache}
 %{gem_spec}
 
@@ -68,6 +68,9 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 %exclude %{gem_instdir}/sidekiq.gemspec
 
 %changelog
+* Fri Sep 23 2022 Eric D. Helms <ericdhelms@gmail.com> - 6.3.1-2
+- Include web directory
+
 * Tue Aug 23 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 6.3.1-1
 - Update to 6.3.1
 


### PR DESCRIPTION
We mount and display the the Sidekiq web console and the web directory is needed for that:

```
Errno::ENOENT: No such file or directory @ rb_sysopen - /usr/share/gems/gems/sidekiq-6.3.1/web/views/layout.erb
/usr/share/gems/gems/sidekiq-6.3.1/lib/sidekiq/web.rb:166:in `read'
/usr/share/gems/gems/sidekiq-6.3.1/lib/sidekiq/web.rb:166:in `<module:Sidekiq>'
/usr/share/gems/gems/sidekiq-6.3.1/lib/sidekiq/web.rb:19:in `<top (required)>'
/usr/share/gems/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
/usr/share/gems/gems/activesupport-6.1.6.1/lib/active_support/dependencies.rb:332:in `block in require'
/usr/share/gems/gems/activesupport-6.1.6.1/lib/active_support/dependencies.rb:299:in `load_dependency'
/usr/share/gems/gems/activesupport-6.1.6.1/lib/active_support/dependencies.rb:332:in `require'
/usr/share/gems/gems/foreman-tasks-7.0.0/config/routes.rb:72:in `block (2 levels) in <top (required)>'
```