### PR TITLE
Use nodejs 12 for version bumps

### DIFF
--- a/.github/workflows/bump_packages.yml
+++ b/.github/workflows/bump_packages.yml
@@ -47,7 +47,7 @@ jobs:
       if: ${{ matrix.npm_name != null }}
       uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 12
     - name: Install npm2rpm
       if: ${{ matrix.npm_name != null }}
       run: npm install --global npm2rpm


### PR DESCRIPTION
I do not know why I picked 14 to begin with, this has to be the same version as the build environment or we get failures like https://github.com/theforeman/foreman-packaging/pull/9674 for packages that have C bindings.