### PR TITLE
Fixes #36868 - Automatically depend on the correct SELinux policy

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -4,7 +4,7 @@
 %global dynflow_sidekiq_service_name dynflow-sidekiq@
 %global rake /usr/bin/rake
 
-%global release 4
+%global release 5
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -24,6 +24,8 @@ BuildArch:  noarch
 
 # Plugin was removed in Foreman 3.3, 3.5 includes DB cleanup
 Obsoletes: rubygem-foreman_docker < 5.0.0-4
+
+Requires: (%{name}-selinux if selinux-policy-targeted)
 
 Requires: ruby(release)
 Requires: rubygems
@@ -1010,6 +1012,9 @@ exit 0
 %systemd_postun %{name}.socket
 
 %changelog
+* Thu Oct 26 2023 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.9.0-0.5.develop
+- Automatically depend on selinux package if needed
+
 * Fri Oct 13 2023 Eric D. Helms <ericdhelms@gmail.com> - 3.9.0-0.4.develop
 - Require fapolicyd rules package if fapolicyd is present
 

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -6,7 +6,7 @@
 %global prereleasesource pre.master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
 %global mainver 4.11.0
-%global release 3
+%global release 4
 
 Name: rubygem-%{gem_name}
 Version: %{mainver}
@@ -18,6 +18,7 @@ Source0: https://rubygems.org/downloads/%{gem_name}-%{version}%{?prerelease}.gem
 
 Requires: foreman-postgresql
 Requires: foreman < %{foreman_max_version}
+Requires: (katello-selinux if selinux-policy-targeted)
 
 # start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
@@ -193,6 +194,9 @@ done
 %{foreman_plugin_log}
 
 %changelog
+* Thu Oct 26 2023 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 4.11.0-0.4.pre.master
+- Automatically depend on selinux package if needed
+
 * Fri Sep 29 2023 Eric D. Helms <ericdhelms@gmail.com> - 4.11.0-0.3.pre.master
 - Drop rubygem-qpid_proton
 


### PR DESCRIPTION
Using RPM rich dependencies it's possible to install the correct policy if needed. This can be done for both foreman and rubygem-katello.