### PR TITLE
Fixes #37663 - Make foreman-installer-katello pull in foreman-maintain

### DIFF
--- a/packages/foreman/foreman-installer/foreman-installer.spec
+++ b/packages/foreman/foreman-installer/foreman-installer.spec
@@ -1,4 +1,4 @@
-%global release 1
+%global release 2
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -42,6 +42,10 @@ Requires: %{name} = %{epoch}:%{version}-%{release}
 Requires: openssl
 Requires: katello-certs-tools
 Requires: which
+
+# both katello and foreman-proxy-content scenarios require this
+# it also makes the package lock feature available on the first run
+Requires: foreman-maintain
 
 %description katello
 Various scenarios and tools for the Katello ecosystem
@@ -122,6 +126,9 @@ foreman-installer --scenario katello --migrations-only > /dev/null
 %{_sbindir}/foreman-proxy-certs-generate
 
 %changelog
+* Thu Jul 18 2024 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1:3.12.0-0.2.develop
+- katello: depend on foreman-maintain
+
 * Wed May 22 2024 Zach Huntington-Meath <zhunting@redhat.com> - 1:3.12.0-0.1.develop
 - Bump version to 3.12-develop
 


### PR DESCRIPTION
Both katello and foreman-proxy-content pull in foreman-maintain. The package locking feature also requires this. It was [noted](https://community.theforeman.org/t/installer-doesnt-recognize-documented-options/38465) that the locking feature isn't present on the first run, but is on the second.  This is confusing to users.