### PR TITLE
include foreman_assets_* in files also when webpack only

### DIFF
--- a/gem2rpm/foreman_plugin.spec.erb
+++ b/gem2rpm/foreman_plugin.spec.erb
@@ -164,7 +164,7 @@ find %{buildroot}%{gem_instdir}/<%= spec.bindir %> -type f | xargs chmod a+x
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-<% if has_assets -%>
+<% if has_assets || has_webpack -%>
 %{foreman_assets_plugin}
 %{foreman_assets_foreman}
 <% end -%>


### PR DESCRIPTION
for both, sprockets and webpack based, assets we use plugin:assets:precompile, which generates the content under foreman_assets_* regardless whether sprockets assets are present or not.

for plugins that only ship webpack based assets, this means that the template will generate a file list that is insufficient and rpmbuild will complain about unpackaged files. not sure those files are really needed as we don't have sprockets in that case, but its easier to just include them for now.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
