### PR TITLE
vendor faraday

### DIFF
--- a/debian/bullseye/foreman/changelog
+++ b/debian/bullseye/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (3.5.0-6) stable; urgency=low
+
+  * Vendor faraday
+
+ -- Evgeni Golov <evgeni@debian.org>  Mon, 07 Nov 2022 11:02:28 +0100
+
 foreman (3.5.0-5) stable; urgency=low
 
   * Replace foreman-gce with ruby-foreman-google

--- a/debian/bullseye/foreman/rules
+++ b/debian/bullseye/foreman/rules
@@ -26,6 +26,10 @@ build:
 	# foreman pulls in rack-protection via sidekiq, f-tasks needs sinatra
 	# let foreman.deb provide both gems in the cache, so that they always match
 	echo 'gem "sinatra"' >> bundler.d/debian.rb
+	# foreman_google and foreman_azure_rm both require faraday
+	# let foreman.deb provide both gems in the cache, so that the plugins always
+	# get compatible versions
+	echo 'gem "faraday", "<2"' >> bundler.d/debian.rb
 	/bin/rm -f bundler.d/test.rb bundler.d/development.rb
 	/bin/sed -i '2i  gem "puma-status"' bundler.d/service.rb
 	$(BUNDLE) install

--- a/debian/focal/foreman/changelog
+++ b/debian/focal/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (3.5.0-6) stable; urgency=low
+
+  * Vendor faraday
+
+ -- Evgeni Golov <evgeni@debian.org>  Mon, 07 Nov 2022 11:02:28 +0100
+
 foreman (3.5.0-5) stable; urgency=low
 
   * Replace foreman-gce with ruby-foreman-google

--- a/debian/focal/foreman/rules
+++ b/debian/focal/foreman/rules
@@ -26,6 +26,10 @@ build:
 	# foreman pulls in rack-protection via sidekiq, f-tasks needs sinatra
 	# let foreman.deb provide both gems in the cache, so that they always match
 	echo 'gem "sinatra"' >> bundler.d/debian.rb
+	# foreman_google and foreman_azure_rm both require faraday
+	# let foreman.deb provide both gems in the cache, so that the plugins always
+	# get compatible versions
+	echo 'gem "faraday", "<2"' >> bundler.d/debian.rb
 	/bin/rm -f bundler.d/test.rb bundler.d/development.rb
 	/bin/sed -i '2i  gem "puma-status"' bundler.d/service.rb
 	$(BUNDLE) install


### PR DESCRIPTION
foreman_google and foreman_azure_rm both require faraday let foreman.deb provide both gems in the cache, so that the plugins always get compatible versions

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
