### PR TITLE
Update katello-host-tools to 4.4.0

### DIFF
--- a/packages/client/katello-host-tools/katello-host-tools-4.2.3.tar.gz
+++ b/packages/client/katello-host-tools/katello-host-tools-4.2.3.tar.gz
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/QJ/f1/SHA256E-s42509--f1154e83da02acc7231115ffe4bec9221a8cd371c4d07ff9bdc468d22d5adb6c.tar.gz/SHA256E-s42509--f1154e83da02acc7231115ffe4bec9221a8cd371c4d07ff9bdc468d22d5adb6c.tar.gz

--- a/packages/client/katello-host-tools/katello-host-tools-4.4.0.tar.gz
+++ b/packages/client/katello-host-tools/katello-host-tools-4.4.0.tar.gz
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/f1/Pw/SHA256E-s26375--0581ac5b5b16e19b69397bc15cfde1d3be363e617c3ab6ba119c204df7fcd762.tar.gz/SHA256E-s26375--0581ac5b5b16e19b69397bc15cfde1d3be363e617c3ab6ba119c204df7fcd762.tar.gz

--- a/packages/client/katello-host-tools/katello-host-tools.spec
+++ b/packages/client/katello-host-tools/katello-host-tools.spec
@@ -36,8 +36,8 @@
 %global katello_libdir %{python_libdir}/katello
 
 Name: katello-host-tools
-Version: 4.2.3
-Release: 5%{?dist}
+Version: 4.4.0
+Release: 1%{?dist}
 Summary: A set of commands and yum plugins that support a Katello host
 Group:   Development/Languages
 %if 0%{?suse_version}
@@ -393,6 +393,9 @@ exit 0
 
 
 %changelog
+* Tue Apr 02 2024 Ian Ballou <ianballou67@gmail.com> - 4.4.0-1
+- Update to 4.4.0
+
 * Thu Jan 25 2024 Ian Ballou <ianballou67@gmail.com> - 4.2.3-5
 - Add missing EL6/7 python-setuptools dependency
 


### PR DESCRIPTION
Bumping k-h-t version since the move to `dnf needs-restarting` is included.