### PR TITLE
Obsolete rubygem-google-api-client < 0.33.2-3

### DIFF
--- a/packages/foreman/foreman-obsolete-packages/foreman-obsolete-packages.spec
+++ b/packages/foreman/foreman-obsolete-packages/foreman-obsolete-packages.spec
@@ -1,11 +1,13 @@
 Name: foreman-obsolete-packages
-Version: 1.0
+Version: 1.1
 Release: 1%{?dist}
 License: MIT
 Summary: A package to obsolete retired packages
 URL: https://github.com/theforeman/foreman-packaging
+BuildArch: noarch
 
 Obsoletes: rubygem-fog-google < 1.19.0-2
+Obsoletes: rubygem-google-api-client < 0.33.2-3
 
 %description
 This package exists only to obsolete other packages which need to be removed
@@ -20,5 +22,9 @@ from the distribution for some reason.
 %files
 
 %changelog
+* Fri Jan 20 2023 Evgeni Golov - 1.1-1
+- Obsolete rubygem-google-api-client < 0.33.2-3
+- Mark the package as noarch
+
 * Fri Nov 11 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.0-1
 - Initial package


### PR DESCRIPTION
Mark the package as noarch

google-api-client was removed in 6f25ff6adffd1290b7e6b533038ac3d51ae4163b
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
