### PR TITLE
Update rubygem-smart_proxy_dns_infoblox to 1.2.0

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_dns_infoblox/rubygem-smart_proxy_dns_infoblox.spec
+++ b/packages/plugins/rubygem-smart_proxy_dns_infoblox/rubygem-smart_proxy_dns_infoblox.spec
@@ -16,8 +16,8 @@
 %global foreman_proxy_settingsd_dir %{_root_sysconfdir}/foreman-proxy/settings.d
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
-Version: 1.1.0
-Release: 7%{?foremandist}%{?dist}
+Version: 1.2.0
+Release: 1%{?foremandist}%{?dist}
 Summary: Infoblox DNS provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -26,16 +26,10 @@ Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
 # start specfile generated dependencies
 Requires: foreman-proxy >= %{foreman_proxy_min_version}
-Requires: %{?scl_prefix_ruby}ruby(release)
-Requires: %{?scl_prefix_ruby}ruby
-Requires: %{?scl_prefix_ruby}ruby(rubygems)
-Requires: %{?scl_prefix}rubygem(infoblox) >= 3.0
-Requires: %{?scl_prefix}rubygem(infoblox) < 4
-BuildRequires: %{?scl_prefix_ruby}ruby(release)
-BuildRequires: %{?scl_prefix_ruby}ruby
-BuildRequires: %{?scl_prefix_ruby}rubygems-devel
+Requires: ruby >= 2.5
+BuildRequires: ruby >= 2.5
+BuildRequires: rubygems-devel
 BuildArch: noarch
-Provides: %{?scl_prefix}rubygem(%{gem_name}) = %{version}
 Provides: foreman-proxy-plugin-%{plugin_name} = %{version}
 # end specfile generated dependencies
 
@@ -110,6 +104,9 @@ mv %{buildroot}%{gem_instdir}/config/dns_infoblox.yml.example \
 %{gem_instdir}/test
 
 %changelog
+* Tue Jul 02 2024 Foreman Packaging Automation <packaging@theforeman.org> - 1.2.0-1
+- Update to 1.2.0
+
 * Mon May 09 2022 Eric D. Helms <ericdhelms@gmail.com> - 1.1.0-7
 - Drop unused smart_proxy_dynflow_core_bundlerd_dir macro
 

--- a/packages/plugins/rubygem-smart_proxy_dns_infoblox/smart_proxy_dns_infoblox-1.1.0.gem
+++ b/packages/plugins/rubygem-smart_proxy_dns_infoblox/smart_proxy_dns_infoblox-1.1.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/Vj/JQ/SHA256E-s21504--51fdc8143d5d1606b67b349aa6f51bf2873f4c98be6c7ece1c1d468bd60ac16f.0.gem/SHA256E-s21504--51fdc8143d5d1606b67b349aa6f51bf2873f4c98be6c7ece1c1d468bd60ac16f.0.gem

--- a/packages/plugins/rubygem-smart_proxy_dns_infoblox/smart_proxy_dns_infoblox-1.2.0.gem
+++ b/packages/plugins/rubygem-smart_proxy_dns_infoblox/smart_proxy_dns_infoblox-1.2.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/q6/vV/SHA256E-s22016--edbfce0d2edd01632a9bb6893b468a35902bdd7a7d1b23a3eac1785c2e02bff5.0.gem/SHA256E-s22016--edbfce0d2edd01632a9bb6893b468a35902bdd7a7d1b23a3eac1785c2e02bff5.0.gem


### PR DESCRIPTION
(cherry picked from commit 6a8d15cd528b7a6079af0e6ae7371f11a7013688)