### PR TITLE
hammer plugin CPs for 3.9

### DIFF
--- a/dependencies/bullseye/hammer_cli_foreman_webhooks/changelog
+++ b/dependencies/bullseye/hammer_cli_foreman_webhooks/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-webhooks (0.1.0-1) stable; urgency=low
+
+  * 0.1.0 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Mon, 08 Jan 2024 13:05:43 +0000
+
 ruby-hammer-cli-foreman-webhooks (0.0.4-1) stable; urgency=low
 
   * 0.0.4 released

--- a/dependencies/focal/hammer_cli_foreman_webhooks/changelog
+++ b/dependencies/focal/hammer_cli_foreman_webhooks/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-webhooks (0.1.0-1) stable; urgency=low
+
+  * 0.1.0 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Mon, 08 Jan 2024 13:05:43 +0000
+
 ruby-hammer-cli-foreman-webhooks (0.0.4-1) stable; urgency=low
 
   * 0.0.4 released


### PR DESCRIPTION
@evgeni, here you go :) Same plugins except for h-c-f-admin and h-c-f-openscap. They seem to not be available for debs.