### PR TITLE
Fixes #37419 - Patch puma to fix chunked upload bug

### DIFF
--- a/packages/foreman/rubygem-puma/fix-request-chunking.patch
+++ b/packages/foreman/rubygem-puma/fix-request-chunking.patch
@@ -1,0 +1,22 @@
+From 67063acd4d1431771686a383db2045897d79b627 Mon Sep 17 00:00:00 2001
+From: MSP-Greg <Greg.mpls@gmail.com>
+Date: Wed, 21 Feb 2024 19:32:56 -0600
+Subject: [PATCH 1/1] client.rb - fix up request chunked body handling
+
+---
+ lib/puma/client.rb | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/puma/client.rb b/lib/puma/client.rb
+index 6c82eed356..5470d0b240 100644
+--- a/lib/puma/client.rb
++++ b/lib/puma/client.rb
+@@ -642,7 +642,7 @@ def decode_chunk(chunk)
+             @partial_part_left = len - part.size
+           end
+         else
+-          if @prev_chunk.size + chunk.size >= MAX_CHUNK_HEADER_SIZE
++          if @prev_chunk.size + line.size >= MAX_CHUNK_HEADER_SIZE
+             raise HttpParserError, "maximum size of chunk header exceeded"
+           end
+ 

--- a/packages/foreman/rubygem-puma/rubygem-puma.spec
+++ b/packages/foreman/rubygem-puma/rubygem-puma.spec
@@ -4,11 +4,12 @@
 
 Name: rubygem-%{gem_name}
 Version: 6.4.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Puma is a simple, fast, threaded, and highly parallel HTTP 1.1 server for Ruby/Rack applications
 License: BSD-3-Clause
 URL: https://puma.io
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
+Patch0: fix-request-chunking.patch
 
 # start specfile generated dependencies
 Requires: ruby >= 2.4
@@ -40,6 +41,7 @@ Documentation for %{name}.
 
 %prep
 %setup -q -n  %{gem_name}-%{version}
+%patch0 -p1
 
 %build
 # Create the gem as gem install only works on a gem file
@@ -97,6 +99,9 @@ rm -rf gem_ext_test
 %doc %{gem_instdir}/docs
 
 %changelog
+* Tue May 07 2024 Ian Ballou <ianballou67@gmail.com> - 6.4.2-2
+- Add patch for chunking bug
+
 * Tue Jan 09 2024 Foreman Packaging Automation <packaging@theforeman.org> - 6.4.2-1
 - Update to 6.4.2
 


### PR DESCRIPTION
Add a patch to solve https://github.com/puma/puma/issues/3337 , which causes a Katello `podman push` to fail for all but  the smallest container images.

I tested that the patch applies to Puma 6.4.2.