### PR TITLE
Add EL9 compatibility to forman-bootloaders-redhat

### DIFF
--- a/packages/foreman/foreman-bootloaders-redhat/foreman-bootloaders-redhat.spec
+++ b/packages/foreman/foreman-bootloaders-redhat/foreman-bootloaders-redhat.spec
@@ -1,6 +1,6 @@
 Name: foreman-bootloaders-redhat
 Version: 202102220000
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Metapackage with Grub2 and Shim TFTP bootloaders
 
 Group: Applications/System
@@ -10,8 +10,12 @@ BuildArch: noarch
 
 Source0: foreman-generate-bootloaders
 
-Requires: grub2-tools-extra
+Requires: /usr/bin/grub2-mknetdir
+Requires: /usr/bin/grub2-mkimage
+
+%if 0%{rhel} < 9
 Requires: grub2-efi-ia32-modules
+%endif
 Requires: grub2-efi-x64-modules
 Requires: grub2-pc-modules
 Requires: shim-ia32
@@ -69,6 +73,9 @@ install -Dp -m0755 %{SOURCE0} %{buildroot}%{_bindir}/foreman-generate-bootloader
 
 
 %changelog
+* Wed Jan 03 2024 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 202102220000-2
+- EL9 compatibility
+
 * Fri Feb 19 2021 Oliver Freyermuth <o.freyermuth@googlemail.com> 202102220000-1
 - Add efinet module only on *-efi platforms.
 

--- a/packages/foreman/foreman-bootloaders-redhat/foreman-generate-bootloaders
+++ b/packages/foreman/foreman-bootloaders-redhat/foreman-generate-bootloaders
@@ -17,8 +17,12 @@ generate() {
   grub2-mkimage -d /usr/lib/grub/$1/ -O $1 -o /var/lib/tftpboot/$2 -p "grub2" $MODULES $MODULES_EFI
 }
 
+has_pkg() {
+  rpm -q "$1" &>/dev/null
+}
+
 check_pkg() {
-  rpm -q "$1" &>/dev/null || ( echo "Please install: yum -y install $1" >/dev/stderr && exit 1 )
+  has_pkg "$1" || ( echo "Please install: yum -y install $1" >/dev/stderr && exit 1 )
 }
 
 if [[ "$ARCH" == "aa64" ]]; then
@@ -42,8 +46,11 @@ elif [[ "$ARCH" == "ppc64le" ]]; then
 else
   check_pkg grub2-pc-modules
   generate i386-pc grub2/grubia32.0
-  check_pkg grub2-efi-ia32-modules
-  generate i386-efi grub2/grubia32.efi
+
+  if has_pkg grub2-efi-ia32-modules ; then
+    generate i386-efi grub2/grubia32.efi
+  fi
+
   check_pkg grub2-efi-x64-modules
   generate x86_64-efi grub2/grubx64.efi
 fi


### PR DESCRIPTION
On EL9 the grub2-efi-ia32-modules package has been dropped.

Technically the changes to requires aren't needed, but it makes it explicit and no longer depends on shim-x64 pulling in grub2-tools.