### PR TITLE
Add OpenVox support to RPM

### DIFF
--- a/packages/foreman/foreman-installer/foreman-installer.spec
+++ b/packages/foreman/foreman-installer/foreman-installer.spec
@@ -16,7 +16,7 @@ BuildArch:  noarch
 
 Requires:   curl
 Requires:   hostname
-Requires:   puppet-agent >= 7.0.0
+Requires:   (openvox-agent >= 7.35.0 or puppet-agent >= 7.0.0)
 Requires:   rubygem(kafo) >= 7.6.0
 Requires:   rubygem(kafo) < 8.0.0
 Requires:   ruby(release)

--- a/packages/foreman/foreman-installer/foreman-installer.spec
+++ b/packages/foreman/foreman-installer/foreman-installer.spec
@@ -22,7 +22,7 @@ Requires:   rubygem(kafo) < 8.0.0
 Requires:   ruby(release)
 
 BuildRequires: asciidoc
-BuildRequires: puppet-agent >= 7.0.0
+BuildRequires: (openvox-agent >= 7.35.0 or puppet-agent >= 7.0.0)
 BuildRequires: rubygem(rake)
 BuildRequires: rubygem(kafo) >= 7.6.0
 BuildRequires: rubygem(kafo) < 8.0.0

--- a/packages/foreman/puppet-agent-oauth/puppet-agent-oauth.spec
+++ b/packages/foreman/puppet-agent-oauth/puppet-agent-oauth.spec
@@ -9,7 +9,7 @@ Group: Development/Languages
 License: MIT
 URL: http://rubydoc.info/gems/oauth
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
-Requires: puppet-agent
+Requires: (openvox-agent or puppet-agent)
 BuildArch: noarch
 
 %description

--- a/packages/foreman/puppet-agent-puppet-strings/puppet-agent-puppet-strings.spec
+++ b/packages/foreman/puppet-agent-puppet-strings/puppet-agent-puppet-strings.spec
@@ -9,7 +9,7 @@ Group: Development/Languages
 License: ASL-2.0
 URL: https://github.com/puppetlabs/puppetlabs-strings
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
-Requires: puppet-agent >= 7
+Requires: (openvox-agent >= 7 or puppet-agent >= 7)
 Requires: (puppet-agent-yard >= 0.9.5 with puppet-agent-yard < 1)
 Requires: (puppet-agent-rgen >= 0.9 with puppet-agent-rgen < 1)
 BuildArch: noarch

--- a/packages/foreman/puppet-agent-rgen/puppet-agent-rgen.spec
+++ b/packages/foreman/puppet-agent-rgen/puppet-agent-rgen.spec
@@ -9,7 +9,7 @@ Group: Development/Languages
 License: MIT
 URL: http://rubydoc.info/gems/rgen
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
-Requires: puppet-agent
+Requires: (openvox-agent or puppet-agent)
 BuildArch: noarch
 
 %description

--- a/packages/foreman/puppet-agent-yard/puppet-agent-yard.spec
+++ b/packages/foreman/puppet-agent-yard/puppet-agent-yard.spec
@@ -9,7 +9,7 @@ Group: Development/Languages
 License: MIT
 URL: http://yardoc.org/
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
-Requires: puppet-agent
+Requires: (openvox-agent or puppet-agent)
 BuildArch: noarch
 
 %description


### PR DESCRIPTION
It might be better to start at version 8.11.0 instead. The 7.35.0 version is only best-effort supported. It's only intended to help people migrate and then upgrade.