### PR TITLE
Use epel-7-x86_64 copr target for client repos

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -105,9 +105,8 @@ copr_projects:
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-client-el{{ rhel_8 }}.xml"
           external_repos:
             - "{{ client_staging }}/rhel-{{ rhel_8 }}-x86_64"
-        - name: "rhel-{{ rhel_7 }}-x86_64"
+        - name: "epel-{{ rhel_7 }}-x86_64"
           external_repos:
-            - "https://dl.fedoraproject.org/pub/epel/{{ rhel_7 }}/x86_64/"
             - "{{ client_staging }}/rhel-{{ rhel_7 }}-x86_64"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-client-rhel{{ rhel_7 }}.xml"
         - name: "opensuse-leap-15.5-x86_64"

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -91,7 +91,7 @@ baseurl=https://vault.centos.org/centos/7/extras/x86_64/
 
 [el7-epel]
 name=epel
-baseurl=https://dl.fedoraproject.org/pub/epel/7/x86_64/
+baseurl=https://archive.fedoraproject.org/pub/epel/7/x86_64/
 
 [el7-puppet-7]
 name=el7-puppet-7


### PR DESCRIPTION
This was always a better option because it allows COPR to use its own EPEL mirror, which is faster. Now that EPEL 7 has been archived, this is the only way to build on EL7.

Still needs to address repoclosure if we actually want to maintain EL7 builds, which @evgeni would prefer with his downstream hat on.