### PR TITLE
add dependabot config to update our actions automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/bump_packages.yml
+++ b/.github/workflows/bump_packages.yml
@@ -18,7 +18,7 @@ jobs:
       matrix: ${{ steps.set_list.outputs.matrix }}
     steps:
     - name: Checkout RPM
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: rpm/develop
     - name: Set the list
@@ -44,7 +44,7 @@ jobs:
         echo 'echo "$GIT_AUTHOR_NAME <$GIT_AUTHOR_EMAIL>"' | sudo tee /usr/local/bin/rpmdev-packager
         sudo chmod +x /usr/local/bin/spectool /usr/local/bin/rpmdev-packager
     - name: Checkout RPM
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: rpm/develop
     - name: Initialize git annex
@@ -54,7 +54,7 @@ jobs:
       env:
         SKIP_GIT_COMMIT: 1
     - name: Open a PR
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v4
       with:
         commit-message: "Update ${{ matrix.package_name }} to ${{ matrix.new_version }}"
         branch: "bump_rpm/${{ matrix.package_name }}"
@@ -70,7 +70,7 @@ jobs:
       matrix: ${{ steps.set_list.outputs.matrix }}
     steps:
     - name: Checkout deb
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: deb/develop
     - name: Set the list
@@ -88,13 +88,13 @@ jobs:
         include: ${{ fromJson(needs.deb_list.outputs.matrix) }}
     steps:
     - name: Checkout DEB
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: deb/develop
     - name: Update package
       run: ./scripts/update_package.rb --name "$(basename ${{ matrix.directory }})" --version "${{ matrix.new_version }}"
     - name: Open a PR
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v4
       with:
         commit-message: "Update ${{ matrix.package_name }} to ${{ matrix.new_version }}"
         branch: "bump_deb/${{ matrix.package_name }}"


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
