### PR TITLE
Set correct plugin packages section

### DIFF
--- a/add_gem_package.sh
+++ b/add_gem_package.sh
@@ -91,7 +91,7 @@ add_to_manifest() {
 	if [[ $REPO == "foreman-el8" ]] ; then
 		local section="foreman_core_packages"
 	elif [[ $REPO == "foreman-plugins-el8" ]] ; then
-		local section="foreman_plugin_packages"
+		local section="foreman_plugin_packages_tier2"
 	elif [[ $REPO == "katello-el8" ]] ; then
 		local section="katello_packages"
 	elif [[ $REPO == "foreman-client-*" ]] ; then


### PR DESCRIPTION
This fixes the following issue:
  add_host.py: error: Section foreman_plugin_packages was not found

Most of the time, new plugin end up the in tier2 section first and may be moved to higher tier later on

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
