### PR TITLE
Drop requires on psutil, runner doesn't need it anymore

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
+++ b/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
@@ -17,7 +17,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.4.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Smart-Proxy Ansible plugin
 Group: Applications/Internet
 License: GPLv3
@@ -28,7 +28,6 @@ Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ansible
 %else
 Requires: (ansible or ansible-core)
-Requires: (python38-psutil if ansible-core)
 %endif
 
 Requires: ansible-collection-theforeman-foreman
@@ -148,6 +147,9 @@ ln -sv %{_root_sysconfdir}/foreman-proxy/ansible.cfg %{buildroot}%{foreman_proxy
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Tue Sep 27 2022 Evgeni Golov - 3.4.1-2
+- Drop requires on psutil, runner doesn't need it anymore
+
 * Mon Sep 05 2022 Leos Stejskal <lstejska@redhat.com> 3.4.1-1
 - Update to 3.4.1
 

--- a/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
+++ b/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
@@ -29,6 +29,7 @@ Requires: ansible
 %else
 Requires: (ansible or ansible-core)
 %endif
+Requires: ansible-runner >= 2
 
 Requires: ansible-collection-theforeman-foreman
 

--- a/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
+++ b/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
@@ -150,6 +150,7 @@ ln -sv %{_root_sysconfdir}/foreman-proxy/ansible.cfg %{buildroot}%{foreman_proxy
 %changelog
 * Tue Sep 27 2022 Evgeni Golov - 3.4.1-2
 - Drop requires on psutil, runner doesn't need it anymore
+- Add dependency on ansible-runner
 
 * Mon Sep 05 2022 Leos Stejskal <lstejska@redhat.com> 3.4.1-1
 - Update to 3.4.1


### PR DESCRIPTION
This was an workaround introduced in fbae4775a45c122123e475c574df981a1ba0a174, but in the meantime we did get a fixed runner package (ansible-runner 2.x doesn't need psutil at all), so we can drop the workaround.

You could argue this should add a `Requires: ansible-runner >= 2`, and I would agree ;)