### PR TITLE
Update ruby-smart-proxy-remote-execution-ssh to 0.9.0

### DIFF
--- a/plugins/smart_proxy_remote_execution_ssh/changelog
+++ b/plugins/smart_proxy_remote_execution_ssh/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-remote-execution-ssh (0.9.0-1) stable; urgency=low
+
+  * 0.9.0 released
+
+ -- Adam Ruzicka <aruzicka@redhat.com>  Mon, 14 Nov 2022 12:31:01 +0100
+
 ruby-smart-proxy-remote-execution-ssh (0.8.0-1) stable; urgency=low
 
   * 0.8.0 released

--- a/plugins/smart_proxy_remote_execution_ssh/remote_execution_ssh.rb
+++ b/plugins/smart_proxy_remote_execution_ssh/remote_execution_ssh.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_remote_execution_ssh', '0.8.0'
+gem 'smart_proxy_remote_execution_ssh', '0.9.0'


### PR DESCRIPTION
CPs:
- 3.5
