### PR TITLE
Install nokogiri in package update job

### DIFF
--- a/.github/workflows/bump_packages.yml
+++ b/.github/workflows/bump_packages.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y --no-install-recommends rpm git-annex python3-semver
-        sudo gem install gem2rpm --no-document
+        sudo gem install gem2rpm nokogiri --no-document
         sudo curl --create-dirs -o /usr/local/bin/spectool https://pagure.io/rpmdevtools/raw/26a8abc746fba9c0b32eb899b96c92841a37855a/f/spectool.in
         echo 'echo "$GIT_AUTHOR_NAME <$GIT_AUTHOR_EMAIL>"' | sudo tee /usr/local/bin/rpmdev-packager
         sudo chmod +x /usr/local/bin/spectool /usr/local/bin/rpmdev-packager


### PR DESCRIPTION
Based on https://github.com/theforeman/foreman-packaging/actions/runs/6434684686/job/17474394173

```
FINISHED
Updating comps... - 
<internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- nokogiri (LoadError)
	from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from ./add_to_comps.rb:2:in `<main>'
Error: Process completed with exit code 1.
```

Thar probably be dragons with this attempt given nokogiri's past.