### PR TITLE
Bump foreman-installer release to work around Koji

### DIFF
--- a/packages/foreman/foreman-installer/foreman-installer.spec
+++ b/packages/foreman/foreman-installer/foreman-installer.spec
@@ -1,7 +1,7 @@
 %{?scl:%global scl_prefix %{scl}-}
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 1
+%global release 2
 
 Name:       foreman-installer
 Epoch:      1
@@ -141,6 +141,9 @@ done
 %{_sbindir}/foreman-proxy-certs-generate
 
 %changelog
+* Fri Oct 07 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1:3.3.1-2
+- Bump release to work around Koji issue
+
 * Thu Oct 06 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1:3.3.1-1
 - Release foreman-installer 3.3.1
 


### PR DESCRIPTION
Koji already knows foreman-installer-katello and doesn't track the epoch in its database. That leads to a duplicate ID. Bumping the release works around it.