### PR TITLE
support non-semver range definitions

### DIFF
--- a/update-requirements
+++ b/update-requirements
@@ -24,7 +24,10 @@ def get_requirement(version):
 
     if version.startswith('^') or version.startswith('~'):
         modifier = version[0]
-        parsed = semver.parse(version[1:])
+        split_version = version[1:].split('.', 2)
+        while(len(split_version) < 3):
+            split_version.append('0')
+        parsed = semver.parse('.'.join(split_version))
 
         min_version = '{}.{}.{}'.format(parsed['major'], parsed['minor'], parsed['patch'])
         if modifier == '^':


### PR DESCRIPTION
while node packages need to me semver-versioned, the version range definition as used to specify dependencies is not. `^10.0` is a perfectly valid way to say "at least 10.0 and less than 11".

In semver3 you can use `parse('10.0', optional_minor_and_patch=True)` but we don't have semver3 yet (it's not even released yet), so we need to make this up ourself.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
