### PR TITLE
only configure python 3.11 for plugins not core

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -45,6 +45,8 @@ copr_projects:
       - 'postgresql:12'
     core_buildroot_packages:
       - 'foreman-build'
+    plugins_buildroot_packages:
+      - 'foreman-build'
       - python3.11-rpm-macros
       - python3.11
     rhel_9: '9'
@@ -95,7 +97,7 @@ copr_projects:
             - "{{ foreman_staging }}/rhel-{{ rhel_8 }}-x86_64"
             - "{{ plugins_staging }}/rhel-{{ rhel_8 }}-x86_64"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-plugins-el{{ rhel_8 }}.xml"
-          buildroot_packages: "{{ core_buildroot_packages }}"
+          buildroot_packages: "{{ plugins_buildroot_packages }}"
     katello-copr:
       copr_project_name: "katello-{{ katello_version }}-staging"
       copr_project_fork_from: "{{ 'katello-nightly-staging' if foreman_version != 'nightly' else False }}"


### PR DESCRIPTION
this way we can still build foreman_maintain, websockify and other core bits with system python

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
