### PR TITLE
Add support for devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
     "--privileged",
     "--platform=linux/amd64"
   ],
+  // When using podman instead of docker, uncomment the next line and follow to configure your editor https://code.visualstudio.com/remote/advancedcontainers/docker-options#_podman
+  // "remoteUser": "root",
   "workspaceFolder": "/opt/foreman-packaging",
   "workspaceMount": "source=${localWorkspaceFolder},target=/opt/foreman-packaging,type=bind,consistency=cached"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,11 @@
     "dockerfile": "../Containerfile",
     "context": "."
   },
+  "customizations": {
+    "vscode": {
+      "extensions": ["ian-h-chamberlain.rpm-specfile"]
+    }
+  },
   "runArgs": [
     "--privileged",
     "--platform=linux/amd64"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "build": {
+    "dockerfile": "../Containerfile",
+    "context": "."
+  },
+  "runArgs": [
+    "--privileged"
+  ],
+  "workspaceFolder": "/opt/foreman-packaging",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/opt/foreman-packaging,type=bind,consistency=cached"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
     "context": "."
   },
   "runArgs": [
-    "--privileged"
+    "--privileged",
+    "--platform=linux/amd64"
   ],
   "workspaceFolder": "/opt/foreman-packaging",
   "workspaceMount": "source=${localWorkspaceFolder},target=/opt/foreman-packaging,type=bind,consistency=cached"

--- a/Containerfile
+++ b/Containerfile
@@ -13,7 +13,7 @@ RUN echo "[git-annex]" >> /etc/yum.repos.d/git-annex.repo \
 RUN dnf -y module enable nodejs:18
 
 RUN dnf install -y epel-release && \
-    dnf -y install nodejs vim git rpmdevtools git-annex-standalone wget ruby jq ruby-devel make gcc-c++ mock postgresql-devel libxml2-devel libcurl-devel systemd-devel \
+    dnf -y install nodejs vim git rpmdevtools git-annex-standalone wget ruby jq ruby-devel make gcc-c++ mock postgresql-devel libxml2-devel libcurl-devel systemd-devel rpmlint \
     python3 python3-pip python3-ruamel-yaml python3-requests python3-packaging
 
 RUN npm install npm2rpm --global

--- a/Containerfile
+++ b/Containerfile
@@ -17,5 +17,7 @@ RUN dnf -y install nodejs vim git rpmdevtools git-annex-standalone wget ruby jq 
 
 RUN npm install npm2rpm --global
 
+RUN gem install gem2rpm
+
 RUN mkdir -p /opt/foreman-packaging
 WORKDIR /opt/foreman-packaging

--- a/Containerfile
+++ b/Containerfile
@@ -20,5 +20,7 @@ RUN npm install npm2rpm --global
 
 RUN gem install gem2rpm
 
+RUN pip3 install rpmspectool obal
+
 RUN mkdir -p /opt/foreman-packaging
 WORKDIR /opt/foreman-packaging

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,8 @@ RUN echo "[git-annex]" >> /etc/yum.repos.d/git-annex.repo \
 
 RUN dnf -y module enable nodejs:18
 
-RUN dnf -y install nodejs vim git rpmdevtools git-annex-standalone wget ruby jq ruby-devel make gcc-c++ postgresql-devel libxml2-devel libcurl-devel systemd-devel \
+RUN dnf install -y epel-release && \
+    dnf -y install nodejs vim git rpmdevtools git-annex-standalone wget ruby jq ruby-devel make gcc-c++ mock postgresql-devel libxml2-devel libcurl-devel systemd-devel \
     python3 python3-pip python3-ruamel-yaml python3-requests python3-packaging
 
 RUN npm install npm2rpm --global

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9
+FROM --platform=linux/amd64 quay.io/centos/centos:stream9
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
It would be nice if this could get us to a state where those using vscode (or any of the other devcontainer-related tooling) could just open the repo, let the tooling crunch for a bit and then be able to do all the packaging actions without having to fiddle with anything.

TODOs:
- [x] Add obal, mock and friends. In general get this to a feature parity with what you get when you run the [rpm_packaging role](https://github.com/theforeman/forklift/blob/master/roles/rpm_packaging/tasks/main.yml) from forklift
- [x] some comments about how to make this work with podman instead of docker
