### PR TITLE
Drop EL7 compatibility form foreman-tasks

### DIFF
--- a/packages/plugins/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
+++ b/packages/plugins/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
@@ -33,7 +33,6 @@ BuildRequires: rubygem(sinatra)
 BuildRequires: npm(@babel/core) >= 7.7.0
 BuildRequires: npm(@babel/core) < 8.0.0
 BuildRequires: npm(@theforeman/builder) >= 10.1.0
-BuildRequires: npm(@theforeman/builder) < 11.0.0
 BuildRequires: npm(jed) >= 1.1.1
 BuildRequires: npm(jed) < 2.0.0
 # end package.json devDependencies BuildRequires

--- a/packages/plugins/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
+++ b/packages/plugins/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
@@ -1,18 +1,12 @@
 # template: foreman_plugin
-%{?scl:%scl_package rubygem-%{gem_name}}
-%{!?scl:%global pkg_name %{name}}
-%{!?_root_sysconfdir:%global _root_sysconfdir %{_sysconfdir}}
-%{!?_root_bindir:%global _root_bindir %{_bindir}}
-
 %global gem_name foreman-tasks
 %global plugin_name foreman-tasks
 %global foreman_min_version 3.3.0
 
-Name: %{?scl_prefix}rubygem-%{gem_name}
+Name: rubygem-%{gem_name}
 Version: 7.2.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman plugin for showing tasks information for resources and users
-Group: Applications/Systems
 License: GPLv3
 URL: https://github.com/theforeman/foreman-tasks
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
@@ -61,36 +55,23 @@ for managing the tasks.
 
 
 %package doc
-Summary: Documentation for %{pkg_name}
-Group: Documentation
-Requires: %{?scl_prefix}%{pkg_name} = %{version}-%{release}
+Summary: Documentation for %{name}
+Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
 %description doc
-Documentation for %{pkg_name}.
+Documentation for %{name}.
 
 %prep
-%{?scl:scl enable %{scl} - << \EOF}
-gem unpack %{SOURCE0}
-%{?scl:EOF}
-
-%setup -q -D -T -n  %{gem_name}-%{version}
-
-%{?scl:scl enable %{scl} - << \EOF}
-gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
-%{?scl:EOF}
+%setup -q -n  %{gem_name}-%{version}
 
 %build
 # Create the gem as gem install only works on a gem file
-%{?scl:scl enable %{scl} - << \EOF}
-gem build %{gem_name}.gemspec
-%{?scl:EOF}
+gem build ../%{gem_name}-%{version}.gemspec
 
 # %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
 # by default, so that we can move it into the buildroot in %%install
-%{?scl:scl enable %{scl} - << \EOF}
 %gem_install
-%{?scl:EOF}
 
 %install
 mkdir -p %{buildroot}%{gem_dir}
@@ -113,12 +94,12 @@ chmod +x %{buildroot}%{gem_instdir}/extra/dynflow-debug.sh
 ln -s %{gem_instdir}/extra/dynflow-debug.sh %{buildroot}%{foreman_dir}/script/foreman-debug.d/60-dynflow_debug
 
 # Link rake task interface scripts into /usr/bin
-mkdir -p %{buildroot}%{_root_bindir}
-ln -s %{gem_instdir}/extra/foreman-tasks-cleanup.sh %{buildroot}%{_root_bindir}/foreman-tasks-cleanup
-ln -s %{gem_instdir}/extra/foreman-tasks-export.sh %{buildroot}%{_root_bindir}/foreman-tasks-export
+mkdir -p %{buildroot}%{_bindir}
+ln -s %{gem_instdir}/extra/foreman-tasks-cleanup.sh %{buildroot}%{_bindir}/foreman-tasks-cleanup
+ln -s %{gem_instdir}/extra/foreman-tasks-export.sh %{buildroot}%{_bindir}/foreman-tasks-export
 
 # Logrotate script
-install -Dp -m0644 %{SOURCE1} %{buildroot}%{_root_sysconfdir}/logrotate.d/%{gem_name}
+install -Dp -m0644 %{SOURCE1} %{buildroot}%{_sysconfdir}/logrotate.d/%{gem_name}
 
 %post
 type foreman-selinux-relabel >/dev/null 2>&1 && foreman-selinux-relabel 2>&1 >/dev/null || true
@@ -142,8 +123,8 @@ type foreman-selinux-relabel >/dev/null 2>&1 && foreman-selinux-relabel 2>&1 >/d
 %{gem_instdir}/db
 %{gem_instdir}/deploy
 %{gem_instdir}/extra
-%{_root_bindir}/foreman-tasks-cleanup
-%{_root_bindir}/foreman-tasks-export
+%{_bindir}/foreman-tasks-cleanup
+%{_bindir}/foreman-tasks-export
 %exclude %{gem_instdir}/gemfile.d
 %{gem_libdir}
 %{gem_instdir}/locale
@@ -155,7 +136,7 @@ type foreman-selinux-relabel >/dev/null 2>&1 && foreman-selinux-relabel 2>&1 >/d
 %{foreman_bundlerd_plugin}
 %config %{foreman_pluginconf_dir}/%{gem_name}.yaml
 %{foreman_dir}/script/foreman-debug.d/60-dynflow_debug
-%config(noreplace) %{_root_sysconfdir}/logrotate.d/%{gem_name}
+%config(noreplace) %{_sysconfdir}/logrotate.d/%{gem_name}
 %{foreman_assets_plugin}
 %{foreman_assets_foreman}
 %{gem_instdir}/public/assets/foreman_tasks/
@@ -175,6 +156,9 @@ type foreman-selinux-relabel >/dev/null 2>&1 && foreman-selinux-relabel 2>&1 >/d
 %{foreman_plugin_log}
 
 %changelog
+* Tue Feb 21 2023 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 7.2.1-2
+- Remove EL7 compatibility
+
 * Sun Feb 05 2023 Foreman Packaging Automation <packaging@theforeman.org> 7.2.1-1
 - Update to 7.2.1
 


### PR DESCRIPTION
Packit gets confused by these, and we no longer need them so it's a nice cleanup.