### PR TITLE
Add dependency on hostname to foreman_maintain

### DIFF
--- a/packages/foreman/rubygem-foreman_maintain/rubygem-foreman_maintain.spec
+++ b/packages/foreman/rubygem-foreman_maintain/rubygem-foreman_maintain.spec
@@ -7,7 +7,7 @@
 Summary: The Foreman/Satellite maintenance tool
 Name: rubygem-%{gem_name}
 Version: 1.6.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Epoch: 1
 Group: Development/Languages
 License: GPLv3
@@ -24,6 +24,7 @@ BuildRequires: rubygems-devel
 BuildArch: noarch
 # end specfile generated dependencies
 
+Requires: hostname
 Requires: yum-utils
 Requires: /usr/bin/psql
 Requires: nftables
@@ -113,6 +114,9 @@ install -D -m0644 %{SOURCE1} %{buildroot}%{_sysconfdir}/logrotate.d/%{gem_name}
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Thu Apr 04 2024 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1:1.6.2-2
+- Add dependency on hostname
+
 * Sun Mar 31 2024 Foreman Packaging Automation <packaging@theforeman.org> - 1:1.6.2-1
 - Update to 1.6.2
 


### PR DESCRIPTION
This is executed in the system helpers and hostname isn't present in very minimal environments. This allows for better testing.