### PR TITLE
Update ruby-puppetdb-foreman to 6.0.0

### DIFF
--- a/plugins/ruby-puppetdb-foreman/debian/changelog
+++ b/plugins/ruby-puppetdb-foreman/debian/changelog
@@ -1,3 +1,9 @@
+ruby-puppetdb-foreman (6.0.0-1) stable; urgency=low
+
+  * 6.0.0 released
+
+ -- Dirk Goetz <dirk.goetz@netways.de>  Fri, 14 Oct 2022 16:16:06 +0200
+
 ruby-puppetdb-foreman (5.0.0-4) stable; urgency=low
 
   * Use foreman-plugin.mk

--- a/plugins/ruby-puppetdb-foreman/debian/gem.list
+++ b/plugins/ruby-puppetdb-foreman/debian/gem.list
@@ -1,2 +1,2 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/puppetdb_foreman-5.0.0.gem"
+GEMS="https://rubygems.org/downloads/puppetdb_foreman-6.0.0.gem"

--- a/plugins/ruby-puppetdb-foreman/puppetdb_foreman.rb
+++ b/plugins/ruby-puppetdb-foreman/puppetdb_foreman.rb
@@ -1,1 +1,1 @@
-gem 'puppetdb_foreman', '5.0.0'
+gem 'puppetdb_foreman', '6.0.0'


### PR DESCRIPTION
Cherry picked to supported versions as it breaks installations.

(cherry picked from commit a1450644b389da20043a35d362a5ec083989085a)