### PR TITLE
Use copr:// links for external repositories

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -27,7 +27,7 @@ copr_projects:
     rhel_9: '9'
     rhel_8: '8'
     puppet_baseurl: "https://yum.voxpupuli.org/openvox{{ puppet_version }}"
-    root_repo_url: "https://download.copr.fedorainfracloud.org/results/{{ copr_project_user }}"
+    root_repo_url: "copr://{{ copr_project_user }}"
     foreman_staging: "{{ root_repo_url }}/foreman-{{ foreman_version }}-staging"
     plugins_staging: "{{ root_repo_url }}/plugins-{{ foreman_version }}-staging"
     katello_staging: "{{ root_repo_url }}/katello-{{ katello_version }}-staging"
@@ -41,7 +41,7 @@ copr_projects:
           modules: "{{ core_modules_el9 }}"
           external_repos:
             - "{{ puppet_baseurl }}/el/$releasever/$basearch/"
-            - "{{ foreman_staging }}/rhel-{{ rhel_9 }}-x86_64"
+            - "{{ foreman_staging }}"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-el{{ rhel_9 }}.xml"
           buildroot_packages: "{{ core_buildroot_packages }}"
     plugins-copr:
@@ -51,8 +51,8 @@ copr_projects:
         - name: "rhel-{{ rhel_9 }}-x86_64"
           modules: "{{ core_modules_el9 }}"
           external_repos:
-            - "{{ foreman_staging }}/rhel-{{ rhel_9 }}-x86_64"
-            - "{{ plugins_staging }}/rhel-{{ rhel_9 }}-x86_64"
+            - "{{ foreman_staging }}"
+            - "{{ plugins_staging }}"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-plugins-el{{ rhel_9 }}.xml"
           buildroot_packages: "{{ core_buildroot_packages }}"
     katello-copr:
@@ -62,9 +62,9 @@ copr_projects:
         - name: "rhel-{{ rhel_9 }}-x86_64"
           modules: "{{ core_modules_el9 }}"
           external_repos:
-            - "{{ foreman_staging }}/rhel-{{ rhel_9 }}-x86_64"
-            - "{{ plugins_staging }}/rhel-{{ rhel_9 }}-x86_64"
-            - "{{ katello_staging }}/rhel-{{ rhel_9 }}-x86_64"
+            - "{{ foreman_staging }}"
+            - "{{ plugins_staging }}"
+            - "{{ katello_staging }}"
           comps_file: "{{ inventory_dir }}/comps/comps-katello-el{{ rhel_9 }}.xml"
           buildroot_packages: "{{ core_buildroot_packages }}"
     client-copr:
@@ -74,18 +74,18 @@ copr_projects:
         - name: "rhel-{{ rhel_10 }}-x86_64"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-client-el{{ rhel_10 }}.xml"
           external_repos:
-            - "{{ client_staging }}/rhel-{{ rhel_10 }}-x86_64"
+            - "{{ client_staging }}"
         - name: "rhel-{{ rhel_9 }}-x86_64"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-client-el{{ rhel_9 }}.xml"
           external_repos:
-            - "{{ client_staging }}/rhel-{{ rhel_9 }}-x86_64"
+            - "{{ client_staging }}"
         - name: "rhel-{{ rhel_8 }}-x86_64"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-client-el{{ rhel_8 }}.xml"
           external_repos:
-            - "{{ client_staging }}/rhel-{{ rhel_8 }}-x86_64"
+            - "{{ client_staging }}"
         - name: "opensuse-leap-15.6-x86_64"
           external_repos:
-            - "{{ client_staging }}/opensuse-leap-15.6-x86_64"
+            - "{{ client_staging }}"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-client-sles156.xml"
 
 packages:


### PR DESCRIPTION
This has the benefit that COPR internally knows where to download it from. We don't need to repeat the specific buildroot name.

My long term goal is to have less configuration for the buildroots so it becomes easier to manage multiple. Ideally we support multiple architectures with minimal configuration.

At this moment it's untested, but I'd like to experiment with this. In fact, we should probably use https://fedora-copr.github.io/posts/runtime-dependencies and enhance obal to manage that.