### PR TITLE
Use python39-psutil with ansible-core 2.13+

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
+++ b/packages/plugins/rubygem-smart_proxy_ansible/rubygem-smart_proxy_ansible.spec
@@ -17,7 +17,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.4.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Smart-Proxy Ansible plugin
 Group: Applications/Internet
 License: GPLv3
@@ -28,7 +28,8 @@ Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires: ansible
 %else
 Requires: (ansible or ansible-core)
-Requires: (python38-psutil if ansible-core)
+Requires: (python38-psutil if ansible-core < 2.13)
+Requires: (python39-psutil if ansible-core >= 2.13)
 %endif
 
 Requires: ansible-collection-theforeman-foreman
@@ -148,6 +149,9 @@ ln -sv %{_root_sysconfdir}/foreman-proxy/ansible.cfg %{buildroot}%{foreman_proxy
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Thu Sep 29 2022 Evgeni Golov - 3.4.0-2
+- Use python39-psutil with ansible-core 2.13+
+
 * Thu Mar 31 2022 Adam Ruzicka <aruzicka@redhat.com> 3.4.0-1
 - Update to 3.4.0
 


### PR DESCRIPTION
In CentOS Stream 8, ansible-core 2.13 is built with Python 3.9 and thus needs the matching psutil package when called by ansible-runner.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
