### PR TITLE
Drop foreman- prefix on project names in Copr

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -48,10 +48,9 @@ copr_projects:
     rhel_7: '7'
     root_repo_url: https://download.copr.fedorainfracloud.org/results/@theforeman
     foreman_staging: "{{ root_repo_url }}/foreman-{{ foreman_version }}-staging"
-    plugins_staging: "{{ root_repo_url }}/foreman-plugins-{{ foreman_version }}-staging"
-    katello_staging: "{{ root_repo_url }}/foreman-katello-{{ foreman_version }}-staging"
-    candlepin_staging: "{{ root_repo_url }}/foreman-candlepin-{{ foreman_version }}-staging"
-    client_staging: "{{ root_repo_url }}/foreman-client-{{ foreman_version }}-staging"
+    plugins_staging: "{{ root_repo_url }}/plugins-{{ foreman_version }}-staging"
+    katello_staging: "{{ root_repo_url }}/katello-{{ foreman_version }}-staging"
+    client_staging: "{{ root_repo_url }}/client-{{ foreman_version }}-staging"
   hosts:
     foreman-copr:
       copr_project_name: "foreman-{{ foreman_version }}-staging"
@@ -63,7 +62,7 @@ copr_projects:
             - "{{ foreman_staging }}/rhel-{{ rhel_8 }}-x86_64"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-el{{ rhel_8 }}.xml"
     plugins-copr:
-      copr_project_name: "foreman-plugins-{{ foreman_version }}-staging"
+      copr_project_name: "plugins-{{ foreman_version }}-staging"
       copr_project_chroots:
         - name: "rhel-{{ rhel_8 }}-x86_64"
           modules: "{{ core_modules }}"
@@ -72,7 +71,7 @@ copr_projects:
             - "{{ plugins_staging }}/rhel-{{ rhel_8 }}-x86_64"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-plugins-el{{ rhel_8 }}.xml"
     katello-copr:
-      copr_project_name: "foreman-katello-{{ foreman_version }}-staging"
+      copr_project_name: "katello-{{ foreman_version }}-staging"
       copr_project_chroots:
         - name: "rhel-{{ rhel_8 }}-x86_64"
           modules: "{{ core_modules }}"
@@ -81,12 +80,8 @@ copr_projects:
             - "{{ plugins_staging }}/rhel-{{ rhel_8 }}-x86_64"
             - "{{ katello_staging }}/rhel-{{ rhel_8 }}-x86_64"
           comps_file: "{{ inventory_dir }}/comps/comps-katello-el{{ rhel_8 }}.xml"
-    candlepin-copr:
-      copr_project_name: "foreman-candlepin-{{ foreman_version }}-staging"
-      copr_project_chroots:
-        - name: "rhel-{{ rhel_8 }}-x86_64"
     client-copr:
-      copr_project_name: "foreman-client-{{ foreman_version }}-staging"
+      copr_project_name: "client-{{ foreman_version }}-staging"
       copr_project_chroots:
         - name: "rhel-{{ rhel_9 }}-x86_64"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-client-el{{ rhel_9 }}.xml"


### PR DESCRIPTION
This would better reflect how we layout the repositories in staging and production (see proposal below). And prevent some translation having to happen inside the stage generation script.


https://github.com/theforeman/foreman-infra/issues/1937
