### PR TITLE
Correct auto-requires generation to allow bundled gems in Ruby 2.7

### DIFF
--- a/packages/foreman/rubygem-mail/rubygem-mail.spec
+++ b/packages/foreman/rubygem-mail/rubygem-mail.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.8.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Mail provides a nice Ruby DSL for making, sending and reading emails
 License: MIT
 URL: https://github.com/mikel/mail
@@ -15,6 +15,9 @@ BuildRequires: ruby >= 2.5
 BuildRequires: rubygems-devel
 BuildArch: noarch
 # end specfile generated dependencies
+
+# Prefer to consume net-smtp/net-imap/net-pop as a default gem
+Requires: ruby-default-gems < 3
 
 %description
 A really Ruby Mail handler.
@@ -30,6 +33,12 @@ Documentation for %{name}.
 
 %prep
 %setup -q -n  %{gem_name}-%{version}
+
+# On EL8 rubygem-net-smtp/imap/pop are bundled into ruby-libs package and
+# auto-generated dependencies will break dependency resolution
+%gemspec_remove_dep -g net-smtp
+%gemspec_remove_dep -g net-imap
+%gemspec_remove_dep -g net-pop
 
 %build
 # Create the gem as gem install only works on a gem file
@@ -56,6 +65,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Tue Jan 03 2023 Evgeni Golov - 2.8.0-2
+- Correct auto-requires generation to allow bundled gems in Ruby 2.7
+
 * Sun Jan 01 2023 Foreman Packaging Automation <packaging@theforeman.org> 2.8.0-1
 - Update to 2.8.0
 

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -51,7 +51,7 @@ mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=AppSt
 #baseurl=http://vault.centos.org/centos/8/AppStream/$arch/os/
 failovermethod=priority
 module_hotfixes=1
-excludepkgs=ruby-3*,ruby-devel-3*,ruby-libs-3*,rubygem-rdoc-6.4*
+excludepkgs=ruby-3*,ruby-default-gems-3*,ruby-devel-3*,ruby-libs-3*,rubygem-rdoc-6.4*
 
 [el8-configmanagement-salt]
 name=SaltStack configmanagement


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
