### PR TITLE
Update ruby-foreman-tasks foreman version

### DIFF
--- a/plugins/ruby-foreman-tasks/debian/control
+++ b/plugins/ruby-foreman-tasks/debian/control
@@ -2,7 +2,7 @@ Source: ruby-foreman-tasks
 Section: ruby
 Priority: extra
 Maintainer: Michael Moll <mmoll@mmoll.at>
-Build-Depends: debhelper, git | git-core, foreman (>= 3.5.0~rc1), foreman-nulldb (>= 3.5.0~rc1), foreman-assets, python-dev
+Build-Depends: debhelper, git | git-core, foreman (>= 3.4.0~rc1), foreman-nulldb (>= 3.4.0~rc1), foreman-assets, python-dev
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-tasks
 
@@ -10,6 +10,6 @@ Package: ruby-foreman-tasks
 Architecture: all
 Conflicts: ruby-foreman-dynflow
 Replaces: ruby-foreman-dynflow
-Depends: ${misc:Depends}, bundler, foreman (>= 3.5.0~rc1), ruby-dynflow (>= 1.6.0)
+Depends: ${misc:Depends}, bundler, foreman (>= 3.4.0~rc1), ruby-dynflow (>= 1.6.0)
 Description: Tasks management engine for Foreman.
   Tasks management engine for Foreman. Gives you and overview of what's happening/happened in your Foreman instance.


### PR DESCRIPTION
Update the foreman version ruby-foreman-tasks depends on.

When trying to update Foreman from v3.3 to v3.4, ruby-foreman-tasks says it depends on foreman (>= 3.4.0-2) but 3.4.0-1 is to be installed. The current foreman version specified in https://github.com/theforeman/foreman-packaging/blob/deb/3.4/plugins/ruby-foreman-tasks/debian/control is 3.4.0-2.

Foreman community ref: https://community.theforeman.org/t/not-able-to-upgrade-foreman-from-v3-3-to-v3-4/30711

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
