### PR TITLE
Correct the puppet-agent minimum version

### DIFF
--- a/packages/foreman/foreman-installer/foreman-installer.spec
+++ b/packages/foreman/foreman-installer/foreman-installer.spec
@@ -1,7 +1,7 @@
 %{?scl:%global scl_prefix %{scl}-}
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
-%global release 1
+%global release 2
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -19,13 +19,13 @@ BuildArch:  noarch
 
 Requires:   curl
 Requires:   hostname
-Requires:   puppet-agent >= 6.15.0
+Requires:   puppet-agent >= 6.24.0
 Requires:   %{?scl_prefix}rubygem(kafo) >= 6.5.0
 Requires:   %{?scl_prefix}rubygem(kafo) < 7.0.0
 Requires:   %{?scl_prefix_ruby}ruby(release)
 
 BuildRequires: asciidoc
-BuildRequires: puppet-agent >= 6.15.0
+BuildRequires: puppet-agent >= 6.24.0
 BuildRequires: %{?scl_prefix_ruby}rubygem(rake)
 BuildRequires: %{?scl_prefix}rubygem(kafo) >= 6.5.0
 BuildRequires: %{?scl_prefix}rubygem(kafo) < 7.0.0
@@ -141,6 +141,9 @@ done
 %{_sbindir}/foreman-proxy-certs-generate
 
 %changelog
+* Tue Mar 21 2023 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1:3.7.0-0.2.develop
+- Correct Puppet version lower bound
+
 * Wed Feb 22 2023 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1:3.7.0-0.1.develop
 - Bump version to 3.7-develop
 


### PR DESCRIPTION
Modules we include have raised the minimum version to 6.24.0, which introduced the ability to specify the exec command as an array.