### PR TITLE
Use Puppet 8 for repoclosure

### DIFF
--- a/mock/el7.cfg
+++ b/mock/el7.cfg
@@ -46,7 +46,7 @@ enabled=0
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel7&arch=x86_64
 failovermethod=priority
 
-[puppet-7]
-name=puppet-7
-baseurl=https://yum.puppetlabs.com/puppet7/el/7/x86_64/
+[puppet-8]
+name=puppet-8
+baseurl=https://yum.puppetlabs.com/puppet8/el/7/x86_64/
 """

--- a/mock/el8.cfg
+++ b/mock/el8.cfg
@@ -85,7 +85,7 @@ baseurl=https://yum.theforeman.org/plugins/nightly/el8/x86_64/
 name=katello
 baseurl=https://yum.theforeman.org/katello/nightly/katello/el8/x86_64/
 
-[puppet-7]
-name=puppet-7
-baseurl=https://yum.puppetlabs.com/puppet7/el/8/x86_64/
+[puppet-8]
+name=puppet-8
+baseurl=https://yum.puppetlabs.com/puppet8/el/8/x86_64/
 """

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -862,7 +862,7 @@ repoclosures:
           - el8-appstream
           - el8-powertools
           - el8-extras
-          - el8-puppet-7
+          - "el8-puppet-{{ puppet_version }}"
           - "el8-candlepin-{{ candlepin_version }}-staging"
     foreman-staging-repoclosure-el9:
       repoclosure_target_repos:
@@ -873,7 +873,7 @@ repoclosures:
         el9:
           - el9-baseos
           - el9-appstream
-          - el9-puppet-7
+          - "el9-puppet-{{ puppet_version }}"
           - "el9-candlepin-{{ candlepin_version }}-staging"
     plugins-staging-repoclosure-el8:
       repoclosure_target_repos:
@@ -887,7 +887,7 @@ repoclosures:
           - el8-powertools
           - el8-configmanagement-salt
           - el8-extras
-          - el8-puppet-7
+          - "el8-puppet-{{ puppet_version }}"
           - "el8-foreman-{{ foreman_version }}-staging"
     plugins-staging-repoclosure-el9:
       repoclosure_target_repos:
@@ -899,7 +899,7 @@ repoclosures:
           - el9-baseos
           - el9-appstream
           - el9-configmanagement-salt
-          - el9-puppet-7
+          - "el9-puppet-{{ puppet_version }}"
           - "el9-foreman-{{ foreman_version }}-staging"
     katello-staging-repoclosure-el8:
       repoclosure_target_repos:
@@ -912,7 +912,7 @@ repoclosures:
           - el8-appstream
           - el8-powertools
           - el8-extras
-          - el8-puppet-7
+          - "el8-puppet-{{ puppet_version }}"
           - "el8-foreman-{{ foreman_version }}-staging"
           - "el8-foreman-plugins-{{ foreman_version }}-staging"
           - "el8-candlepin-{{ candlepin_version }}-staging"
@@ -925,7 +925,7 @@ repoclosures:
         el9:
           - el9-baseos
           - el9-appstream
-          - el9-puppet-7
+          - "el9-puppet-{{ puppet_version }}"
           - "el9-foreman-{{ foreman_version }}-staging"
           - "el9-foreman-plugins-{{ foreman_version }}-staging"
           - "el9-candlepin-{{ candlepin_version }}-staging"
@@ -938,7 +938,7 @@ repoclosures:
         el9:
           - el9-baseos
           - el9-appstream
-          - el9-puppet-7
+          - "el9-puppet-{{ puppet_version }}"
     foreman-client-staging-repoclosure-el8:
       repoclosure_target_repos:
         el8:
@@ -951,7 +951,7 @@ repoclosures:
           - el8-powertools
           - el8-epel
           - el8-extras
-          - el8-puppet-7
+          - "el8-puppet-{{ puppet_version }}"
     foreman-client-staging-repoclosure-el7:
       repoclosure_target_repos:
         el7:
@@ -963,7 +963,7 @@ repoclosures:
           - el7-updates
           - el7-epel
           - el7-extras
-          - el7-puppet-7
+          - "el7-puppet-{{ puppet_version }}"
 
 foreman_release_packages:
   vars:

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -5,7 +5,7 @@ all:
     foreman_version: 'nightly'
     katello_version: 'nightly'
     candlepin_version: '4.4'
-    puppet_version: 7
+    puppet_version: 8
     copr_project_user: "@theforeman"
     build_package_build_system: copr
   children:

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -28,9 +28,9 @@ name=CentOS Stream 9 - CRB
 metalink=https://mirrors.centos.org/metalink?repo=centos-crb-9-stream&arch=x86_64&protocol=https,http
 enabled=1
 
-[el9-puppet-7]
-name=el9-puppet-7
-baseurl=https://yum.puppetlabs.com/puppet7/el/9/x86_64/
+[el9-puppet-8]
+name=el9-puppet-8
+baseurl=https://yum.puppetlabs.com/puppet8/el/9/x86_64/
 
 [el9-foreman-client-nightly-staging]
 name=Foreman Client nightly EL9
@@ -71,9 +71,9 @@ mirrorlist=https://mirrors.almalinux.org/mirrorlist/8/powertools
 name=Foreman Client nightly EL8
 baseurl=https://stagingyum.theforeman.org/client/nightly/el8/x86_64/
 
-[el8-puppet-7]
-name=el8-puppet-7
-baseurl=https://yum.puppetlabs.com/puppet7/el/8/x86_64/
+[el8-puppet-8]
+name=el8-puppet-8
+baseurl=https://yum.puppetlabs.com/puppet8/el/8/x86_64/
 
 [el7-base]
 name=BaseOS
@@ -93,9 +93,9 @@ baseurl=https://vault.centos.org/centos/7/extras/x86_64/
 name=epel
 baseurl=https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/
 
-[el7-puppet-7]
-name=el7-puppet-7
-baseurl=https://yum.puppetlabs.com/puppet7/el/7/x86_64/
+[el7-puppet-8]
+name=el7-puppet-8
+baseurl=https://yum.puppetlabs.com/puppet8/el/7/x86_64/
 
 [el9-foreman-nightly-staging]
 name=Foreman nightly staging EL9


### PR DESCRIPTION
Now that Foreman supports this, it's good to run with this.

One big change is that puppet-agent 8.x no longer has a `Provides: puppet` line which otherwise we won't capture.