### PR TITLE
Fix foreman_ygg_worker build on CentOS 9-stream

### DIFF
--- a/packages/client/foreman_ygg_worker/foreman_ygg_worker.spec
+++ b/packages/client/foreman_ygg_worker/foreman_ygg_worker.spec
@@ -22,7 +22,7 @@
 Name: foreman_ygg_worker
 Version: 0.2.2
 Summary: Worker service for yggdrasil that can act as pull client for Foreman Remote Execution
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: MIT
 
 Source0: https://github.com/%{repo_orgname}/%{repo_name}/releases/download/v%{version}/%{repo_name}-%{version}.tar.gz
@@ -45,7 +45,7 @@ Worker service for yggdrasil that can act as pull client for Foreman Remote Exec
 
 %build
 mkdir -p _gopath/src
-ln -fs $(pwd)/src _gopath/src/%{name}-%{version}
+cp -av $(pwd)/src _gopath/src/%{name}-%{version}
 ln -fs $(pwd)/vendor _gopath/src/%{name}-%{version}/vendor
 export GOPATH=$(pwd)/_gopath
 pushd _gopath/src/%{name}-%{version}
@@ -70,6 +70,9 @@ EOF
 %doc README.md
 
 %changelog
+* Fri Nov 10 2023 Bernhard Suttner <suttner@atix.de> - 0.2.2-2
+- Fix build on CentOS 9-stream
+
 * Fri Oct 13 2023 Eric D. Helms <ericdhelms@gmail.com> - 0.2.2-1
 - Release 0.2.2
 


### PR DESCRIPTION
This fixes a build issue on CentOS 9 stream:

```
+ head -c20 /dev/urandom
+ od -An -tx1
+ tr -d ' \n'
+ go build -buildmode pie -compiler gc '-tags=rpm_crashtraceback libtrust_openssl ' -ldflags ' -linkmode=external -compressdwarf=false -B 0x9155578dd8908ef952f7d130ca0a82e638b73252 -extldflags '\''-Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 '\''' -a -v
go: open ../../../go.mod: no such file or directory
```

