### PR TITLE
Remove json >= 2.5 dependency

### DIFF
--- a/packages/foreman/rubygem-gitlab-sidekiq-fetcher/rubygem-gitlab-sidekiq-fetcher.spec
+++ b/packages/foreman/rubygem-gitlab-sidekiq-fetcher/rubygem-gitlab-sidekiq-fetcher.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.9.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Reliable fetch extension for Sidekiq
 License: LGPL-3.0
 URL: https://gitlab.com/gitlab-org/sidekiq-reliable-fetch/
@@ -30,6 +30,9 @@ Documentation for %{name}.
 
 %prep
 %setup -q -n  %{gem_name}-%{version}
+
+# 0.9.0 added a dep on >= 2.5 to get Ruby 3.0 support, which we don't need yet
+%gemspec_remove_dep -g json ">= 2.5"
 
 %build
 # Create the gem as gem install only works on a gem file
@@ -66,6 +69,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/tests
 
 %changelog
+* Mon Nov 07 2022 Evgeni Golov - 0.9.0-2
+- Remove json >= 2.5 dependency
+
 * Fri Nov 04 2022 Foreman Packaging Automation <packaging@theforeman.org> 0.9.0-1
 - Update to 0.9.0
 


### PR DESCRIPTION
0.9.0 added a dep on >= 2.5 to get Ruby 3.0 support, which we don't need yet

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
