### PR TITLE
Bump Pulp client versions and katello-repos to 3.28

### DIFF
--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -1,11 +1,11 @@
-%global pulpcore_version 3.22
+%global pulpcore_version 3.28
 
 %define repo_dir %{_sysconfdir}/yum.repos.d
 %define repo_dist %{dist}
 
 %global prereleasesource nightly
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 1
+%global release 2
 
 Name:           katello-repos
 Version:        4.10
@@ -68,6 +68,9 @@ rm -rf %{buildroot}
 %config %{repo_dir}/*.repo
 
 %changelog
+* Tue Aug 15 2023 Ian Ballou <ianballou67@gmail.com> - 4.10-0.2.nightly
+- Bump version to 4.10.0
+
 * Wed May 24 2023 William Bradford Clark <wclark@redhat.com> - 4.10-0.1.nightly
 - Bump version to 4.10.0
 

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -6,7 +6,7 @@
 %global prereleasesource pre.master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
 %global mainver 4.10.0
-%global release 1
+%global release 2
 
 Name: rubygem-%{gem_name}
 Version: %{mainver}
@@ -49,22 +49,23 @@ BuildRequires: rubygem(apipie-rails) >= 0.5.14
 BuildRequires: rubygem(fx) < 1.0
 BuildRequires: rubygem(pg)
 BuildRequires: rubygem(anemone)
-BuildRequires: rubygem(pulpcore_client) >= 3.22.0
-BuildRequires: rubygem(pulpcore_client) < 3.23.0
-BuildRequires: rubygem(pulp_file_client) >= 1.12.0
-BuildRequires: rubygem(pulp_file_client) < 1.13
-BuildRequires: rubygem(pulp_ansible_client) >= 0.16.0
-BuildRequires: rubygem(pulp_ansible_client) < 0.17
-BuildRequires: rubygem(pulp_container_client) >= 2.14.0
-BuildRequires: rubygem(pulp_container_client) < 2.15.0
-BuildRequires: rubygem(pulp_deb_client) >= 2.20.0
-BuildRequires: rubygem(pulp_deb_client) < 2.21
-BuildRequires: rubygem(pulp_rpm_client) >= 3.19.0
-BuildRequires: rubygem(pulp_rpm_client) < 3.20.0
-BuildRequires: rubygem(pulp_certguard_client) < 2.0
-BuildRequires: rubygem(pulp_python_client) >= 3.8.0
-BuildRequires: rubygem(pulp_python_client) < 3.9
-BuildRequires: rubygem(pulp_ostree_client)
+BuildRequires: rubygem(pulpcore_client) >= 3.28.0
+BuildRequires: rubygem(pulpcore_client) < 3.29.0
+BuildRequires: rubygem(pulp_file_client) >= 1.14.0
+BuildRequires: rubygem(pulp_file_client) < 1.15.0
+BuildRequires: rubygem(pulp_ansible_client) >= 0.18.0
+BuildRequires: rubygem(pulp_ansible_client) < 0.19.0
+BuildRequires: rubygem(pulp_container_client) >= 2.15.0
+BuildRequires: rubygem(pulp_container_client) < 2.16.0
+BuildRequires: rubygem(pulp_deb_client) >= 2.21.0
+BuildRequires: rubygem(pulp_deb_client) < 2.22.0
+BuildRequires: rubygem(pulp_rpm_client) >= 3.22.0
+BuildRequires: rubygem(pulp_rpm_client) < 3.23.0
+BuildRequires: rubygem(pulp_certguard_client) < 2.0.0
+BuildRequires: rubygem(pulp_python_client) >= 3.10.0
+BuildRequires: rubygem(pulp_python_client) < 3.11.0
+BuildRequires: rubygem(pulp_ostree_client) >= 2.1.0
+BuildRequires: rubygem(pulp_ostree_client) < 2.2.0
 BuildRequires: rubygem(deface) >= 1.0.2
 BuildRequires: rubygem(deface) < 2.0.0
 BuildRequires: rubygem(angular-rails-templates) >= 1.1.0
@@ -193,6 +194,9 @@ done
 %{foreman_plugin_log}
 
 %changelog
+* Fri Aug 04 2023 Ian Ballou <ianballou67@gmail.com> - 4.10.0-0.2.pre.master
+- Bump Pulpcore client requirements for 3.28
+
 * Wed May 24 2023 William Bradford Clark <wclark@redhat.com> - 4.10.0-0.1.pre.master
 - Bump version to 4.10.0
 


### PR DESCRIPTION
Related:

https://github.com/theforeman/foreman-packaging/pull/9622
https://github.com/Katello/katello/pull/10682