### PR TITLE
Add recommends on rubygem-irb for rubygem-railties

### DIFF
--- a/packages/foreman/rubygem-railties/rubygem-railties.spec
+++ b/packages/foreman/rubygem-railties/rubygem-railties.spec
@@ -3,12 +3,13 @@
 
 Name: rubygem-%{gem_name}
 Version: 6.1.7.7
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Tools for creating, working with, and running Rails applications
 License: MIT
 URL: https://rubyonrails.org
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
+Recommends: rubygem(irb)
 # start specfile generated dependencies
 Requires: ruby >= 2.5.0
 BuildRequires: ruby >= 2.5.0
@@ -66,6 +67,9 @@ find %{buildroot}%{gem_instdir}/exe -type f | xargs chmod a+x
 %doc %{gem_instdir}/README.rdoc
 
 %changelog
+* Wed Apr 03 2024 Eric D. Helms <ericdhelms@gmail.com> - 6.1.7.7-2
+- Require rubygem-irb
+
 * Thu Feb 29 2024 Foreman Packaging Automation <packaging@theforeman.org> - 6.1.7.7-1
 - Update to 6.1.7.7
 


### PR DESCRIPTION
The railties package requires `irb` to be present when using commands like `foreman-rake console` as that calls the underlying `rails console`. We have seen cases where rubygem-irb is not getting installed on EL9 when foreman-console is.

Example: https://github.com/rails/rails/blob/v6.1.7.7/railties/lib/rails/commands/console/console_command.rb#L3
