### PR TITLE
strip debian/ubuntu suffix from repo packages during compare

### DIFF
--- a/scripts/compare_deb_repo.py
+++ b/scripts/compare_deb_repo.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import re
 import requests
 import subprocess
 from collections import defaultdict
@@ -25,7 +26,7 @@ def get_repo_packages(dist, release='nightly', arch='amd64', staging=False):
     remote_packages = requests.get(repo_url)
     for pkg in Packages.iter_paragraphs(remote_packages.text, use_apt_pkg=False):
         source = pkg.get('Source', pkg['Package'])
-        version = pkg['Version']
+        version = re.sub(r'\+(debian|ubuntu).*', '', pkg['Version'])
         if version.startswith('9999-') and release == 'nightly' and source in NIGHTLY_PACKAGES:
             continue
         if NativeVersion(packages[source]) < NativeVersion(version):

--- a/scripts/compare_deb_repo.py
+++ b/scripts/compare_deb_repo.py
@@ -14,7 +14,7 @@ from debian.debian_support import NativeVersion
 
 DISTS = [path.name for path in Path('debian/').glob('*')]
 PLUGINS = ['plugins']
-NIGHTLY_PACKAGES = ['foreman', 'foreman-installer', 'foreman-proxy']
+NIGHTLY_PACKAGES = ['foreman', 'foreman-installer', 'foreman-proxy', 'foreman-release']
 
 
 def get_repo_packages(dist, release='nightly', arch='amd64', staging=False):


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
