### PR TITLE
dont exit add_npm_package when compgen is empty

### DIFF
--- a/add_npm_package.sh
+++ b/add_npm_package.sh
@@ -18,10 +18,7 @@ else
   PACKAGE_NAME=nodejs-${PACKAGE_MODULE}
 fi
 
-PACKAGE_DIR=$(compgen -G "packages/*/${PACKAGE_NAME}/")
-if [[ -z "${PACKAGE_DIR}" ]]; then
-  PACKAGE_DIR=packages/$BASE_DIR/$PACKAGE_NAME
-fi
+PACKAGE_DIR=$(compgen -G "packages/*/${PACKAGE_NAME}/" || echo "packages/$BASE_DIR/$PACKAGE_NAME")
 SPEC_FILE="${PACKAGE_DIR}/${PACKAGE_NAME}.spec"
 
 ROOT=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
Not sure if this is the best solution, but the script exists right after running `PACKAGE_DIR=$(compgen -G "packages/*/${PACKAGE_NAME}/")`
without any error. 
Only happens when the folder is empty, which is to be expected when someone adds a new npm package.
Any other solutions are welcome, or doc changes if I'm running something wrong?