### PR TITLE
Use an absolute path to the spec file

### DIFF
--- a/bump_rpm.sh
+++ b/bump_rpm.sh
@@ -42,7 +42,7 @@ if [[ -z $2 ]] ; then
 	if [[ $PACKAGE_NAME == *rubygem-* ]]; then
 		ensure_program curl
 		ensure_program jq
-		GEM_NAME=$(awk '/^%global\s+gem_name/ { print $3 }' $SPEC_FILE)
+		GEM_NAME=$(awk '/^%global\s+gem_name/ { print $3 }' "$1"/$SPEC_FILE)
 		NEW_VERSION=$(curl -s "https://rubygems.org/api/v1/versions/${GEM_NAME}/latest.json" | jq -r .version)
 	else
 		echo "Unknown package type for $1; a version must be specified"


### PR DESCRIPTION
The line was copied from a place where there was a cd "$1" in place.

Fixes: 52ea3509d11ff1e3709578951940efd6c9353b1d ("Fix determining latest version in bump_rpm.sh")