### PR TITLE
Bump hammer-cli-katello to 1.13

### DIFF
--- a/packages/katello/rubygem-hammer_cli_katello/rubygem-hammer_cli_katello.spec
+++ b/packages/katello/rubygem-hammer_cli_katello/rubygem-hammer_cli_katello.spec
@@ -13,7 +13,7 @@
 %global hammer_confdir %{_root_sysconfdir}/hammer
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 1.12.0
+Version: 1.13.0
 Release: %{?prerelease:0.}%{release}%{?prerelease}%{?nightly}%{?dist}
 Summary: Katello commands for Hammer
 Group: Development/Languages
@@ -96,6 +96,9 @@ install -m 0644 .%{gem_instdir}/config/%{plugin_name}.yml \
 %{gem_instdir}/test
 
 %changelog
+* Fri May 10 2024 Ian Ballou <ianballou67@gmail.com> - 1.13.0-0.1.pre.master
+- Bump version to 1.13.0
+
 * Mon Nov 27 2023 Chris Roberts <chrobert@redhat.com> - 1.12.0-0.1.pre.master
 - Bump version to 1.12.0
 


### PR DESCRIPTION
Now that the nightly source pipeline is green, we need to bump this to get the package out.