### PR TITLE
strip ~fmX.Y suffix from version when comparing

### DIFF
--- a/scripts/compare_deb_repo.py
+++ b/scripts/compare_deb_repo.py
@@ -27,6 +27,7 @@ def get_repo_packages(dist, release='nightly', arch='amd64', staging=False):
     for pkg in Packages.iter_paragraphs(remote_packages.text, use_apt_pkg=False):
         source = pkg.get('Source', pkg['Package'])
         version = re.sub(r'\+(debian|ubuntu).*', '', pkg['Version'])
+        version = re.sub(r'~fm\d+\.\d+$', '', version)
         if version.startswith('9999-') and release == 'nightly' and source in NIGHTLY_PACKAGES:
             continue
         if NativeVersion(packages[source]) < NativeVersion(version):


### PR DESCRIPTION
in https://github.com/theforeman/jenkins-jobs/commit/a13893edaa37f9b6f475cd5b27349e5c49ccb77a we started to inject `~fmX.Y` into the version of plugin builds, but forgot to strip it here

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
