### PR TITLE
Fixes #37334 - Drop keycloak-httpd-client-install from EL9

### DIFF
--- a/comps/comps-foreman-el9.xml
+++ b/comps/comps-foreman-el9.xml
@@ -40,7 +40,6 @@
       <packagereq type="default">foreman-telemetry</packagereq>
       <packagereq type="default">foreman-vmware</packagereq>
       <packagereq type="default">katello-certs-tools</packagereq>
-      <packagereq type="default">keycloak-httpd-client-install</packagereq>
       <packagereq type="default">libsass</packagereq>
       <packagereq type="default">libsass-devel</packagereq>
       <packagereq type="default">nodejs-argv-parse</packagereq>
@@ -90,7 +89,6 @@
       <packagereq type="default">puppet-agent-puppet-strings</packagereq>
       <packagereq type="default">puppet-agent-rgen</packagereq>
       <packagereq type="default">puppet-agent-yard</packagereq>
-      <packagereq type="default">python3-keycloak-httpd-client-install</packagereq>
       <packagereq type="default">python3-websockify</packagereq>
       <packagereq type="default">rubygem-actioncable</packagereq>
       <packagereq type="default">rubygem-actionmailbox</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -55,6 +55,17 @@ copr_projects:
             - "{{ foreman_staging }}/rhel-{{ rhel_9 }}-x86_64"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-el{{ rhel_9 }}.xml"
           buildroot_packages: "{{ core_buildroot_packages }}"
+    foreman-copr-el8:
+      copr_project_name: "foreman-{{ foreman_version }}-staging"
+      copr_project_fork_from: "{{ 'foreman-nightly-staging' if foreman_version != 'nightly' else False }}"
+      copr_project_chroots:
+        - name: "rhel-{{ rhel_8 }}-x86_64"
+          modules: "{{ core_modules_el8 }}"
+          external_repos:
+            - "{{ puppet_baseurl }}/el/{{ rhel_8 }}/x86_64/"
+            - "{{ foreman_staging }}/rhel-{{ rhel_8 }}-x86_64"
+          comps_file: "{{ inventory_dir }}/comps/comps-foreman-el{{ rhel_8 }}.xml"
+          buildroot_packages: "{{ core_buildroot_packages }}"
     plugins-copr:
       copr_project_name: "plugins-{{ foreman_version }}-staging"
       copr_project_fork_from: "{{ 'plugins-nightly-staging' if foreman_version != 'nightly' else False }}"
@@ -222,7 +233,9 @@ other_core_packages:
     dynflow-utils: {}
     foreman-bootloaders-redhat: {}
     foreman-obsolete-packages: {}
-    keycloak-httpd-client-install: {}
+    keycloak-httpd-client-install:
+      copr_projects:
+        - "{{ hostvars['foreman-copr-el8'] }}"
     pcp-mmvstatsd: {}
     python-websockify: {}
 


### PR DESCRIPTION
EL9 BaseOS contains a new enough version (1.1). Initially it was packaged because EL7 only contained 0.8 which lacked OIDC support. EL8 is also new enough, but contains a bug[1]. EL9 support was only introduced in Foreman 3.10 as experimental so there's probably still only a small userbase to have it installed. A release note should suffice.

[1]: https://issues.redhat.com/browse/RHEL-31496