### PR TITLE
Remove duplicated required_ruby_version block

### DIFF
--- a/gem2rpm/foreman_plugin.spec.erb
+++ b/gem2rpm/foreman_plugin.spec.erb
@@ -43,9 +43,6 @@ Source0: <%= download_path %>%{gem_name}-%{version}.gem
 
 # start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
-<% for req in spec.required_ruby_version -%>
-Requires: ruby<%= " #{req}" unless req.empty? %>
-<% end -%>
 <% if has_assets || has_webpack -%>
 BuildRequires: foreman-assets >= %{foreman_min_version}
 <% end -%>


### PR DESCRIPTION
Fixes: 3f4c04273594 ("Update based on fedora-27-rawhide.spec.erb to rely on autorequire and provides")