### PR TITLE
Bump rubygem-katello pulp bindings to 3.63

### DIFF
--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -6,7 +6,7 @@
 %global prereleasesource pre.master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
 %global mainver 4.15.0
-%global release 1
+%global release 2
 
 Name: rubygem-%{gem_name}
 Version: %{mainver}
@@ -45,15 +45,15 @@ BuildRequires: rubygem(apipie-rails) >= 0.5.14
 BuildRequires: rubygem(fx) < 1.0
 BuildRequires: rubygem(pg)
 BuildRequires: rubygem(spidr)
-BuildRequires: (rubygem(pulpcore_client) >= 3.49.3 with rubygem(pulpcore_client) < 3.50.0)
-BuildRequires: (rubygem(pulp_file_client) >= 3.49.3 with rubygem(pulp_file_client) < 3.50.0)
-BuildRequires: (rubygem(pulp_ansible_client) >= 0.21.3 with rubygem(pulp_ansible_client) < 0.22.0)
-BuildRequires: (rubygem(pulp_container_client) >= 2.20.0 with rubygem(pulp_container_client) < 2.21.0)
-BuildRequires: (rubygem(pulp_deb_client) >= 3.2.0 with rubygem(pulp_deb_client) < 3.3.0)
-BuildRequires: (rubygem(pulp_rpm_client) >= 3.26.1 with rubygem(pulp_rpm_client) < 3.27.0)
-BuildRequires: (rubygem(pulp_certguard_client) >= 3.49.3 with rubygem(pulp_certguard_client) < 3.50.0)
-BuildRequires: (rubygem(pulp_python_client) >= 3.11.0 with rubygem(pulp_python_client) < 3.12.0)
-BuildRequires: (rubygem(pulp_ostree_client) >= 2.3.0 with rubygem(pulp_ostree_client) < 2.4.0)
+BuildRequires: (rubygem(pulpcore_client) >= 3.63.1 with rubygem(pulpcore_client) < 3.64.0)
+BuildRequires: (rubygem(pulp_file_client) >= 3.63.1 with rubygem(pulp_file_client) < 3.64.0)
+BuildRequires: (rubygem(pulp_ansible_client) >= 0.22.2 with rubygem(pulp_ansible_client) < 0.23.0)
+BuildRequires: (rubygem(pulp_container_client) >= 2.21.1 with rubygem(pulp_container_client) < 2.22.0)
+BuildRequires: (rubygem(pulp_deb_client) >= 3.3.1 with rubygem(pulp_deb_client) < 3.4.0)
+BuildRequires: (rubygem(pulp_rpm_client) >= 3.27.2 with rubygem(pulp_rpm_client) < 3.28.0)
+BuildRequires: (rubygem(pulp_certguard_client) >= 3.63.1 with rubygem(pulp_certguard_client) < 3.64.0)
+BuildRequires: (rubygem(pulp_python_client) >= 3.12.5 with rubygem(pulp_python_client) < 3.13.0)
+BuildRequires: (rubygem(pulp_ostree_client) >= 2.4.4 with rubygem(pulp_ostree_client) < 2.5.0)
 BuildRequires: (rubygem(deface) >= 1.0.2 with rubygem(deface) < 2.0.0)
 BuildRequires: (rubygem(angular-rails-templates) >= 1.1.0 with rubygem(angular-rails-templates) < 1.2)
 BuildArch: noarch
@@ -168,6 +168,9 @@ done
 %{foreman_plugin_log}
 
 %changelog
+* Wed Oct 30 2024 Ian Ballou <ianballou67@gmail.com> - 4.15.0-0.2.pre.master
+- Bump Pulpcore client bindings requirements for the 3.63 repo.
+
 * Tue Aug 20 2024 Chris Roberts <chrobert@redhat.com> - 4.15.0-0.1.pre.master
 - Bump version to 4.15.0
 


### PR DESCRIPTION
Bumps Pulp bindings requirements to match those in https://github.com/Katello/katello/pull/11197
Bindings packaging PR: https://github.com/theforeman/foreman-packaging/pull/11414