### PR TITLE
Build Foreman Client for REX Pull Provider on SLES

### DIFF
--- a/packages/client/foreman_ygg_worker/foreman_ygg_worker.spec
+++ b/packages/client/foreman_ygg_worker/foreman_ygg_worker.spec
@@ -15,14 +15,18 @@
         go build -buildmode pie -compiler gc -tags="rpm_crashtraceback libtrust_openssl ${BUILDTAGS:-}" -ldflags "${LDFLAGS:-} -linkmode=external -compressdwarf=false -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '%__global_ldflags'" -a -v %{?**};
 %else
 %if ! 0%{?gobuild:1}
+%if 0%{?suse_version}
+%define gobuild(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -a -v %{?**};
+%else
 %define gobuild(o:) GO111MODULE=off go build -buildmode pie -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "${LDFLAGS:-} -linkmode=external -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld '" -a -v %{?**};
+%endif
 %endif
 %endif
 
 Name: foreman_ygg_worker
 Version: 0.2.2
 Summary: Worker service for yggdrasil that can act as pull client for Foreman Remote Execution
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: MIT
 
 Source0: https://github.com/%{repo_orgname}/%{repo_name}/releases/download/v%{version}/%{repo_name}-%{version}.tar.gz
@@ -34,7 +38,12 @@ Url: https://github.com/%{repo_orgname}/%{repo_name}/
 %endif
 ExclusiveArch: %{go_arches}
 
+%if 0%{?suse_version}
+BuildRequires: go
+%else
 BuildRequires: golang
+BuildRequires: redhat-rpm-config
+%endif
 Requires: yggdrasil
 
 %description
@@ -70,6 +79,9 @@ EOF
 %doc README.md
 
 %changelog
+* Fri Oct 27 2023 Maximilian Kolb <kolb@atix.de> - 0.2.2-2
+- Require go and disable hardened go linker on SLES
+
 * Fri Oct 13 2023 Eric D. Helms <ericdhelms@gmail.com> - 0.2.2-1
 - Release 0.2.2
 

--- a/packages/client/yggdrasil/yggdrasil.spec
+++ b/packages/client/yggdrasil/yggdrasil.spec
@@ -2,7 +2,7 @@
 
 Name:    yggdrasil
 Version: 0.2.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Message dispatch agent for cloud-connected systems
 License: GPLv3
 URL:     https://github.com/redhatinsights/yggdrasil
@@ -20,8 +20,13 @@ Patch2:  Propagate-FOREMAN_REX_WORKDIR-to-workers.patch
 ExclusiveArch: %{go_arches}
 
 BuildRequires: git
-BuildRequires: golang
+%if 0%{?suse_version}
+BuildRequires: dbus-1-devel
+BuildRequires: go
+%else
 BuildRequires: dbus-devel
+BuildRequires: golang
+%endif
 BuildRequires: systemd-devel
 
 Requires: subscription-manager
@@ -42,6 +47,7 @@ BUILDFLAGS="%buildflags" \
 make PREFIX=%{_prefix} \
      SYSCONFDIR=%{_sysconfdir} \
      LOCALSTATEDIR=%{_localstatedir} \
+     LIBEXECDIR=%{_libexecdir} \
      SHORTNAME=%{name} \
      LONGNAME=%{name} \
      PKGNAME=%{name} \
@@ -53,6 +59,7 @@ BUILDFLAGS="%buildflags" \
 make PREFIX=%{_prefix} \
      SYSCONFDIR=%{_sysconfdir} \
      LOCALSTATEDIR=%{_localstatedir} \
+     LIBEXECDIR=%{_libexecdir} \
      DESTDIR=%{buildroot} \
      SHORTNAME=%{name} \
      LONGNAME=%{name} \
@@ -72,6 +79,9 @@ make PREFIX=%{_prefix} \
 %{_libexecdir}/%{name}
 
 %changelog
+* Fri Oct 27 2023 Maximilian Kolb <kolb@atix.de> - 0.2.3-2
+- Require go on SLES
+
 * Wed Oct 18 2023 Adam Ruzicka <aruzicka@redhat.com> - 0.2.3-1
 - Bump version to 0.2.3
 


### PR DESCRIPTION
* On EL, the golang package is called "golang"; on openSUSE and SLES, it's called "go".
* Require redhat-rpm-config for go When building the Foreman Client for REX pull mode, you have to compile go code. On EL, you can set a flag that requires the file "redhat-hardened-ld" which is part of the "redhat-rpm-config" package. See https://fedora.pkgs.org/rawhide/fedora-x86_64/redhat-rpm-config-264-1.fc40.noarch.rpm.html
* Do not use hardened linker on SLES Hardened go linker requires "redhat-rpm-config" which is not available on openSUSE and SLES systems.
* DBus package name depends on distribution
* Remove ldflags for compiling go on SLES
* Unset GO111MODULE on SLES
* Change bin path for yggdrasil on SLES