### PR TITLE
move katello ruby packages to an own group and build on el9

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -701,6 +701,7 @@ katello_packages:
   children:
     satellite_packages: {}
     katello_common_packages: {}
+    katello_ruby_packages: {}
   hosts:
     nodejs-angular: {}
     nodejs-bootstrap-select: {}
@@ -709,14 +710,10 @@ katello_packages:
     nodejs-ngreact: {}
     nodejs-query-string: {}
     nodejs-strict-uri-encode: {}
-    rubygem-activerecord-import: {}
-    rubygem-anemone: {}
-    rubygem-ethon: {}
     rubygem-foreman_kernel_care: {}
     rubygem-foreman_rh_cloud: {}
     rubygem-foreman_scc_manager: {}
     rubygem-foreman_virt_who_configure: {}
-    rubygem-fx: {}
     rubygem-hammer_cli_foreman_rh_cloud: {}
     rubygem-hammer_cli_foreman_scc_manager: {}
     rubygem-hammer_cli_foreman_virt_who_configure: {}
@@ -726,15 +723,25 @@ katello_packages:
     rubygem-katello:
       source_location: https://ci.theforeman.org/job/katello-master-source-release
       source_system: jenkins
-    rubygem-pulp_python_client: {}
-    rubygem-pulpcore_client: {}
+
+katello_ruby_packages:
+  vars:
+    copr_projects:
+      - "{{ hostvars['katello-copr-with-el9'] }}"
+  hosts:
+    rubygem-activerecord-import: {}
+    rubygem-anemone: {}
+    rubygem-ethon: {}
+    rubygem-fx: {}
     rubygem-pulp_ansible_client: {}
     rubygem-pulp_certguard_client: {}
     rubygem-pulp_container_client: {}
     rubygem-pulp_deb_client: {}
     rubygem-pulp_file_client: {}
     rubygem-pulp_ostree_client: {}
+    rubygem-pulp_python_client: {}
     rubygem-pulp_rpm_client: {}
+    rubygem-pulpcore_client: {}
     rubygem-robotex: {}
     rubygem-stomp: {}
     rubygem-typhoeus: {}


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
