### PR TITLE
Drop python3-psutil on foreman-client-el9

### DIFF
--- a/comps/comps-foreman-client-el9.xml
+++ b/comps/comps-foreman-client-el9.xml
@@ -16,7 +16,6 @@
       <packagereq type="default">katello-host-tools</packagereq>
       <packagereq type="default">katello-host-tools-tracer</packagereq>
       <packagereq type="default">katello-pull-transport-migrate</packagereq>
-      <packagereq type="default">python3-psutil</packagereq>
       <packagereq type="default">rubygem-foreman_scap_client</packagereq>
       <packagereq type="default">yggdrasil</packagereq>
       <!--


### PR DESCRIPTION
We package version 5.7.2 and by now EL 9 has version 5.8.0 in its repositories so this package is unused. EL 8 ships version 5.4.3 so there it's still used.