### PR TITLE
Updated hammer_cli[_foreman] to 3.8.0

### DIFF
--- a/dependencies/bullseye/hammer_cli/changelog
+++ b/dependencies/bullseye/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (3.8.0-1) stable; urgency=low
+
+  * 3.8.0 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Fri, 25 Aug 2023 18:20:01 +0000
+
 ruby-hammer-cli (3.7.0-1) stable; urgency=low
 
   * 3.7.0 released

--- a/dependencies/bullseye/hammer_cli_foreman/changelog
+++ b/dependencies/bullseye/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (3.8.0-1) stable; urgency=low
+
+  * 3.8.0 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Fri, 25 Aug 2023 18:20:48 +0000
+
 ruby-hammer-cli-foreman (3.7.0-1) stable; urgency=low
 
   * 3.7.0 released

--- a/dependencies/bullseye/hammer_cli_foreman/control
+++ b/dependencies/bullseye/hammer_cli_foreman/control
@@ -12,7 +12,7 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 3.3.0),
+         ruby-hammer-cli (>= 3.8.0),
          ruby-apipie-bindings (>= 0.5.0),
          ruby-jwt (>= 2.2.1),
          ruby-rest-client (>= 1.8.0),

--- a/dependencies/focal/hammer_cli/changelog
+++ b/dependencies/focal/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (3.8.0-1) stable; urgency=low
+
+  * 3.8.0 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Fri, 25 Aug 2023 18:20:01 +0000
+
 ruby-hammer-cli (3.7.0-1) stable; urgency=low
 
   * 3.7.0 released

--- a/dependencies/focal/hammer_cli_foreman/changelog
+++ b/dependencies/focal/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (3.8.0-1) stable; urgency=low
+
+  * 3.8.0 released
+
+ -- Oleh Fedorenko <ofedoren@redhat.com>  Fri, 25 Aug 2023 18:20:48 +0000
+
 ruby-hammer-cli-foreman (3.7.0-1) stable; urgency=low
 
   * 3.7.0 released

--- a/dependencies/focal/hammer_cli_foreman/control
+++ b/dependencies/focal/hammer_cli_foreman/control
@@ -12,7 +12,7 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 3.3.0),
+         ruby-hammer-cli (>= 3.8.0),
          ruby-apipie-bindings (>= 0.5.0),
          ruby-jwt (>= 2.2.1),
          ruby-rest-client (>= 1.8.0),


### PR DESCRIPTION
Supported Versions:

 * Nightly
 * 3.8: https://github.com/theforeman/foreman-packaging/pull/9710