### PR TITLE
Updated ruby-foreman-webhooks to 3.1.0

### DIFF
--- a/plugins/ruby-foreman-webhooks/debian/changelog
+++ b/plugins/ruby-foreman-webhooks/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-webhooks (3.1.0-1) stable; urgency=low
+
+  * 3.1.0 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Tue, 21 Mar 2023 15:51:44 +0000
+
 ruby-foreman-webhooks (3.0.5-1) stable; urgency=low
 
   * 3.0.5 released

--- a/plugins/ruby-foreman-webhooks/debian/gem.list
+++ b/plugins/ruby-foreman-webhooks/debian/gem.list
@@ -1,2 +1,2 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman_webhooks-3.0.5.gem"
+GEMS="https://rubygems.org/downloads/foreman_webhooks-3.1.0.gem"

--- a/plugins/ruby-foreman-webhooks/foreman_webhooks.rb
+++ b/plugins/ruby-foreman-webhooks/foreman_webhooks.rb
@@ -1,1 +1,1 @@
-gem 'foreman_webhooks', '3.0.5'
+gem 'foreman_webhooks', '3.1.0'


### PR DESCRIPTION
Supported Versions:

 * Nightly
 * 3.6