### PR TITLE
Set foreman_min_version on gem creation

### DIFF
--- a/bump_rpm.sh
+++ b/bump_rpm.sh
@@ -94,9 +94,9 @@ if [[ $CURRENT_VERSION != $NEW_VERSION ]] ; then
 				UNPACKED_GEM_DIR=$(mktemp -d)
 				gem unpack --target "$UNPACKED_GEM_DIR" *.gem
 				PLUGIN_LIB="${UNPACKED_GEM_DIR}/${GEM_NAME}-${NEW_VERSION}/lib"
-				REQUIRES_FOREMAN=$(grep --recursive --no-filename requires_foreman $PLUGIN_LIB |sed -E 's/[^0-9.]//g')
+				REQUIRES_FOREMAN=$(grep --recursive --no-filename requires_foreman "$PLUGIN_LIB" | sed -E 's/[^0-9.]//g')
 				if [[ -n $REQUIRES_FOREMAN ]]; then
-					sed -i "/%global foreman_min_version/ s/foreman_min_version.*/foreman_min_version $REQUIRES_FOREMAN/" $SPEC_FILE
+					sed -i "/%global foreman_min_version/ s/foreman_min_version.*/foreman_min_version $REQUIRES_FOREMAN/" "$SPEC_FILE"
 				fi
 				rm -rf "$UNPACKED_GEM_DIR"
 			fi

--- a/gem2rpm/foreman_plugin.spec.erb
+++ b/gem2rpm/foreman_plugin.spec.erb
@@ -1,7 +1,3 @@
-# FIXME:
-#   1. Edit foreman requirement(s) and specify minimum version
-#   2. Delete these lines
-#
 # template: foreman_plugin
 <%-
 require 'json'


### PR DESCRIPTION
Like 267e95a2d756ccfe8060aa33e35ea6b88258d99e did for bump_rpm.sh, this sets the foreman_min_version value for add_gem_package.sh and removes it from the TODO in the template. This reduces the manual work needed to add a Foreman plugin package.

I should note I didn't try this out yet.