### PR TITLE
Make katello-client-bootstrap files owned by root

### DIFF
--- a/packages/katello/katello-client-bootstrap/katello-client-bootstrap.spec
+++ b/packages/katello/katello-client-bootstrap/katello-client-bootstrap.spec
@@ -18,7 +18,7 @@
 
 Name:           katello-client-bootstrap
 Version:        1.7.9
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Client bootstrap utility for Foreman and Katello
 
 Group:          System Environment/Base
@@ -43,11 +43,13 @@ install -m644 -D bootstrap.py %{buildroot}%{_var}/www/html/pub/bootstrap.py
 %files
 %doc README.md
 %doc bootstrap.yml
-%defattr(-,apache,apache,-)
-%{_var}/www/html/pub
+%dir %{_var}/www/html/pub
 %{_var}/www/html/pub/bootstrap.py
 
 %changelog
+* Thu Mar 09 2023 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.7.9-2
+- Make files owned by root
+
 * Wed Apr 20 2022 Evgeni Golov - 1.7.9-1
 - Release katello-client-bootstrap 1.7.9
 


### PR DESCRIPTION
There was a report from a user who saw errors in dnf.log:

```
2023-01-20T16:20:05+0200 SUBDEBUG Installed:
katello-client-bootstrap-1.7.9-1.el8sat.noarch
2023-01-20T16:20:05+0200 INFO warning: user apache does not exist - using
root
warning: group apache does not exist - using root
warning: user apache does not exist - using root
warning: group apache does not exist - using root
```

That implies the package was installed before httpd-filesystem (which normally creates the user + group), or something else was wrong. It's weird because it should depend on /var/www/html provided by httpd-filesystem.

This changes the files to be owned by root, which means apache can't modify them. This is actually desired. Since they're world readable, it should not be a problem and may solve an edge case.