### PR TITLE
Cherry pick explicit vendorization of sinatra to deb/3.3

### DIFF
--- a/plugins/ruby-foreman-tasks/debian/changelog
+++ b/plugins/ruby-foreman-tasks/debian/changelog
@@ -1,4 +1,10 @@
-ruby-foreman-tasks (6.0.2) stable; urgency=low
+ruby-foreman-tasks (6.0.2-2) stable; urgency=low
+
+  * don't vendor sinatra and its gems, this is now provided by foreman
+
+ -- Evgeni Golov <evgeni@debian.org>  Tue, 11 Oct 2022 16:05:03 +0200
+
+ruby-foreman-tasks (6.0.2-1) stable; urgency=low
 
   * 6.0.2 released
 

--- a/plugins/ruby-foreman-tasks/debian/control
+++ b/plugins/ruby-foreman-tasks/debian/control
@@ -10,6 +10,6 @@ Package: ruby-foreman-tasks
 Architecture: all
 Conflicts: ruby-foreman-dynflow
 Replaces: ruby-foreman-dynflow
-Depends: ${misc:Depends}, bundler, foreman (>= 3.1.0~rc1), ruby-dynflow (>= 1.6.0)
+Depends: ${misc:Depends}, bundler, foreman (>= 3.3.1-2), ruby-dynflow (>= 1.6.0)
 Description: Tasks management engine for Foreman.
   Tasks management engine for Foreman. Gives you and overview of what's happening/happened in your Foreman instance.

--- a/plugins/ruby-foreman-tasks/debian/gem.list
+++ b/plugins/ruby-foreman-tasks/debian/gem.list
@@ -1,6 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
 GEMS="https://rubygems.org/downloads/foreman-tasks-6.0.2.gem"
 GEMS="$GEMS https://rubygems.org/downloads/parse-cron-0.1.4.gem"
-GEMS="$GEMS https://rubygems.org/downloads/sinatra-2.2.0.gem"
-GEMS="$GEMS https://rubygems.org/downloads/mustermann-1.1.1.gem"
-GEMS="$GEMS https://rubygems.org/downloads/ruby2_keywords-0.0.1.gem"


### PR DESCRIPTION
After the release of 3.3.1-1 installation of foreman-tasks fails. These picks should allow it to work again.