### PR TITLE
Fixes #35270 - Add isoinfo dependency

### DIFF
--- a/debian/bullseye/foreman-proxy/control
+++ b/debian/bullseye/foreman-proxy/control
@@ -13,7 +13,7 @@ Section: net
 Priority: extra
 Architecture: all
 Depends: ruby, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext, ruby-concurrent (>= 1.0.0), ruby-concurrent (<< 2.0.0), ruby-rsec, ruby-logging, ruby-sd-notify (>= 0.1.0), ruby-sd-notify (<< 0.2.0)
-Recommends: sudo, curl, ping, ruby-gssapi, ruby-rubyipmi (>= 0.10.0), ruby-redfish-client (>= 0.5.1), ruby-rkerberos (>= 0.1.1), ruby-libvirt (>= 0.6.0), ruby-rb-inotify, ruby-jwt (>= 1.5.6), ruby-xmlrpc (>= 0.3), foreman-debug
+Recommends: sudo, curl, ping, ruby-gssapi, ruby-rubyipmi (>= 0.10.0), ruby-redfish-client (>= 0.5.1), ruby-rkerberos (>= 0.1.1), ruby-libvirt (>= 0.6.0), ruby-rb-inotify, ruby-jwt (>= 1.5.6), ruby-xmlrpc (>= 0.3), foreman-debug, genisoimage
 Suggests: foreman-proxy-journald
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems

--- a/debian/focal/foreman-proxy/control
+++ b/debian/focal/foreman-proxy/control
@@ -13,7 +13,7 @@ Section: net
 Priority: extra
 Architecture: all
 Depends: ruby, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext, ruby-concurrent (>= 1.0.0), ruby-concurrent (<< 2.0.0), ruby-rsec, ruby-logging, ruby-sd-notify (>= 0.1.0), ruby-sd-notify (<< 0.2.0)
-Recommends: sudo, curl, ping, ruby-gssapi, ruby-rubyipmi (>= 0.10.0), ruby-redfish-client (>= 0.5.1), ruby-rkerberos (>= 0.1.1), ruby-libvirt (>= 0.6.0), ruby-rb-inotify, ruby-jwt (>= 1.5.6), ruby-xmlrpc (>= 0.3), foreman-debug
+Recommends: sudo, curl, ping, ruby-gssapi, ruby-rubyipmi (>= 0.10.0), ruby-redfish-client (>= 0.5.1), ruby-rkerberos (>= 0.1.1), ruby-libvirt (>= 0.6.0), ruby-rb-inotify, ruby-jwt (>= 1.5.6), ruby-xmlrpc (>= 0.3), foreman-debug, genisoimage
 Suggests: foreman-proxy-journald
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet
  Smart-Proxy is a project which provides a RESTful API to various sub-systems


### PR DESCRIPTION
Refer to [Smart Proxy PR](https://github.com/theforeman/smart-proxy/pull/837).

Adds dependency to install `isoinfo` which is provided by [genisoimage](https://packages.debian.org/search?keywords=genisoimage).

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
