### PR TITLE
Add a Containerfile to represent the current build environment

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,21 @@
+FROM centos:stream8
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+
+RUN echo "[git-annex]" >> /etc/yum.repos.d/git-annex.repo \
+         && echo "name=git-annex" >> /etc/yum.repos.d/git-annex.repo \
+         && echo "baseurl='https://downloads.kitenet.net/git-annex/linux/current/rpms/'" >> /etc/yum.repos.d/git-annex.repo \
+         && echo "gpgcheck=0" >> /etc/yum.repos.d/git-annex.repo \
+         && echo "enabled=1" >> /etc/yum.repos.d/git-annex.repo
+
+RUN dnf -y module enable nodejs:14 ruby:2.7
+RUN dnf -y install nodejs vim git rpmdevtools git-annex-standalone wget python3 ruby jq ruby-devel make gcc-c++ postgresql-devel libvirt-devel libxml2-devel libcurl-devel systemd-devel
+
+RUN npm install npm2rpm --global
+
+RUN pip3 install packaging requests
+
+RUN mkdir -p /opt/foreman-packaging
+WORKDIR /opt/foreman-packaging

--- a/build-container
+++ b/build-container
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+podman build . -t foreman-packaging

--- a/enter-container
+++ b/enter-container
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+podman run --rm --privileged -it -v ./:/opt/foreman-packaging foreman-packaging


### PR DESCRIPTION
All our various scripts are in a variety of languages and dependencies, which I lose track of and sometimes need a defined environment in order to perform actions.

Additionally, the NPM ecosystem with our packaging requires that the sources be generated with the right version of NodeJS which is not available locally on a more up to date Fedora for example. This provides an easy to use environment that is configured with that right set of versions.
