### PR TITLE
Drop requirement on foreman-debug

### DIFF
--- a/packages/foreman/foreman-proxy/foreman-proxy.spec
+++ b/packages/foreman/foreman-proxy/foreman-proxy.spec
@@ -1,7 +1,7 @@
 %global homedir %{_datadir}/%{name}
 %global confdir config
 
-%global release 1
+%global release 2
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -30,8 +30,6 @@ Requires:       rubygem(bundler_ext)
 
 # Require fapolicyd package if fapolicyd is present
 Requires: (%{name}-fapolicyd if fapolicyd)
-
-Requires:       foreman-debug
 
 # These come from smart_proxy.gemspec - get-gemfile-deps can't handle that yet
 Requires:       rubygem(json)
@@ -239,6 +237,9 @@ exit 0
 
 
 %changelog
+* Wed Jan 03 2024 Evgeni Golov - 3.10.0-0.2.develop
+- Drop requirement on foreman-debug
+
 * Wed Nov 29 2023 Zach Huntington-Meath <zhunting@redhat.com> - 3.10.0-0.1.develop
 - Bump version to 3.10-develop
 

--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -4,7 +4,7 @@
 %global dynflow_sidekiq_service_name dynflow-sidekiq@
 %global rake /usr/bin/rake
 
-%global release 2
+%global release 3
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -44,9 +44,6 @@ Requires(preun): systemd-units
 
 # Require fapolicyd package if fapolicyd is present
 Requires: (%{name}-fapolicyd if fapolicyd)
-
-# Subpackages
-Requires: %{name}-debug
 
 # start specfile default Requires
 Requires: (rubygem(rails) >= 6.1.6 with rubygem(rails) < 6.2.0)
@@ -866,6 +863,9 @@ exit 0
 %systemd_postun %{name}.socket
 
 %changelog
+* Wed Jan 03 2024 Evgeni Golov - 3.10.0-0.3.develop
+- Drop requirement on foreman-debug
+
 * Tue Dec 12 2023 Evgeni Golov - 3.10.0-0.2.develop
 - Update GEM dependencies
 


### PR DESCRIPTION
This still packages the integration bits, just doesn't force the users to install foreman-debug.