### PR TITLE
fix ruby/bundler dependency for Debian 10

### DIFF
--- a/debian/buster/foreman/changelog
+++ b/debian/buster/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (3.3.1-3) stable; urgency=low
+
+  * correct ruby/bundler depdendencies for Debian 10
+
+ -- Evgeni Golov <evgeni@debian.org>  Fri, 14 Oct 2022 15:12:38 +0200
+
 foreman (3.3.1-2) stable; urgency=low
 
   * explicitly vendor sinatra

--- a/debian/buster/foreman/control
+++ b/debian/buster/foreman/control
@@ -14,7 +14,7 @@ Package: foreman
 Architecture: any
 Section: web
 Priority: extra
-Depends: ruby, ruby (>= 1:2.7), bundler (>= 1.3), ruby-dev, zlib1g-dev,
+Depends: ruby, ruby (>= 1:2.7) | bundler (>= 1.3), ruby-dev, zlib1g-dev,
          build-essential, tzdata,
          rake (>=0.8.4), gawk, ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug (= ${binary:Version}), python-minimal


### PR DESCRIPTION
Debian 10 has Ruby 2.5, so we need the old "or" relationship which will correctly pull in bundler already

Fixes: c6f5cc523c3bbdfbf74ef2c08d7af9afe86b44c2

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
