### PR TITLE
Fix determining latest version in bump_rpm.sh & fix some shellcheck

### DIFF
--- a/bump_rpm.sh
+++ b/bump_rpm.sh
@@ -42,6 +42,7 @@ if [[ -z $2 ]] ; then
 	if [[ $PACKAGE_NAME == *rubygem-* ]]; then
 		ensure_program curl
 		ensure_program jq
+		GEM_NAME=$(awk '/^%global\s+gem_name/ { print $3 }' $SPEC_FILE)
 		NEW_VERSION=$(curl -s https://rubygems.org/api/v1/versions/${GEM_NAME}/latest.json | jq -r .version)
 	else
 		echo "Unknown package type for $1; a version must be specified"


### PR DESCRIPTION
While refactoring I suggested to determine GEM_NAME lazily, but this broke. I also fixed some shellcheck warnings. There are still many left, mostly around `$SPEC_FILE`.

Fixes: 3d4a05733316 ("Handle bumping nodejs RPMs")