### PR TITLE
Allow foreman-build to be included per the needs of the build system

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -4,7 +4,7 @@
 %global dynflow_sidekiq_service_name dynflow-sidekiq@
 %global rake /usr/bin/rake
 
-%global release 3
+%global release 4
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -506,7 +506,6 @@ Meta package to install asset pipeline support.
 Summary: Foreman plugin support
 Group: Development/Libraries
 Requires: %{name} = %{version}-%{release}
-Requires: %{name}-build = %{version}-%{release}
 Requires: rubygem(activerecord-nulldb-adapter)
 
 %description plugin
@@ -992,6 +991,9 @@ exit 0
 %systemd_postun %{name}.socket
 
 %changelog
+* Wed Nov 23 2022 Eric D. Helms <ericdhelms@gmail.com> - 3.6.0-0.4.develop
+- Drop requirement on foreman-build from foreman-plugin
+
 * Mon Nov 21 2022 Quirin Pamp <pamp@atix.de> - 3.6.0-0.3.develop
 - Ensure tmp directory exists in foreman_precompile_plugin
 


### PR DESCRIPTION
The foreman-build RPM provides a macro for plugin versioning that is not desired across all build systems and rebuilds of RPMs. Dropping the requires on foreman-build allows it to be included in buildroots per the configuration rather than a hard requirement of the foreman-plugin package.


The alternative solution:

Configure each build system with the `foremandist` macro as part of the configuration. For Koji that is using (https://docs.pagure.org/koji/setting_rpm_macros/#setting-rpm-macro-values) and configuring it in tool_belt tag configurations. For mock that is setting `rpmmacros` option, which I believe is the same for Copr. 

I think the standard method is still the proposal here -- a dedicated RPM with macros in it that is included at buildroot install time (e.g. `python39-rpm-macros`).