### PR TITLE
Add dependency on ruby-gssapi

### DIFF
--- a/dependencies/bullseye/apipie-bindings/changelog
+++ b/dependencies/bullseye/apipie-bindings/changelog
@@ -1,3 +1,9 @@
+ruby-apipie-bindings (0.5.0-2) stable; urgency=low
+
+  * Add dependency on ruby-gssapi
+
+ -- Evgeni Golov <evgeni@debian.org>  Tue, 18 Oct 2022 11:09:30 +0200
+
 ruby-apipie-bindings (0.5.0-1) stable; urgency=low
 
   * 0.5.0 released

--- a/dependencies/bullseye/apipie-bindings/control
+++ b/dependencies/bullseye/apipie-bindings/control
@@ -13,6 +13,6 @@ XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-json (>= 1.6.1),
          ruby-rest-client (>= 1.6.5), ruby-rest-client (<< 3.0.0),
-         ruby-oauth,
+         ruby-oauth, ruby-gssapi
 Description: Ruby bindings for Apipie documented APIs
  Bindings for API calls that are documented with Apipie. Bindings are generated on the fly.

--- a/dependencies/focal/apipie-bindings/changelog
+++ b/dependencies/focal/apipie-bindings/changelog
@@ -1,3 +1,9 @@
+ruby-apipie-bindings (0.5.0-2) stable; urgency=low
+
+  * Add dependency on ruby-gssapi
+
+ -- Evgeni Golov <evgeni@debian.org>  Tue, 18 Oct 2022 11:09:30 +0200
+
 ruby-apipie-bindings (0.5.0-1) stable; urgency=low
 
   * 0.5.0 released

--- a/dependencies/focal/apipie-bindings/control
+++ b/dependencies/focal/apipie-bindings/control
@@ -13,6 +13,6 @@ XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-json (>= 1.6.1),
          ruby-rest-client (>= 1.6.5), ruby-rest-client (<< 3.0.0),
-         ruby-oauth,
+         ruby-oauth, ruby-gssapi
 Description: Ruby bindings for Apipie documented APIs
  Bindings for API calls that are documented with Apipie. Bindings are generated on the fly.


### PR DESCRIPTION
apipie-bindings 0.5.0 started using the gssapi gem, but the packaging dependencies were forgotten

Fixes: b36b6cd08f85c97dfabe0995e61175f96f2a1117

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
