### PR TITLE
only configure python 3.11 for plugins not core

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -45,6 +45,8 @@ copr_projects:
       - 'postgresql:12'
     core_buildroot_packages:
       - 'foreman-build'
+    plugins_buildroot_packages:
+      - 'foreman-build'
       - python3.11-rpm-macros
       - python3.11
     rhel_9: '9'
@@ -78,7 +80,7 @@ copr_projects:
             - "{{ foreman_staging }}/rhel-{{ rhel_8 }}-x86_64"
             - "{{ plugins_staging }}/rhel-{{ rhel_8 }}-x86_64"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-plugins-el{{ rhel_8 }}.xml"
-          buildroot_packages: "{{ core_buildroot_packages }}"
+          buildroot_packages: "{{ plugins_buildroot_packages }}"
     katello-copr:
       copr_project_name: "katello-{{ katello_version }}-staging"
       copr_project_fork_from: "{{ 'katello-nightly-staging' if foreman_version != 'nightly' else False }}"


### PR DESCRIPTION
this way we can still build foreman_maintain, websockify and other core bits with system python

(cherry picked from commit e7ff8a2ca9bcef8d412d96a18e8256c33442b998)