### PR TITLE
Remove %pretrans section of spec

### DIFF
--- a/packages/foreman/foreman-installer/foreman-installer.spec
+++ b/packages/foreman/foreman-installer/foreman-installer.spec
@@ -1,4 +1,4 @@
-%global release 3
+%global release 4
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -73,17 +73,6 @@ foreman-installer --scenario foreman --migrations-only > /dev/null
 foreman-installer --scenario foreman-proxy-content --migrations-only > /dev/null
 foreman-installer --scenario katello --migrations-only > /dev/null
 
-%pretrans katello
-# RPM can't change a directory into a symlink
-# https://bugzilla.redhat.com/show_bug.cgi?id=447156
-for scenario in foreman-proxy-content katello ; do
-	MIGRATIONS=%{_sysconfdir}/%{name}/scenarios.d/$scenario.migrations
-	if [ -d $MIGRATIONS ] && [ ! -L $MIGRATIONS ] ; then
-		mv $MIGRATIONS/.applied %{_sysconfdir}/%{name}/scenarios.d/$scenario-migrations-applied
-		rm -rf $MIGRATIONS
-	fi
-done
-
 %files
 %defattr(-,root,root,-)
 %doc README.*
@@ -133,6 +122,9 @@ done
 %{_sbindir}/foreman-proxy-certs-generate
 
 %changelog
+* Thu Jan 11 2024 Patrick Creech <pcreech@redhat.com> - 1:3.10.0-0.4.develop
+- Remove pretrans segment
+
 * Wed Nov 29 2023 Zach Huntington-Meath <zhunting@redhat.com> - 1:3.10.0-0.3.develop
 - Bump version to 3.10-develop
 


### PR DESCRIPTION
Utilizing %pretrans with bash pulls in a requirement on /bin/sh, which in certain circumstances (install image generation) can be ran in a clean room environment with no /bin/sh available.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
