### PR TITLE
Drop tracer from foreman-client-el{8,9}

### DIFF
--- a/comps/comps-foreman-client-el8.xml
+++ b/comps/comps-foreman-client-el8.xml
@@ -16,9 +16,7 @@
       <packagereq type="default">katello-host-tools-tracer</packagereq>
       <packagereq type="default">katello-pull-transport-migrate</packagereq>
       <packagereq type="default">python3-psutil</packagereq>
-      <packagereq type="default">python3-tracer</packagereq>
       <packagereq type="default">rubygem-foreman_scap_client</packagereq>
-      <packagereq type="default">tracer-common</packagereq>
       <packagereq type="default">yggdrasil</packagereq>
       <!--
         Do not edit this section manually and use ./comps_doc.sh script

--- a/comps/comps-foreman-client-el9.xml
+++ b/comps/comps-foreman-client-el9.xml
@@ -16,9 +16,7 @@
       <packagereq type="default">katello-host-tools-tracer</packagereq>
       <packagereq type="default">katello-pull-transport-migrate</packagereq>
       <packagereq type="default">python3-psutil</packagereq>
-      <packagereq type="default">python3-tracer</packagereq>
       <packagereq type="default">rubygem-foreman_scap_client</packagereq>
-      <packagereq type="default">tracer-common</packagereq>
       <packagereq type="default">yggdrasil</packagereq>
       <!--
         Do not edit this section manually and use ./comps_doc.sh script


### PR DESCRIPTION
Since 626307d7f2dc727a873924d34a651aa157932758 tracer support is built into katello-host-tools for EL8+. This means it's only used on EL7.