### PR TITLE
Fixes #37334 - Drop keycloak-httpd-client-install from EL9 (comps only)

### DIFF
--- a/comps/comps-foreman-el9.xml
+++ b/comps/comps-foreman-el9.xml
@@ -40,7 +40,6 @@
       <packagereq type="default">foreman-telemetry</packagereq>
       <packagereq type="default">foreman-vmware</packagereq>
       <packagereq type="default">katello-certs-tools</packagereq>
-      <packagereq type="default">keycloak-httpd-client-install</packagereq>
       <packagereq type="default">libsass</packagereq>
       <packagereq type="default">libsass-devel</packagereq>
       <packagereq type="default">nodejs-argv-parse</packagereq>


### PR DESCRIPTION
EL9 BaseOS contains a new enough version (1.1). Initially it was packaged because EL7 only contained 0.8 which lacked OIDC support. EL8 is also new enough, but contains a bug[1]. EL9 support was only introduced in Foreman 3.10 as experimental so there's probably still only a small userbase to have it installed. A release note should suffice.

This is an alternative to https://github.com/theforeman/foreman-packaging/pull/10677 but only drops it from comps, not the COPR build.

[1]: https://issues.redhat.com/browse/RHEL-31496