### PR TITLE
only accept full package names in update_package.rb

### DIFF
--- a/scripts/update_package.rb
+++ b/scripts/update_package.rb
@@ -23,26 +23,10 @@ end.parse!
 raise "missing --name" if options[:name].nil?
 raise "missing --version" if options[:version].nil?
 
-# Try and find operating directories, prefer an exact match
+# Try and find operating directories
 def find_directories(name)
-  dirs = if File.exist?("plugins/#{name}")
-           Dir["plugins/#{name}"]
-         else
-           Dir["plugins/*#{name}*"]
-         end
-
-  if dirs.size > 1
-    raise "Ambiguous name given, multiple packages match: #{dirs.inspect}"
-  elsif dirs.empty?
-    # dependencies will have multiple directories, one per OS
-    dirs = Dir["dependencies/*/#{name}"]
-    if dirs.empty?
-      dirs = Dir["dependencies/*/*#{name}*"]
-      if dirs.empty?
-        raise "Cannot find a package with the name #{name}"
-      end
-    end
-  end
+  dirs = Dir["plugins/#{name}"] + Dir["dependencies/*/#{name}"]
+  raise "Cannot find a package with the name #{name}" if dirs.empty?
 
   dirs
 end


### PR DESCRIPTION
otherwise it might match substrings that we do not want. examples:
* `infoblox` matches both the plugin and the dependency gem
* `puppet-strings` matches both the plugin and the dependency gem

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
