### PR TITLE
rex: Drop python-dev build-dependency

### DIFF
--- a/plugins/ruby-foreman-remote-execution/debian/changelog
+++ b/plugins/ruby-foreman-remote-execution/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-remote-execution (14.1.4-2) stable; urgency=low
+
+  * Drop python-dev build-dependency
+
+ -- Evgeni Golov <evgeni@debian.org>  Tue, 28 Jan 2025 08:31:12 +0100
+
 ruby-foreman-remote-execution (14.1.4-1) stable; urgency=low
 
   * 14.1.4 released

--- a/plugins/ruby-foreman-remote-execution/debian/control
+++ b/plugins/ruby-foreman-remote-execution/debian/control
@@ -3,7 +3,7 @@ Section: ruby
 Priority: extra
 Maintainer: Stephen Benjamin <stephen@redhat.com>
 Build-Depends: debhelper (>= 8.0.0), git | git-core, foreman-assets (>= 3.8.0~rc1), foreman (>= 3.8.0~rc1),
-  foreman-nulldb (>= 3.8.0~rc1), ruby-foreman-tasks (>= 8.2.0), ruby-foreman-deface, python-dev,
+  foreman-nulldb (>= 3.8.0~rc1), ruby-foreman-tasks (>= 8.2.0), ruby-foreman-deface,
   ruby-dynflow (>= 1.0.2), ruby-dynflow (<< 2.0.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_remote_execution


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
