### PR TITLE
Update ruby-foreman-tasks to 7.1.0

### DIFF
--- a/plugins/ruby-foreman-tasks/debian/changelog
+++ b/plugins/ruby-foreman-tasks/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-tasks (7.1.0-1) stable; urgency=low
+
+  * 7.1.0 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Thu, 10 Nov 2022 12:08:09 +0000
+
 ruby-foreman-tasks (7.0.0-2) stable; urgency=low
 
   * Use foreman-plugin.mk

--- a/plugins/ruby-foreman-tasks/debian/gem.list
+++ b/plugins/ruby-foreman-tasks/debian/gem.list
@@ -1,3 +1,3 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman-tasks-7.0.0.gem"
+GEMS="https://rubygems.org/downloads/foreman-tasks-7.1.0.gem"
 GEMS="$GEMS https://rubygems.org/downloads/parse-cron-0.1.4.gem"

--- a/plugins/ruby-foreman-tasks/debian/rules
+++ b/plugins/ruby-foreman-tasks/debian/rules
@@ -12,5 +12,5 @@ PLUGIN_HAS_PACKAGE_JSON = true
 include /usr/share/foreman/foreman-plugin.mk
 
 override_dh_auto_install:
-	cp -r /usr/share/foreman/vendor/ruby/*/gems/foreman-tasks-*/extra ./
+	cp -r ./usr/share/foreman/vendor/ruby/*/gems/foreman-tasks-*/extra ./
 	dh_auto_install

--- a/plugins/ruby-foreman-tasks/foreman-tasks.rb
+++ b/plugins/ruby-foreman-tasks/foreman-tasks.rb
@@ -1,1 +1,1 @@
-gem 'foreman-tasks', '7.0.0'
+gem 'foreman-tasks', '7.1.0'


### PR DESCRIPTION
* Update ruby-foreman-tasks to 7.1.0

* fix copying of extra files since the change to the plugin building

Co-authored-by: Evgeni Golov <evgeni@golov.de>
(cherry picked from commit 0ff61958617cf302174191a4fc330123cb1a8f87)
