### PR TITLE
Require sd_notify for systemd integration support from Puma

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -4,7 +4,7 @@
 %global dynflow_sidekiq_service_name dynflow-sidekiq@
 %global rake /usr/bin/rake
 
-%global release 15
+%global release 16
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -661,6 +661,8 @@ Group:  Applications/System
 # start specfile service Requires
 Requires: rubygem(puma) >= 5.1
 Requires: rubygem(puma) < 6.0
+Requires: rubygem(sd_notify) >= 0.1.0
+Requires: rubygem(sd_notify) < 0.2.0
 # end specfile service Requires
 Requires: rubygem(puma-status)
 Requires: %{name} = %{version}-%{release}
@@ -1005,6 +1007,9 @@ exit 0
 %systemd_postun %{name}.socket
 
 %changelog
+* Fri Oct 28 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.5.0-0.16.develop
+- Require sd_notify for Puma systemd support
+
 * Tue Oct 25 2022 Evgeni Golov - 3.5.0-0.15.develop
 - Update GEM dependencies
 


### PR DESCRIPTION
I debated if this should just be added to Puma itself as a requirement. As it's only required if the service using Puma implement systemd support which is driven by our implementation in foreman rather than Puma itself.

On nearly all standard installation, a foreman-proxy is installed alongside Foreman which results in the `sd_notify` gem being present. However, we have places like our puppet acceptance tests that test Foreman in isolation and lack this support. I observed, for example, that foreman.service started timing out on start on https://github.com/theforeman/puppet-katello/pull/457. I see the same behaviour locally, but not when I install rubygem-sd_notify.  