### PR TITLE
Ensure maven:3.8 is enabled on EL8 for Katello

### DIFF
--- a/modulemd/modulemd-katello-el8.yaml
+++ b/modulemd/modulemd-katello-el8.yaml
@@ -23,3 +23,4 @@ data:
       requires:
         foreman: ['el8']
         pki-core: []
+        maven: ['3.8']


### PR DESCRIPTION
The maven 3.5 and 3.6 modules are no longer supported on RHEL. For new installations this enforces that maven:3.8 gets configured. This does not apply for upgrades given maven:3.5 is likely to already be enabled and this case is handled by the installer.

See also https://github.com/theforeman/puppet-candlepin/pull/234 where we ensure this in the installer to handle upgrades.