### PR TITLE
Maintain foremandist in release when bumping versions

### DIFF
--- a/bump_rpm.sh
+++ b/bump_rpm.sh
@@ -32,10 +32,14 @@ ensure_program() {
 bump_spec() {
 	SPEC_FILE=$1
 	NEW_VERSION=$2
+	NEW_VR=$NEW_VERSION
+	if grep -q -E '^Release:.+foremandist' $SPEC_FILE ; then
+		NEW_VR="${NEW_VERSION}-1%{?foremandist}%{?dist}"
+	fi
 
 	spectool --list-files $SPEC_FILE | cut -d' ' -f2 | grep http | xargs --no-run-if-empty -n 1 basename | xargs --no-run-if-empty git rm
 
-	rpmdev-bumpspec --comment "- Update to ${NEW_VERSION}" --new "${NEW_VERSION}" $SPEC_FILE
+	rpmdev-bumpspec --comment "- Update to ${NEW_VERSION}" --new "${NEW_VR}" $SPEC_FILE
 	git add $SPEC_FILE
 
 	spectool --get-files $SPEC_FILE


### PR DESCRIPTION
rpmdev-bumpspec resets the release, but the release can be provided in the new version.

Fixes: 47bdec5c62252ebd91f24a20799ea65962221fed ("Refactor spec file bumping to rely on rpmdev-bumpspec")

A quick look shows this would mostly work:

```console
$ rg --no-filename Release: packages | awk '{ print $2 }' | sort -u
0.33%{?revision:.%{revision}git}%{?dist}.1
10%{?dist}
10%{?foremandist}%{?dist}
11%{?dist}
1%{?dist}
1%{?dotalphatag}%{?dist}
1%{?foremandist}%{?dist}
21%{?dist}
22%{?dist}
23%{?dist}
2%{?dist}
2%{?foremandist}%{?dist}
3%{?dist}
3%{?foremandist}%{?dist}
4%{?dist}
4%{?foremandist}%{?dist}
5%{?dist}
5%{?foremandist}%{?dist}
6%{?dist}
6%{?foremandist}%{?dist}
7%{?dist}
7%{?foremandist}%{?dist}
8%{?foremandist}%{?dist}
9%{?dist}
9%{?foremandist}%{?dist}
%{?prerelease:0.}%{release}%{?prerelease}%{?dist}
%{?prerelease:0.}%{release}%{?prerelease}%{?nightly}%{?dist}
%{?prerelease:0.}%{release}%{?prerelease:.}%{?prerelease}%{?dist}
%{?prerelease:0.}%{release}%{?prerelease:.}%{?prerelease}%{?nightly}%{?dist}
```

The special cases are:
* `1%{?dotalphatag}%{?dist}` from katello-selinux
* `0.33%{?revision:.%{revision}git}%{?dist}.1` from `packages/foreman/gyp/gyp.spec`
* prerelease from our nightly packages

I believe this is good enough for now. I don't think the previous code dealt well with those special cases either.