### PR TITLE
Use $releasever_major in release files

### DIFF
--- a/packages/foreman/foreman-release/foreman-release.spec
+++ b/packages/foreman/foreman-release/foreman-release.spec
@@ -12,11 +12,11 @@
 %define repo_dir %{_sysconfdir}/yum.repos.d
 
 %if 0%{?rhel}
-%define repo_dist el%{rhel}
+%define repo_dist el$releasever_major
 %endif
 %endif
 
-%global release 1
+%global release 2
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -65,8 +65,7 @@ install -Dpm0644 %{SOURCE0} %{buildroot}%{repo_dir}/foreman.repo
 install -Dpm0644 %{SOURCE1} %{buildroot}%{repo_dir}/foreman-plugins.repo
 install -Dpm0644 %{SOURCE5} %{buildroot}%{repo_dir}/foreman-client.repo
 
-trimmed_dist=`echo %{repo_dist} | sed 's/^\.//'`
-sed "s/\$DIST/${trimmed_dist}/g" -i %{buildroot}%{repo_dir}/*.repo
+sed 's/$DIST/%{repo_dist}/g' -i %{buildroot}%{repo_dir}/*.repo
 
 if [[ '%{release}' != *"develop"* ]];then
   VERSION="%{version}"
@@ -84,6 +83,9 @@ install -Dpm0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-f
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman
 
 %changelog
+* Fri Jun 21 2024 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.12.0-0.2.develop
+- Use $releasever_major for better leapp compatibility
+
 * Wed May 22 2024 Zach Huntington-Meath <zhunting@redhat.com> - 3.12.0-0.1.develop
 - Bump version to 3.12-develop
 

--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -2,11 +2,11 @@
 %global candlepin_version 4.4
 
 %define repo_dir %{_sysconfdir}/yum.repos.d
-%define repo_dist %{dist}
+%define repo_dist el$releasever_major
 
 %global prereleasesource nightly
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 2
+%global release 3
 
 Name:           katello-repos
 Version:        4.14
@@ -54,8 +54,7 @@ else
 fi
 
 for repofile in %{buildroot}%{repo_dir}/*.repo; do
-    trimmed_dist=`echo %{repo_dist} | sed 's/^\.//'`
-    sed -i "s/@DIST@/${trimmed_dist}/" $repofile
+    sed -i 's/@DIST@/%{repo_dist}/' $repofile
     sed -i "s/@RHEL@/%{rhel}/" $repofile
     sed -i "s/@REPO_VERSION@/${REPO_VERSION}/" $repofile
     sed -i "s/@REPO_NAME@/${REPO_NAME}/" $repofile
@@ -73,6 +72,9 @@ rm -rf %{buildroot}
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-candlepin
 
 %changelog
+* Fri Jun 21 2024 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 4.14-0.3.nightly
+- Use $releasever_major for better leapp compatibility
+
 * Mon Jun 03 2024 Evgeni Golov - 4.14-0.2.nightly
 - Update Candlepin 4.4 key
 


### PR DESCRIPTION
This makes distribution upgrades with leapp smoother. Well, this PR is to test that theory.