### PR TITLE
Add a filter parameter for bump_packages

### DIFF
--- a/.github/workflows/bump_packages.yml
+++ b/.github/workflows/bump_packages.yml
@@ -2,6 +2,12 @@ name: Update packages
 
 on:
   workflow_dispatch:
+    inputs:
+      filter:
+        type: string
+        description: A filter to apply on package names
+        required: false
+        default: ""
   schedule:
     - cron: '4 4 * * 0,3'
 
@@ -23,7 +29,7 @@ jobs:
         ref: rpm/develop
     - name: Set the list
       id: set_list
-      run: ./list_updatable_packages
+      run: ./list_updatable_packages "${{ inputs.filter }}"
 
   bump_rpm:
     name: 'Bump ${{ matrix.package_name }} RPM ${{ matrix.new_version }}'
@@ -84,7 +90,7 @@ jobs:
         ref: deb/develop
     - name: Set the list
       id: set_list
-      run: ./scripts/list_updatable_packages
+      run: ./scripts/list_updatable_packages "${{ inputs.filter }}"
 
   bump_plugin_deb:
     name: 'Bump ${{ matrix.package_name }} deb ${{ matrix.new_version }}'


### PR DESCRIPTION
Applying this filter allows calling it from a specific plugin to only update a single package. For example, when a gem is released it can automatically trigger this workflow.

Right now the actual scripts don't implement this, so this is just a proposal. My idea is that we enhance our [release-gem](https://github.com/theforeman/actions/blob/v0/.github/workflows/release-gem.yml) workflow to trigger a packaging bump. That way we don't update all existing PRs but still have nice end-to-end automation for nightly. Stable branches still need additional work.