### PR TITLE
Update ruby-smart-proxy-remote-execution-ssh to 0.10.3

### DIFF
--- a/plugins/smart_proxy_remote_execution_ssh/changelog
+++ b/plugins/smart_proxy_remote_execution_ssh/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-remote-execution-ssh (0.10.3-1) stable; urgency=low
+
+  * 0.10.3 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Thu, 16 Nov 2023 12:16:30 +0000
+
 ruby-smart-proxy-remote-execution-ssh (0.10.2-1) stable; urgency=low
 
   * 0.10.2 released

--- a/plugins/smart_proxy_remote_execution_ssh/changelog
+++ b/plugins/smart_proxy_remote_execution_ssh/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-remote-execution-ssh (0.10.2-1) stable; urgency=low
+
+  * 0.10.2 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Thu, 26 Oct 2023 15:18:13 +0000
+
 ruby-smart-proxy-remote-execution-ssh (0.10.1-1) stable; urgency=low
 
   * 0.10.1 released

--- a/plugins/smart_proxy_remote_execution_ssh/remote_execution_ssh.rb
+++ b/plugins/smart_proxy_remote_execution_ssh/remote_execution_ssh.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_remote_execution_ssh', '0.10.2'
+gem 'smart_proxy_remote_execution_ssh', '0.10.3'

--- a/plugins/smart_proxy_remote_execution_ssh/remote_execution_ssh.rb
+++ b/plugins/smart_proxy_remote_execution_ssh/remote_execution_ssh.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_remote_execution_ssh', '0.10.1'
+gem 'smart_proxy_remote_execution_ssh', '0.10.2'


### PR DESCRIPTION
(cherry picked from commit 4b7a265ebc1cb02c58a4b9fcd5c70e4de8de12f0)