### PR TITLE
use el7 everywhere for Copr

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -157,13 +157,6 @@ foreman_packages:
         - el8-powertools
         - el8-puppet-7
         - "el8-katello-candlepin-{{ katello_version }}"
-      rhel-8-x86_64:
-        - el8-baseos
-        - el8-appstream
-        - el8-extras
-        - el8-powertools
-        - el8-puppet-7
-        - "el8-katello-candlepin-{{ katello_version }}"
   children:
     foreman_core_packages: {}
     foreman_proxy_packages: {}
@@ -575,7 +568,7 @@ foreman_client_packages:
         - "el9-foreman-client-{{ foreman_version }}"
       el8:
         - "el8-foreman-client-{{ foreman_version }}"
-      rhel7:
+      el7:
         - "el7-foreman-client-{{ foreman_version }}"
     repoclosure_lookaside_repos:
       el9:
@@ -589,7 +582,7 @@ foreman_client_packages:
         - el8-epel
         - el8-extras
         - el8-puppet-7
-      rhel7:
+      el7:
         - el7-base
         - el7-updates
         - el7-epel
@@ -941,11 +934,11 @@ repoclosures:
           - el8-puppet-7
     foreman-client-repoclosure-el7:
       repoclosure_target_repos:
-        rhel7:
+        el7:
           - "el7-foreman-client-{{ foreman_version }}"
-      repoclosure_target_dist: rhel7
+      repoclosure_target_dist: el7
       repoclosure_lookaside_repos:
-        rhel7:
+        el7:
           - el7-base
           - el7-updates
           - el7-epel
@@ -1018,11 +1011,11 @@ repoclosures:
           - el8-puppet-7
     foreman-client-staging-repoclosure-el7:
       repoclosure_target_repos:
-        rhel7:
+        el7:
           - "el7-foreman-client-{{ foreman_version }}-staging"
-      repoclosure_target_dist: rhel7
+      repoclosure_target_dist: el7
       repoclosure_lookaside_repos:
-        rhel7:
+        el7:
           - el7-base
           - el7-updates
           - el7-epel
@@ -1045,7 +1038,7 @@ foreman_release_packages:
         - "el9-foreman-client-{{ foreman_version }}"
       el8:
         - "el8-foreman-client-{{ foreman_version }}"
-      rhel7:
+      el7:
         - "el7-foreman-client-{{ foreman_version }}"
     repoclosure_lookaside_repos:
       el9:
@@ -1058,7 +1051,7 @@ foreman_release_packages:
         - el8-powertools
         - el8-extras
         - el8-puppet-7
-      rhel7:
+      el7:
         - el7-base
         - el7-updates
         - el7-epel


### PR DESCRIPTION
While the Copr chroot is called rhel-7-x86_64 we translate that to "el7" in Jenkins, so all invocations should use the normalized name. Adjust the config to match.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
