### PR TITLE
write to GITHUB_OUTPUT instead of using set-output

### DIFF
--- a/scripts/list_updatable_packages
+++ b/scripts/list_updatable_packages
@@ -56,8 +56,9 @@ def main() -> None:
 
     if 'GITHUB_ACTION' in os.environ:
         directories = [entry['directory'] for entry in matrix]
-        print(f'::set-output name=directories::{json.dumps(directories)}')
-        print(f'::set-output name=matrix::{json.dumps(matrix)}')
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as github_output:
+            print(f'directories={json.dumps(directories)}', file=github_output)
+            print(f'matrix={json.dumps(matrix)}', file=github_output)
     for entry in matrix:
         print(entry['directory'], entry['new_version'])
 


### PR DESCRIPTION
set-output is deprecated https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
