### PR TITLE
move rubygem-jquery-ui-rails package to katello

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -4,7 +4,7 @@
 %global dynflow_sidekiq_service_name dynflow-sidekiq@
 %global rake /usr/bin/rake
 
-%global release 1
+%global release 2
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -198,7 +198,6 @@ BuildRequires: (npm(react-intl) >= 2.8.0 with npm(react-intl) < 3.0.0)
 # end package.json dependencies BuildRequires
 
 # start specfile assets BuildRequires
-BuildRequires: (rubygem(jquery-ui-rails) >= 6.0 with rubygem(jquery-ui-rails) < 7.0)
 BuildRequires: (rubygem(patternfly-sass) >= 3.59.4 with rubygem(patternfly-sass) < 3.60.0)
 BuildRequires: (rubygem(gettext_i18n_rails_js) >= 1.4 with rubygem(gettext_i18n_rails_js) < 2.0)
 BuildRequires: (rubygem(po_to_json) >= 1.1 with rubygem(po_to_json) < 2.0)
@@ -349,7 +348,6 @@ Requires: (npm(react-intl) >= 2.8.0 with npm(react-intl) < 3.0.0)
 # end package.json dependencies Requires
 
 # start specfile assets Requires
-Requires: (rubygem(jquery-ui-rails) >= 6.0 with rubygem(jquery-ui-rails) < 7.0)
 Requires: (rubygem(patternfly-sass) >= 3.59.4 with rubygem(patternfly-sass) < 3.60.0)
 Requires: (rubygem(gettext_i18n_rails_js) >= 1.4 with rubygem(gettext_i18n_rails_js) < 2.0)
 Requires: (rubygem(po_to_json) >= 1.1 with rubygem(po_to_json) < 2.0)
@@ -863,6 +861,9 @@ exit 0
 %systemd_postun %{name}.socket
 
 %changelog
+* Thu Oct 31 2024 MariaAga <mariaaga@redhat.com> - 3.13.0-0.2.develop
+- move jquery-ui-rails package to katello
+
 * Tue Aug 20 2024 Patrick Creech <pcreech@redhat.com> - 3.13.0-0.1.develop
 - Bump version to 3.13-develop
 

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -6,7 +6,7 @@
 %global prereleasesource pre.master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
 %global mainver 4.15.0
-%global release 1
+%global release 2
 
 Name: rubygem-%{gem_name}
 Version: %{mainver}
@@ -75,6 +75,10 @@ BuildRequires: (npm(ngreact) >= 0.5.0 with npm(ngreact) < 1.0.0)
 BuildRequires: (npm(react-bootstrap) >= 0.32.1 with npm(react-bootstrap) < 1.0.0)
 BuildRequires: (npm(use-deep-compare-effect) >= 1.6.1 with npm(use-deep-compare-effect) < 2.0.0)
 # end package.json dependencies BuildRequires
+
+# start specfile assets BuildRequires
+BuildRequires: (rubygem(jquery-ui-rails) >= 6.0 with rubygem(jquery-ui-rails) < 7.0)
+# end specfile assets BuildRequires
 
 %description
 Katello adds Content and Subscription Management to Foreman. For this it
@@ -168,6 +172,9 @@ done
 %{foreman_plugin_log}
 
 %changelog
+* Thu Oct 31 2024 MariaAga <mariaaga@redhat.com> - 4.15.0-0.2.pre.master
+- move jquery-ui-rails package to katello
+
 * Tue Aug 20 2024 Chris Roberts <chrobert@redhat.com> - 4.15.0-0.1.pre.master
 - Bump version to 4.15.0
 


### PR DESCRIPTION
for https://github.com/Katello/katello/pull/10982 and https://github.com/theforeman/foreman/pull/10142
I ran:
`./remove_package rubygem-jquery-ui-rails` 
`./add_gem_package.sh jquery-ui-rails foreman_plugin katello`
