### PR TITLE
Update ruby-smart-proxy-dns-infoblox to 1.2.0

### DIFF
--- a/plugins/smart_proxy_dns_infoblox/changelog
+++ b/plugins/smart_proxy_dns_infoblox/changelog
@@ -1,3 +1,9 @@
+ruby-smart-proxy-dns-infoblox (1.2.0-1) stable; urgency=low
+
+  * 1.2.0 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Sun, 30 Jun 2024 04:09:29 +0000
+
 ruby-smart-proxy-dns-infoblox (1.1.0-1) stable; urgency=low
 
   * 1.1.0 released

--- a/plugins/smart_proxy_dns_infoblox/dns_infoblox.rb
+++ b/plugins/smart_proxy_dns_infoblox/dns_infoblox.rb
@@ -1,1 +1,1 @@
-gem 'smart_proxy_dns_infoblox', '1.1.0'
+gem 'smart_proxy_dns_infoblox', '1.2.0'


### PR DESCRIPTION
(cherry picked from commit 9230685718c11c33beb7bdd6f80235bd4aaa6216)