### PR TITLE
Revert "Update the bundler version in Gemfile.lock on package update"

### DIFF
--- a/debian/bullseye/foreman/changelog
+++ b/debian/bullseye/foreman/changelog
@@ -1,9 +1,3 @@
-foreman (3.5.0-5) stable; urgency=low
-
-  * Update the bundler version in Gemfile.lock on package update
-
- -- Evgeni Golov <evgeni@debian.org>  Thu, 20 Oct 2022 11:33:51 +0200
-
 foreman (3.5.0-4) stable; urgency=low
 
   * adjust foreman-plugin.mk to build the plugin as a user

--- a/debian/bullseye/foreman/foreman-plugin.postinst-lib.in
+++ b/debian/bullseye/foreman/foreman-plugin.postinst-lib.in
@@ -13,13 +13,13 @@ foreman_plugin_install() {
   cd /usr/share/foreman
   if [ ! -z "${DEBUG}" ]; then
     if [ -n "${PREVIOUS_VERSION}" ] ; then
-      $BUNDLE update $PLUGIN --local --bundler
+      $BUNDLE update $PLUGIN --local
     else
       $BUNDLE install --local --no-prune
     fi
   else
     if [ -n "${PREVIOUS_VERSION}" ] ; then
-      $BUNDLE update $PLUGIN --local --bundler 2>&1 >> $LOGFILE
+      $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
     else
       $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
     fi

--- a/debian/bullseye/foreman/foreman.postinst-lib.in
+++ b/debian/bullseye/foreman/foreman.postinst-lib.in
@@ -7,9 +7,9 @@ foreman_postinst() {
   export HOME=/usr/share/foreman
   cd /usr/share/foreman
   if [ ! -z "${DEBUG}" ]; then
-    $BUNDLE update --jobs 4 --local --bundler
+    $BUNDLE update --jobs 4 --local
   else
-    $BUNDLE update --jobs 4 --local --bundler 2>&1 >> $LOGFILE
+    $BUNDLE update --jobs 4 --local 2>&1 >> $LOGFILE
   fi
 
   # Own all the core files

--- a/debian/bullseye/foreman/foreman.postinst.in
+++ b/debian/bullseye/foreman/foreman.postinst.in
@@ -37,7 +37,7 @@ BUNDLE=@BUNDLE@
 export HOME=/usr/share/foreman
 cd /usr/share/foreman
 if [ -f Gemfile.lock ]; then
-  CMD="$BUNDLE update --jobs 4 --local --bundler"
+  CMD="$BUNDLE update --jobs 4 --local"
 else
   CMD="$BUNDLE install --jobs 4 --path ./vendor/ --local --no-prune"
 fi

--- a/debian/focal/foreman/changelog
+++ b/debian/focal/foreman/changelog
@@ -1,9 +1,3 @@
-foreman (3.5.0-5) stable; urgency=low
-
-  * Update the bundler version in Gemfile.lock on package update
-
- -- Evgeni Golov <evgeni@debian.org>  Thu, 20 Oct 2022 11:33:51 +0200
-
 foreman (3.5.0-4) stable; urgency=low
 
   * adjust foreman-plugin.mk to build the plugin as a user

--- a/debian/focal/foreman/foreman-plugin.postinst-lib.in
+++ b/debian/focal/foreman/foreman-plugin.postinst-lib.in
@@ -13,13 +13,13 @@ foreman_plugin_install() {
   cd /usr/share/foreman
   if [ ! -z "${DEBUG}" ]; then
     if [ -n "${PREVIOUS_VERSION}" ] ; then
-      $BUNDLE update $PLUGIN --local --bundler
+      $BUNDLE update $PLUGIN --local
     else
       $BUNDLE install --local --no-prune
     fi
   else
     if [ -n "${PREVIOUS_VERSION}" ] ; then
-      $BUNDLE update $PLUGIN --local --bundler 2>&1 >> $LOGFILE
+      $BUNDLE update $PLUGIN --local 2>&1 >> $LOGFILE
     else
       $BUNDLE install --local --no-prune 2>&1 >> $LOGFILE
     fi

--- a/debian/focal/foreman/foreman.postinst-lib.in
+++ b/debian/focal/foreman/foreman.postinst-lib.in
@@ -7,9 +7,9 @@ foreman_postinst() {
   export HOME=/usr/share/foreman
   cd /usr/share/foreman
   if [ ! -z "${DEBUG}" ]; then
-    $BUNDLE update --jobs 4 --local --bundler
+    $BUNDLE update --jobs 4 --local
   else
-    $BUNDLE update --jobs 4 --local --bundler 2>&1 >> $LOGFILE
+    $BUNDLE update --jobs 4 --local 2>&1 >> $LOGFILE
   fi
 
   # Own all the core files

--- a/debian/focal/foreman/foreman.postinst.in
+++ b/debian/focal/foreman/foreman.postinst.in
@@ -37,7 +37,7 @@ BUNDLE=@BUNDLE@
 export HOME=/usr/share/foreman
 cd /usr/share/foreman
 if [ -f Gemfile.lock ]; then
-  CMD="$BUNDLE update --jobs 4 --local --bundler"
+  CMD="$BUNDLE update --jobs 4 --local"
 else
   CMD="$BUNDLE install --jobs 4 --path ./vendor/ --local --no-prune"
 fi


### PR DESCRIPTION
This reverts commit 1bcac66ffbb620e856b0bb482972102d797c37be.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
