### PR TITLE
Fixes #35743 - Introduce foreman-obsolete-packages

### DIFF
--- a/comps/comps-foreman-el8.xml
+++ b/comps/comps-foreman-el8.xml
@@ -23,6 +23,7 @@
       <packagereq type="default">foreman-installer-katello</packagereq>
       <packagereq type="default">foreman-journald</packagereq>
       <packagereq type="default">foreman-libvirt</packagereq>
+      <packagereq type="default">foreman-obsolete-packages</packagereq>
       <packagereq type="default">foreman-openstack</packagereq>
       <packagereq type="default">foreman-ovirt</packagereq>
       <packagereq type="default">foreman-plugin</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -112,6 +112,7 @@ foreman_core_packages:
       source_location: https://ci.theforeman.org/job/foreman-develop-source-release
       source_system: jenkins
     foreman-bootloaders-redhat: {}
+    foreman-obsolete-packages: {}
     keycloak-httpd-client-install: {}
     pcp-mmvstatsd: {}
     python-websockify: {}

--- a/packages/foreman/foreman-obsolete-packages/foreman-obsolete-packages.spec
+++ b/packages/foreman/foreman-obsolete-packages/foreman-obsolete-packages.spec
@@ -1,0 +1,24 @@
+Name: foreman-obsolete-packages
+Version: 1.0
+Release: 1%{?dist}
+License: MIT
+Summary: A package to obsolete retired packages
+URL: https://github.com/theforeman/foreman-packaging
+
+Obsoletes: rubygem-fog-google < 1.19.0-2
+
+%description
+This package exists only to obsolete other packages which need to be removed
+from the distribution for some reason.
+
+%prep
+
+%build
+
+%install
+
+%files
+
+%changelog
+* Fri Nov 11 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.0-1
+- Initial package


### PR DESCRIPTION
Sometimes packages are removed from our repositories and we want them to be cleaned up automatically. In case there is no replacement (like when a Foreman plugin is retired), there is nothing to obsolete it.

On EL7 we could abuse the tfm package, but no such thing exists on EL8. Fedora has fedora-obsolete-packages for this purpose. foreman-obsolete-packages should fulfill the same purpose.