### PR TITLE
Conflict satellite-maintain < 0.0.3

### DIFF
--- a/packages/foreman/rubygem-foreman_maintain/rubygem-foreman_maintain.spec
+++ b/packages/foreman/rubygem-foreman_maintain/rubygem-foreman_maintain.spec
@@ -7,7 +7,7 @@
 Summary: The Foreman/Satellite maintenance tool
 Name: rubygem-%{gem_name}
 Version: 1.8.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Epoch: 1
 Group: Development/Languages
 License: GPLv3
@@ -28,6 +28,7 @@ Requires: hostname
 Requires: yum-utils
 Requires: /usr/bin/psql
 Requires: nftables
+Conflicts: satellite-maintain < 0.0.3
 BuildRequires: python3-devel
 
 Provides: foreman-maintain = %{version}
@@ -114,6 +115,9 @@ install -D -m0644 %{SOURCE1} %{buildroot}%{_sysconfdir}/logrotate.d/%{gem_name}
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Thu Oct 24 2024 Evgeni Golov - 1:1.8.1-2
+- Conflict satellite-maintain < 0.0.3
+
 * Mon Oct 21 2024 Foreman Packaging Automation <packaging@theforeman.org> - 1:1.8.1-1
 - Update to 1.8.1
 


### PR DESCRIPTION
In foreman_maintain 1.8.0 we moved some Satellite-specific metadata to
the Satellite-specific satellite-maintain package, but the normal
upgrade procedure doesn't enforce the right satellite-maintain version
to be present, thus leading to upgrade errors. Let's enforce this
requirement at the package level.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
