### PR TITLE
Exclude pkgconf definition from yggdrasil

### DIFF
--- a/packages/client/yggdrasil/yggdrasil.spec
+++ b/packages/client/yggdrasil/yggdrasil.spec
@@ -2,7 +2,7 @@
 
 Name:    yggdrasil
 Version: 0.2.3
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Message dispatch agent for cloud-connected systems
 License: GPL-3.0-only
 URL:     https://github.com/redhatinsights/yggdrasil
@@ -80,10 +80,13 @@ make PREFIX=%{_prefix} \
 %{_unitdir}/%{name}d.service
 %{_datadir}/bash-completion/completions/*
 %{_mandir}/man1/*
-%{_prefix}/share/pkgconfig/%{name}.pc
+%exclude %{_prefix}/share/pkgconfig/%{name}.pc
 %{_libexecdir}/%{name}
 
 %changelog
+* Tue Oct 15 2024 Adam Ruzicka <aruzicka@redhat.com> - 0.2.3-3
+- Exclude pkgconf definition file
+
 * Mon Mar 11 2024 Markus Bucher <bucher@atix.de> - 0.2.3-2
 - Fixes for opensuse build service
 - Require go on SLES


### PR DESCRIPTION
to prevent pkgconf from being added as an implicit dependency.

An alternative would be to move it into its own subpackage, but considering we have no use for it just excluding the offending file seemed simpler.
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
