### PR TITLE
tasks: Drop python-dev build-dependency

### DIFF
--- a/plugins/ruby-foreman-tasks/debian/changelog
+++ b/plugins/ruby-foreman-tasks/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-tasks (10.0.2-2) stable; urgency=low
+
+  * Drop python-dev build-dependency
+
+ -- Evgeni Golov <evgeni@debian.org>  Tue, 28 Jan 2025 08:29:55 +0100
+
 ruby-foreman-tasks (10.0.2-1) stable; urgency=low
 
   * 10.0.2 released

--- a/plugins/ruby-foreman-tasks/debian/control
+++ b/plugins/ruby-foreman-tasks/debian/control
@@ -2,7 +2,7 @@ Source: ruby-foreman-tasks
 Section: ruby
 Priority: extra
 Maintainer: Michael Moll <mmoll@mmoll.at>
-Build-Depends: debhelper, git | git-core, foreman (>= 3.7.0~rc1), foreman-nulldb (>= 3.7.0~rc1), foreman-assets, python-dev
+Build-Depends: debhelper, git | git-core, foreman (>= 3.7.0~rc1), foreman-nulldb (>= 3.7.0~rc1), foreman-assets
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman-tasks
 


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
