### PR TITLE
Drop crudini dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ If you're submitting a patch which adds/updates a gem package, you will need:
 
 * [gem2rpm](https://rubygems.org/gems/gem2rpm) or rubygem-gem2rpm
 * [git-annex](http://git-annex.branchable.com/)
-* crudini: for fedora use `dnf install crudini`
 * ruamel: for fedora use `dnf install python3-ruamel-yaml`
 * python3-semver: for fedora use `dnf install python3-semver`
 

--- a/add_npm_package.sh
+++ b/add_npm_package.sh
@@ -110,7 +110,6 @@ if [[ -z $NPM_MODULE_NAME ]]; then
   exit 1
 fi
 
-ensure_program crudini
 ensure_program npm2rpm
 ensure_program spectool
 

--- a/add_pypi_package.sh
+++ b/add_pypi_package.sh
@@ -124,7 +124,6 @@ if [[ -z $PYPI_NAME ]]; then
   exit 1
 fi
 
-ensure_program crudini
 ensure_program pyp2rpm
 ensure_program spec2scl
 


### PR DESCRIPTION
Since tito was dropped, this is no longer needed.

Fixes: fa53fd5eb76a52a15db4cd01a97f8ff6e8575462