### PR TITLE
Bump Katello to 4.13.0 and related packages to newest versions

### DIFF
--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -6,10 +6,10 @@
 
 %global prereleasesource nightly
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 2
+%global release 1
 
 Name:           katello-repos
-Version:        4.12
+Version:        4.13
 Release:        %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:        Definition of yum repositories for Katello
 
@@ -73,6 +73,9 @@ rm -rf %{buildroot}
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-candlepin
 
 %changelog
+* Mon Feb 26 2024 Quinn James <qjames@redhat.com> - 4.13-0.1.nightly
+- Bump version to 4.13.0
+
 * Fri Dec 01 2023 Eric D. Helms <ericdhelms@gmail.com> - 4.12-0.2.nightly
 - Use dedicated Candlepin release repository
 

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,10 +5,10 @@
 %global confdir common
 %global prereleasesource master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 2
+%global release 1
 
 Name:       katello
-Version:    4.12.0
+Version:    4.13.0
 Release:    %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:    A package for managing application life-cycle for Linux systems
 BuildArch:  noarch
@@ -130,6 +130,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Mon Feb 26 2024 Quinn James <qjames@redhat.com> - 4.13.0-0.1.master
+- Bump version to 4.13.0
+
 * Wed Jan 10 2024 Evgeni Golov - 4.12.0-0.2.master
 - Don't require katello-debug
 - Drop katello-debug -> mktemp requirement, it's part of coreutils

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -1,12 +1,12 @@
 # template: foreman_plugin
 %global gem_name katello
 %global plugin_name katello
-%global foreman_min_version 3.10
-%global foreman_max_version 3.11
+%global foreman_min_version 3.11
+%global foreman_max_version 3.12
 %global prereleasesource pre.master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global mainver 4.12.0
-%global release 3
+%global mainver 4.13.0
+%global release 1
 
 Name: rubygem-%{gem_name}
 Version: %{mainver}
@@ -170,6 +170,9 @@ done
 %{foreman_plugin_log}
 
 %changelog
+* Mon Feb 26 2024 Quinn James <qjames@redhat.com> - 4.13.0-0.1.pre.master
+- Bump version to 4.13.0
+
 * Mon Feb 12 2024 Evgeni Golov - 4.12.0-0.3.pre.master
 - Correct (Build)Requirements for EL9
 


### PR DESCRIPTION
This work was completed as a part of Katello 4.12 branching. Other than 'katello-host-tools' (which needed to be updated to version 4.3.0), all packages were already on the latest versions.