### PR TITLE
Updated hammer_cli_foreman to 3.5.1

### DIFF
--- a/dependencies/bullseye/apipie-bindings/changelog
+++ b/dependencies/bullseye/apipie-bindings/changelog
@@ -1,3 +1,9 @@
+ruby-apipie-bindings (0.6.0-1) stable; urgency=low
+
+  * 0.6.0 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Tue, 28 Feb 2023 16:36:20 +0000
+
 ruby-apipie-bindings (0.5.0-2) stable; urgency=low
 
   * Add dependency on ruby-gssapi

--- a/dependencies/bullseye/hammer_cli/changelog
+++ b/dependencies/bullseye/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (3.5.1-1) stable; urgency=low
+
+  * 3.5.1 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Tue, 28 Feb 2023 16:37:00 +0000
+
 ruby-hammer-cli (3.5.0-1) stable; urgency=low
 
   * 3.5.0 released

--- a/dependencies/bullseye/hammer_cli/control
+++ b/dependencies/bullseye/hammer_cli/control
@@ -17,7 +17,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-highline,
          ruby-fast-gettext (>= 1.2.0),
          ruby-locale (>= 2.0.6),
-         ruby-apipie-bindings (>= 0.5.0),
+         ruby-apipie-bindings (>= 0.6.0),
          ruby-unicode-display-width,
          ruby-unicode
 Description: Universal command-line interface

--- a/dependencies/bullseye/hammer_cli_foreman/changelog
+++ b/dependencies/bullseye/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (3.5.1-1) stable; urgency=low
+
+  * 3.5.1 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Tue, 28 Feb 2023 16:37:25 +0000
+
 ruby-hammer-cli-foreman (3.5.0-1) stable; urgency=low
 
   * 3.5.0 released

--- a/dependencies/bullseye/hammer_cli_foreman/control
+++ b/dependencies/bullseye/hammer_cli_foreman/control
@@ -12,8 +12,8 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 3.3.0),
-         ruby-apipie-bindings (>= 0.5.0),
+         ruby-hammer-cli (>= 3.5.1),
+         ruby-apipie-bindings (>= 0.6.0),
          ruby-jwt (>= 2.2.1),
          ruby-rest-client (>= 1.8.0),
          ruby-rest-client (<< 3.0.0)

--- a/dependencies/focal/apipie-bindings/changelog
+++ b/dependencies/focal/apipie-bindings/changelog
@@ -1,3 +1,9 @@
+ruby-apipie-bindings (0.6.0-1) stable; urgency=low
+
+  * 0.6.0 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Tue, 28 Feb 2023 16:36:20 +0000
+
 ruby-apipie-bindings (0.5.0-2) stable; urgency=low
 
   * Add dependency on ruby-gssapi

--- a/dependencies/focal/hammer_cli/changelog
+++ b/dependencies/focal/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (3.5.1-1) stable; urgency=low
+
+  * 3.5.1 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Tue, 28 Feb 2023 16:37:00 +0000
+
 ruby-hammer-cli (3.5.0-1) stable; urgency=low
 
   * 3.5.0 released

--- a/dependencies/focal/hammer_cli/control
+++ b/dependencies/focal/hammer_cli/control
@@ -17,7 +17,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-highline,
          ruby-fast-gettext (>= 1.2.0),
          ruby-locale (>= 2.0.6),
-         ruby-apipie-bindings (>= 0.5.0),
+         ruby-apipie-bindings (>= 0.6.0),
          ruby-unicode-display-width,
          ruby-unicode
 Description: Universal command-line interface

--- a/dependencies/focal/hammer_cli_foreman/changelog
+++ b/dependencies/focal/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (3.5.1-1) stable; urgency=low
+
+  * 3.5.1 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Tue, 28 Feb 2023 16:37:25 +0000
+
 ruby-hammer-cli-foreman (3.5.0-1) stable; urgency=low
 
   * 3.5.0 released

--- a/dependencies/focal/hammer_cli_foreman/control
+++ b/dependencies/focal/hammer_cli_foreman/control
@@ -12,8 +12,8 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 3.3.0),
-         ruby-apipie-bindings (>= 0.5.0),
+         ruby-hammer-cli (>= 3.5.1),
+         ruby-apipie-bindings (>= 0.6.0),
          ruby-jwt (>= 2.2.1),
          ruby-rest-client (>= 1.8.0),
          ruby-rest-client (<< 3.0.0)


### PR DESCRIPTION
Supported Versions:

 * 3.5