### PR TITLE
Use RUBYLIB for simpler Ruby testing

### DIFF
--- a/gem2rpm/default.spec.erb
+++ b/gem2rpm/default.spec.erb
@@ -130,15 +130,7 @@ find %{buildroot}%{gem_instdir}/<%= spec.bindir %> -type f | xargs chmod a+x
 <% end -%>
 <% unless spec.extensions.empty? -%>
 %check
-# Ideally, this would be something like this:
-# GEM_PATH="%{buildroot}%{gem_dir}:$GEM_PATH" ruby -e "require '%{gem_require_name}'"
-# But that fails to find native extensions on EL8, so we fake the structure that ruby expects
-mkdir gem_ext_test
-cp -a %{buildroot}%{gem_dir} gem_ext_test/
-mkdir -p gem_ext_test/gems/extensions/%{_arch}-%{_target_os}/$(ruby -r rbconfig -e 'print RbConfig::CONFIG["ruby_version"]')/
-cp -a %{buildroot}%{gem_extdir_mri} gem_ext_test/gems/extensions/%{_arch}-%{_target_os}/$(ruby -r rbconfig -e 'print RbConfig::CONFIG["ruby_version"]')/
-GEM_PATH="./gem_ext_test/gems:$GEM_PATH" ruby -e "require '%{gem_require_name}'"
-rm -rf gem_ext_test
+RUBYLIB=.%{gem_extdir_mri} ruby -I.%{gem_instdir} -e "require '%{gem_require_name}'"
 
 <% end -%>
 %files


### PR DESCRIPTION
I found `RUBYLIB` while updating some package in Fedora. I haven't tried it yet in our repos, but I think it can simplify things a lot and by opening a PR I no longer have some stash on some local computer.