### PR TITLE
Use Puppet 7

### DIFF
--- a/mock/el7.cfg
+++ b/mock/el7.cfg
@@ -46,7 +46,7 @@ enabled=0
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel7&arch=x86_64
 failovermethod=priority
 
-[puppet-6]
-name=puppet-6
-baseurl=https://yum.puppetlabs.com/puppet6/el/7/x86_64/
+[puppet-7]
+name=puppet-7
+baseurl=https://yum.puppetlabs.com/puppet7/el/7/x86_64/
 """

--- a/mock/el8.cfg
+++ b/mock/el8.cfg
@@ -85,7 +85,7 @@ baseurl=https://yum.theforeman.org/plugins/nightly/el8/x86_64/
 name=katello
 baseurl=https://yum.theforeman.org/katello/nightly/katello/el8/x86_64/
 
-[puppet-6]
-name=puppet-6
-baseurl=https://yum.puppetlabs.com/puppet6/el/8/x86_64/
+[puppet-7]
+name=puppet-7
+baseurl=https://yum.puppetlabs.com/puppet7/el/8/x86_64/
 """

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -58,7 +58,7 @@ foreman_packages:
         - el8-appstream
         - el8-extras
         - el8-powertools
-        - el8-puppet-6
+        - el8-puppet-7
         - "el8-katello-candlepin-{{ katello_version }}"
   children:
     foreman_core_packages: {}
@@ -81,7 +81,7 @@ plugin_packages:
         - el8-powertools
         - el8-configmanagement-salt
         - el8-extras
-        - el8-puppet-6
+        - el8-puppet-7
         - "el8-foreman-{{ foreman_version }}"
   children:
     foreman_plugin_packages: {}
@@ -483,13 +483,13 @@ foreman_client_packages:
         - el8-powertools
         - el8-epel
         - el8-extras
-        - el8-puppet-6
+        - el8-puppet-7
       rhel7:
         - el7-base
         - el7-updates
         - el7-epel
         - el7-extras
-        - el7-puppet-6
+        - el7-puppet-7
   hosts:
     foreman_ygg_worker: {}
     gofer: {}
@@ -515,7 +515,7 @@ katello_packages:
         - el8-powertools
         - el8-epel
         - el8-extras
-        - el8-puppet-6
+        - el8-puppet-7
         - "el8-foreman-{{ foreman_version }}"
         - "el8-foreman-plugins-{{ foreman_version }}"
         - "el8-katello-candlepin-{{ katello_version }}"
@@ -790,7 +790,7 @@ repoclosures:
           - el8-appstream
           - el8-powertools
           - el8-extras
-          - el8-puppet-6
+          - el8-puppet-7
           - "el8-katello-candlepin-{{ katello_version }}"
     plugins-repoclosure-el8:
       repoclosure_target_repos:
@@ -804,7 +804,7 @@ repoclosures:
           - el8-powertools
           - el8-configmanagement-salt
           - el8-extras
-          - el8-puppet-6
+          - el8-puppet-7
           - "el8-foreman-{{ foreman_version }}"
     katello-repoclosure-el8:
       repoclosure_target_repos:
@@ -817,7 +817,7 @@ repoclosures:
           - el8-appstream
           - el8-powertools
           - el8-extras
-          - el8-puppet-6
+          - el8-puppet-7
           - "el8-foreman-{{ foreman_version }}"
           - "el8-foreman-plugins-{{ foreman_version }}"
           - "el8-katello-candlepin-{{ katello_version }}"
@@ -843,7 +843,7 @@ repoclosures:
           - el8-powertools
           - el8-epel
           - el8-extras
-          - el8-puppet-6
+          - el8-puppet-7
     foreman-client-repoclosure-el7:
       repoclosure_target_repos:
         rhel7:
@@ -855,7 +855,7 @@ repoclosures:
           - el7-updates
           - el7-epel
           - el7-extras
-          - el7-puppet-6
+          - el7-puppet-7
 
 foreman_release_packages:
   vars:
@@ -882,12 +882,12 @@ foreman_release_packages:
         - el8-appstream
         - el8-powertools
         - el8-extras
-        - el8-puppet-6
+        - el8-puppet-7
       rhel7:
         - el7-base
         - el7-updates
         - el7-epel
         - el7-extras
-        - el7-puppet-6
+        - el7-puppet-7
   hosts:
     foreman-release: {}

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -77,9 +77,9 @@ failovermethod=priority
 name=Foreman Client nightly EL8
 baseurl=http://koji.katello.org/releases/yum/foreman-client-nightly/el8/x86_64/
 
-[el8-puppet-6]
-name=el8-puppet-6
-baseurl=https://yum.puppetlabs.com/puppet6/el/8/x86_64/
+[el8-puppet-7]
+name=el8-puppet-7
+baseurl=https://yum.puppetlabs.com/puppet7/el/8/x86_64/
 
 [el7-base]
 name=BaseOS
@@ -106,9 +106,9 @@ failovermethod=priority
 name=el7-scl
 baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/rh/
 
-[el7-puppet-6]
-name=el7-puppet-6
-baseurl=https://yum.puppetlabs.com/puppet6/el/7/x86_64/
+[el7-puppet-7]
+name=el7-puppet-7
+baseurl=https://yum.puppetlabs.com/puppet7/el/7/x86_64/
 
 [el8-foreman-nightly]
 name=Foreman nightly EL8


### PR DESCRIPTION
Koji was already switched in Foreman 3.2, but repoclosure and mock remained.