### PR TITLE
allow excluding certain gems from auto-updates

### DIFF
--- a/list_updatable_packages
+++ b/list_updatable_packages
@@ -12,6 +12,8 @@ import requests
 import tempfile
 
 SUPPORTED_TEMPLATES = ('foreman_plugin', 'hammer_plugin', 'smart_proxy_plugin')
+# pulp_ostree_client: only prereleases exist and our tooling can't handle that
+EXCLUDED_GEMS = ('pulp_ostree_client',)
 SESSION = requests.Session()
 DEBUG = (len(sys.argv) == 2 and sys.argv[1] == 'debug')
 
@@ -59,6 +61,14 @@ class Spec:
         return 'prereleasesource' in self.globals
 
     @property
+    def is_excluded(self) -> bool:
+        return self.gem_name in EXCLUDED_GEMS
+
+    @property
+    def is_updateable(self) -> bool:
+        return not self.is_nightly and not self.is_excluded
+
+    @property
     def gem_name(self) -> Optional[str]:
         return self.globals.get('gem_name')
 
@@ -87,7 +97,7 @@ def find_gemfile_lock_specs(ci_job: str, subdir: str) -> Generator[Tuple[Spec, s
         path = base_path / package_name / f'{package_name}.spec'
         if path.is_file():
             spec = Spec(path)
-            if not spec.is_nightly:
+            if spec.is_updateable:
                 yield spec, gem['version']
 
 
@@ -95,7 +105,7 @@ def find_packaged_specs() -> Generator[Tuple[Spec, None], None, None]:
     if DEBUG: print('Finding plugin specs')
     for path in Path('packages').glob('*/*/*.spec'):
         spec = Spec(path)
-        if spec.template in SUPPORTED_TEMPLATES and not spec.is_nightly:
+        if spec.template in SUPPORTED_TEMPLATES and spec.is_updateable:
             yield spec, None
 
 
@@ -157,7 +167,7 @@ def build_matrix(specs: Mapping[Spec, Optional[str]]) -> Generator[Mapping[str, 
             if not new_version:
                 new_version = latest_version(spec)
 
-            if current_version != new_version:
+            if current_version != new_version and spec.is_updateable:
                 entry = {
                     'directory': spec.directory,
                     'package_name': spec.package_name,


### PR DESCRIPTION
ostree_client is too special

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
