### PR TITLE
Refs #35088 - Remove foreman-gce and mark foreman_google as replacement

### DIFF
--- a/comps/comps-foreman-el8.xml
+++ b/comps/comps-foreman-el8.xml
@@ -19,7 +19,6 @@
       <packagereq type="default">foreman-debug</packagereq>
       <packagereq type="default">foreman-dynflow-sidekiq</packagereq>
       <packagereq type="default">foreman-ec2</packagereq>
-      <packagereq type="default">foreman-gce</packagereq>
       <packagereq type="default">foreman-installer</packagereq>
       <packagereq type="default">foreman-installer-katello</packagereq>
       <packagereq type="default">foreman-journald</packagereq>

--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -4,7 +4,7 @@
 %global dynflow_sidekiq_service_name dynflow-sidekiq@
 %global rake /usr/bin/rake
 
-%global release 16
+%global release 17
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -412,22 +412,6 @@ Meta package to install requirements for VMware compute resource support.
 
 %files vmware
 %{_datadir}/%{name}/bundler.d/vmware.rb
-
-%package gce
-Summary: Foreman Google Compute Engine (GCE) support
-Group:  Applications/System
-# start specfile gce Requires
-Requires: rubygem(fog-google) >= 1.14
-Requires: rubygem(fog-google) < 2.0
-Requires: rubygem(faraday) < 2
-# end specfile gce Requires
-Requires: %{name} = %{version}-%{release}
-
-%description gce
-Meta package to install requirements for Google Compute Engine (GCE) support
-
-%files gce
-%{_datadir}/%{name}/bundler.d/gce.rb
 
 %package assets
 Summary: Foreman asset pipeline support
@@ -1007,6 +991,9 @@ exit 0
 %systemd_postun %{name}.socket
 
 %changelog
+* Mon Oct 31 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.5.0-0.17.develop
+- Remove gce subpackage
+
 * Fri Oct 28 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.5.0-0.16.develop
 - Require sd_notify for Puma systemd support
 

--- a/packages/plugins/rubygem-foreman_google/rubygem-foreman_google.spec
+++ b/packages/plugins/rubygem-foreman_google/rubygem-foreman_google.spec
@@ -6,11 +6,14 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.0.2
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Google Compute Engine plugin for the Foreman
 License: GPLv3
 URL: https://github.com/theforeman/foreman_google
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
+
+# Foreman 3.5 dropped the gce compute provider and this is the replacement
+Obsoletes: foreman-gce < 3.5.0-1
 
 # start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
@@ -99,6 +102,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Mon Oct 31 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 0.0.2-2
+- Mark as a replacement for foreman-gce
+
 * Thu Oct 06 2022 Leos Stejskal <lstejska@redhat.com> 0.0.2-1
 - Update to 0.0.2
 


### PR DESCRIPTION
I think this is the migration path for users, but not really sure.