### PR TITLE
Update rubygem-smart_proxy_container_gateway to 3.0.0

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_container_gateway/rubygem-smart_proxy_container_gateway.spec
+++ b/packages/plugins/rubygem-smart_proxy_container_gateway/rubygem-smart_proxy_container_gateway.spec
@@ -9,7 +9,7 @@
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
 Name: rubygem-%{gem_name}
-Version: 2.0.0
+Version: 3.0.0
 Release: 1%{?foremandist}%{?dist}
 Summary: Pulp 3 container registry support for Foreman/Katello Smart-Proxy
 License: GPLv3
@@ -79,6 +79,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/container_gateway.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon May 20 2024 Ian Ballou <ianballou67@gmail.com> - 3.0.0-1
+- Update to 3.0.0
+
 * Mon Apr 15 2024 Ian Ballou <ianballou67@gmail.com> - 2.0.0-1
 - Update to 2.0.0
 

--- a/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-2.0.0.gem
+++ b/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-2.0.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/pk/5f/SHA256E-s24064--ed666d892db3a039e4a07a9b85883d0f54dce7e3cbc2e8c37fcdccad9ec846d8.0.gem/SHA256E-s24064--ed666d892db3a039e4a07a9b85883d0f54dce7e3cbc2e8c37fcdccad9ec846d8.0.gem

--- a/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-3.0.0.gem
+++ b/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-3.0.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/21/qv/SHA256E-s24576--c874fc7da259236d451bed4aa3e26bb4340120422d26feb4e8b62f455d2ee5ae.0.gem/SHA256E-s24576--c874fc7da259236d451bed4aa3e26bb4340120422d26feb4e8b62f455d2ee5ae.0.gem


### PR DESCRIPTION
To finally end the postgres upgrade saga.