### PR TITLE
Use rhel-7 buildroot for EL7 client again

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -105,8 +105,9 @@ copr_projects:
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-client-el{{ rhel_8 }}.xml"
           external_repos:
             - "{{ client_staging }}/rhel-{{ rhel_8 }}-x86_64"
-        - name: "epel-{{ rhel_7 }}-x86_64"
+        - name: "rhel-{{ rhel_7 }}-x86_64"
           external_repos:
+            - "https://archive.fedoraproject.org/pub/epel/{{ rhel_7 }}/x86_64/"
             - "{{ client_staging }}/rhel-{{ rhel_7 }}-x86_64"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-client-rhel{{ rhel_7 }}.xml"
         - name: "opensuse-leap-15.5-x86_64"


### PR DESCRIPTION
This partially reverts 7dd4b56a8b5058e6e0feb65f494b1198d16eb4f7 because we can't switch the buildroot in existing repos.

Fixes: 7dd4b56a8b50 ("Use epel-7-x86_64 copr target for client repos")