### PR TITLE
Use _sharedstatedir macro in smart proxy plugin template

### DIFF
--- a/gem2rpm/smart_proxy_plugin.spec.erb
+++ b/gem2rpm/smart_proxy_plugin.spec.erb
@@ -14,7 +14,7 @@ config.rules[:ignore] << 'config'
 
 %global foreman_proxy_min_version 1.24
 %global foreman_proxy_dir %{_datadir}/foreman-proxy
-%global foreman_proxy_statedir %{_localstatedir}/lib/foreman-proxy
+%global foreman_proxy_statedir %{_sharedstatedir}/foreman-proxy
 %global foreman_proxy_bundlerd_dir %{foreman_proxy_dir}/bundler.d
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 


### PR DESCRIPTION
Previously this used `%{_root_localstatedir}/lib` because `%{_root_sharedstatedir}` was misdefined in SCLs. Since we've removed SCL support we can use the proper definition again.

Fixes: 300d9abd2de151b893cd8ff909d3ef093ec75903