### PR TITLE
only match `requires_foreman`, not `requires_foreman_plugin`

### DIFF
--- a/add_gem_package.sh
+++ b/add_gem_package.sh
@@ -26,7 +26,7 @@ generate_gem_package() {
 		UNPACKED_GEM_DIR=$(mktemp -d)
 		gem unpack --target "$UNPACKED_GEM_DIR" *.gem
 		PLUGIN_LIB="${UNPACKED_GEM_DIR}"/${GEM_NAME}-*/lib
-		REQUIRES_FOREMAN=$(grep --recursive --no-filename requires_foreman $PLUGIN_LIB | sed -E 's/[^0-9.]//g')
+		REQUIRES_FOREMAN=$(grep --extended-regexp --recursive --no-filename 'requires_foreman\s' $PLUGIN_LIB | sed -E 's/[^0-9.]//g')
 		if [[ -n $REQUIRES_FOREMAN ]]; then
 			sed -i "/%global foreman_min_version/ s/foreman_min_version.*/foreman_min_version $REQUIRES_FOREMAN/" "$SPEC_FILE"
 		fi

--- a/bump_rpm.sh
+++ b/bump_rpm.sh
@@ -94,7 +94,7 @@ if [[ $CURRENT_VERSION != $NEW_VERSION ]] ; then
 				UNPACKED_GEM_DIR=$(mktemp -d)
 				gem unpack --target "$UNPACKED_GEM_DIR" *.gem
 				PLUGIN_LIB="${UNPACKED_GEM_DIR}/${GEM_NAME}-${NEW_VERSION}/lib"
-				REQUIRES_FOREMAN=$(grep --recursive --no-filename requires_foreman "$PLUGIN_LIB" | sed -E 's/[^0-9.]//g')
+				REQUIRES_FOREMAN=$(grep --extended-regexp --recursive --no-filename 'requires_foreman\s' "$PLUGIN_LIB" | sed -E 's/[^0-9.]//g')
 				if [[ -n $REQUIRES_FOREMAN ]]; then
 					sed -i "/%global foreman_min_version/ s/foreman_min_version.*/foreman_min_version $REQUIRES_FOREMAN/" $SPEC_FILE
 				fi


### PR DESCRIPTION
some (mostly katello-dependant) plugins have a line like

    requires_foreman_plugin 'katello', '>= 3.16.0'

in their engine definition. this leads to wrong substitution as both lines are considered "the minimum foreman version".

by matchiching on `requires_foreman\s` we ensure there is a space after the keyword, and that can only happen once

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
