### PR TITLE
Allow foreman-ygg-worker to work with newer yggdrasil

### DIFF
--- a/packages/client/foreman_ygg_worker/foreman_ygg_worker.spec
+++ b/packages/client/foreman_ygg_worker/foreman_ygg_worker.spec
@@ -5,6 +5,8 @@
 %global repo_orgname theforeman
 %global repo_name foreman_ygg_worker
 %global yggdrasil_libexecdir %{_libexecdir}/yggdrasil
+%{!?_root_sysconfdir:%global _root_sysconfdir %{_sysconfdir}}
+%global yggdrasil_worker_conf_dir %{_root_sysconfdir}/yggdrasil/workers
 
 %global goipath         github.com/%{repo_orgname}/%{repo_name}
 
@@ -20,7 +22,7 @@
 Name: foreman_ygg_worker
 Version: 0.1.1
 Summary: Worker service for yggdrasil that can act as pull client for Foreman Remote Execution
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: MIT
 
 Source0: https://github.com/%{repo_orgname}/%{repo_name}/releases/download/v%{version}/%{repo_name}-%{version}.tar.gz
@@ -53,13 +55,24 @@ popd
 
 %install
 install -D -m 755 _gopath/src/%{name}-%{version}/%{name}-%{version} %{buildroot}%{yggdrasil_libexecdir}/%{name}
+install -D -d -m 755 %{buildroot}%{yggdrasil_worker_conf_dir}
+
+cat <<EOF >%{buildroot}%{yggdrasil_worker_conf_dir}/foreman.toml
+exec = "%{yggdrasil_libexecdir}/%{name}"
+protocol = "grpc"
+env = []
+EOF
 
 %files
 %{yggdrasil_libexecdir}/%{name}
+%{yggdrasil_worker_conf_dir}/foreman.toml
 %license LICENSE
 %doc README.md
 
 %changelog
+* Mon Oct 10 2022 Adam Ruzicka <aruzicka@redhat.com> - 0.1.1-2
+- Bump version to 0.1.1
+
 * Tue Sep 13 2022 Adam Ruzicka <aruzicka@redhat.com> - 0.1.1-1
 - Bump version to 0.1.1
 


### PR DESCRIPTION
Yggdrasil past 0.2.1 changed the way how workers are discovered, placing a binary into a directory is no longer sufficient. There has to be an accompanying configuration file that point to said binary.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
