### PR TITLE
Use EPEL 7 from the archives

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -118,7 +118,7 @@ copr_projects:
             - "{{ client_staging }}/rhel-{{ rhel_8 }}-x86_64"
         - name: "rhel-{{ rhel_7 }}-x86_64"
           external_repos:
-            - "https://dl.fedoraproject.org/pub/epel/{{ rhel_7 }}/x86_64/"
+            - "https://dl.fedoraproject.org/pub/archive/epel/{{ rhel_7 }}/x86_64/"
             - "{{ client_staging }}/rhel-{{ rhel_7 }}-x86_64"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-client-rhel{{ rhel_7 }}.xml"
 

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -91,7 +91,7 @@ baseurl=https://vault.centos.org/centos/7/extras/x86_64/
 
 [el7-epel]
 name=epel
-baseurl=https://dl.fedoraproject.org/pub/epel/7/x86_64/
+baseurl=https://dl.fedoraproject.org/pub/archive/epel/7/x86_64/
 
 [el7-puppet-7]
 name=el7-puppet-7


### PR DESCRIPTION
EPEL 7 was archived and they changed the URL.

(cherry picked from commit a9de200815731212b96fae6eca4dc43a2d375574)