### PR TITLE
Depend on libopenscap.so.25 explicitly

### DIFF
--- a/packages/plugins/rubygem-openscap/rubygem-openscap.spec
+++ b/packages/plugins/rubygem-openscap/rubygem-openscap.spec
@@ -3,26 +3,22 @@
 %{!?scl:%global pkg_name %{name}}
 
 %global gem_name openscap
-%global min_openscap_version 1.2.9
-%global max_openscap_version 1.3.8
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.4.9
-Release: 8%{?dist}
+Release: 9%{?dist}
 Summary: A FFI wrapper around the OpenSCAP library
 Group: Development/Languages
 License: GPLv2+
 URL: https://github.com/OpenSCAP/ruby-openscap
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
-# require libopenscap.so.8 in an arch neutral way
-Requires: openscap >= %{min_openscap_version}
-Requires: openscap < %{max_openscap_version}
-
-BuildRequires: openscap >= %{min_openscap_version}
-BuildRequires: openscap < %{max_openscap_version}
-BuildRequires: openscap-devel
-BuildRequires: bzip2
+# CI runs rpmlint on EL7
+%if 0%{?rhel} >= 8
+# Loaded via FFI
+Requires: (libopenscap.so.25()(64bit) if libc.so.6()(64bit))
+Requires: (libopenscap.so.25 if libc.so.6)
+%endif
 
 # start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
@@ -92,6 +88,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Wed Mar 08 2023 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 0.4.9-9
+- Depend on libopenscap.so.25 explicitly
+
 * Mon Feb 13 2023 Evgeni Golov - 0.4.9-8
 - Fixes #36086 - Allow openscap 1.3.7
 


### PR DESCRIPTION
In the past we depended on the package name, but that was to support both EL7 & EL8. Now we're EL8 only so we can make it more narrow. That means we no longer need to maintain a version range, which breaks on some EL updates.

It copies the library dependency bit from rubygems-ruby-vips.spec, so it correctly works for all arches as was recommended on the Fedora devel list[1].

[1]: https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/

(cherry picked from commit 71809c15006de5fa6f47878bc64aae02efc2dcbe)

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

Supported Versions:

 * Nightly
 * 2.0
 * 1.24
 * 1.23
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
