### PR TITLE
Precompile foreman_azure_rm assets

### DIFF
--- a/packages/plugins/rubygem-foreman_azure_rm/rubygem-foreman_azure_rm.spec
+++ b/packages/plugins/rubygem-foreman_azure_rm/rubygem-foreman_azure_rm.spec
@@ -8,7 +8,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 2.2.10
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Azure Resource Manager as a compute resource for The Foreman
 Group: Applications/Systems
 License: GPLv3
@@ -80,6 +80,7 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
+%foreman_precompile_plugin -s
 
 %files
 %dir %{gem_instdir}
@@ -92,6 +93,8 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
+%{foreman_assets_plugin}
+%{foreman_assets_foreman}
 
 %files doc
 %doc %{gem_docdir}
@@ -102,6 +105,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Tue Aug 08 2023 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 2.2.10-2
+- Precompile assets
+
 * Mon Jun 05 2023 Chris Roberts <chrobert@redhat.com> 2.2.10-1
 - Update to 2.2.10
 


### PR DESCRIPTION
Now that it has translations as traditional Javascript assets it needs precompilation, otherwise they can't be loaded at runtime.

Context: https://community.theforeman.org/t/luna-nightly-rpm-pipeline-590-failed/34503