### PR TITLE
Don't fail when shim-ia32 is missing when generating bootloaders

### DIFF
--- a/packages/foreman/foreman-bootloaders-redhat/foreman-bootloaders-redhat.spec
+++ b/packages/foreman/foreman-bootloaders-redhat/foreman-bootloaders-redhat.spec
@@ -1,6 +1,6 @@
 Name: foreman-bootloaders-redhat
 Version: 202102220000
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: Metapackage with Grub2 and Shim TFTP bootloaders
 
 Group: Applications/System
@@ -73,6 +73,9 @@ install -Dp -m0755 %{SOURCE0} %{buildroot}%{_bindir}/foreman-generate-bootloader
 
 
 %changelog
+* Mon Nov 11 2024 Evgeni Golov 202102220000-4
+- Don't fail if shim-ia32 is missing
+
 * Sat Mar 23 2024 Eric D. Helms <ericdhelms@gmail.com> 202102220000-3
 - Only requires shim-ia32 on RHEL 8 or less
 

--- a/packages/foreman/foreman-bootloaders-redhat/foreman-generate-bootloaders
+++ b/packages/foreman/foreman-bootloaders-redhat/foreman-generate-bootloaders
@@ -55,7 +55,6 @@ else
   generate x86_64-efi grub2/grubx64.efi
 fi
 
-check_pkg shim-ia32
 check_pkg shim-x64
 cp -f /boot/efi/EFI/*/shim*.efi /var/lib/tftpboot/grub2
 chmod 644 /var/lib/tftpboot/grub2/*.{efi,0}


### PR DESCRIPTION
Fixes: f69b2386e9749024e7d02e5cff808b1c7abd6085

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
