### PR TITLE
Fix how add_npm_package determines if an update is needed

### DIFF
--- a/add_npm_package.sh
+++ b/add_npm_package.sh
@@ -18,6 +18,7 @@ else
   PACKAGE_NAME=nodejs-${PACKAGE_MODULE}
 fi
 PACKAGE_DIR=packages/$BASE_DIR/$PACKAGE_NAME
+SPEC_FILE="${PACKAGE_DIR}/${PACKAGE_NAME}.spec"
 
 ROOT=$(git rev-parse --show-toplevel)
 
@@ -138,7 +139,7 @@ if [[ -z $STRATEGY ]] ; then
   echo "Found $DEPENDENCIES dependencies - using $STRATEGY strategy"
 fi
 
-if [ -f "$PACKAGE_DIR"/*.spec ]; then
+if [[ -f "${SPEC_FILE}" ]]; then
   echo -n "Detected update..."
   UPDATE=true
 else
@@ -146,7 +147,7 @@ else
 fi
 
 if [[ $UPDATE == true ]] ; then
-  EXISTING_VERSION=$(rpmspec --query --srpm --queryformat '%{VERSION}' $PACKAGE_DIR/*.spec)
+  EXISTING_VERSION=$(rpmspec --query --srpm --queryformat '%{VERSION}' "$SPEC_FILE")
   if [[ $REWRITE_ON_SAME_VERSION == true ]] || [[ $VERSION != $EXISTING_VERSION ]]; then
     generate_npm_package
     git commit -m "Bump $PACKAGE_NAME to $VERSION"

--- a/bump_rpm.sh
+++ b/bump_rpm.sh
@@ -129,7 +129,7 @@ if [[ $CURRENT_VERSION != "$NEW_VERSION" ]] ; then
 			NPM_STRATEGY='single'
 		fi
 
-		UPDATE=true "$SCRIPT_DIR"/add_npm_package.sh "$NPM_NAME" "$NEW_VERSION" "$NPM_STRATEGY"
+		"$SCRIPT_DIR"/add_npm_package.sh "$NPM_NAME" "$NEW_VERSION" "$NPM_STRATEGY"
 	else
 		echo "TODO:"
 		echo "* Verify the dependencies"


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
