### PR TITLE
Bump Katello and Katello packages to 4.17 versions

### DIFF
--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -9,7 +9,7 @@
 %global release 1
 
 Name:           katello-repos
-Version:        4.16
+Version:        4.17
 Release:        %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:        Definition of yum repositories for Katello
 
@@ -73,6 +73,9 @@ rm -rf %{buildroot}
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-candlepin
 
 %changelog
+* Tue Feb 18 2025 Quinn James <qj@quinnjam.es> - 4.17-0.1.nightly
+- Bump version to 4.17.0
+
 * Fri Nov 08 2024 Ian Ballou <ianballou67@gmail.com> - 4.16-0.1.nightly
 - Bump version to 4.16.0
 

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -8,7 +8,7 @@
 %global release 2
 
 Name:       katello
-Version:    4.16.0
+Version:    4.17.0
 Release:    %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:    A package for managing application life-cycle for Linux systems
 BuildArch:  noarch
@@ -130,6 +130,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Tue Feb 18 2025 Quinn James <qj@quinnjam.es> - 4.17.0-0.1.master
+- Bump version to 4.17.0
+
 * Mon Dec 16 2024 Evgeni Golov - 4.16.0-0.2.master
 - correctly regenerate Puppet certs when changing hostname
 

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,7 +5,7 @@
 %global confdir common
 %global prereleasesource master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 2
+%global release 1
 
 Name:       katello
 Version:    4.17.0

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -1,12 +1,12 @@
 # template: foreman_plugin
 %global gem_name katello
 %global plugin_name katello
-%global foreman_min_version 3.14
-%global foreman_max_version 3.15
+%global foreman_min_version 3.15
+%global foreman_max_version 3.16
 %global prereleasesource pre.master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global mainver 4.16.0
-%global release 3
+%global mainver 4.17.0
+%global release 1
 
 Name: rubygem-%{gem_name}
 Version: %{mainver}
@@ -169,6 +169,9 @@ done
 %{foreman_plugin_log}
 
 %changelog
+* Tue Feb 18 2025 Quinn James <qj@quinnjam.es> - 4.17.0-0.1.pre.master
+- Bump version to 4.17.0
+
 * Tue Dec 17 2024 MariaAga <mariaaga@redhat.com> - 4.16.0-0.3.pre.master
 - move jquery-ui-rails package to katello
 


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
Bump Katello and Katello packages to 4.17 versions. This PR doesn't contain the updates to `foreman_virt_who_configure`, `hammer_cli_foreman_virt_who_configure`, and `hammer_cli_katello` per Chris Roberts' request.