### PR TITLE
jammy, bookworm: set ruby-webrick dependency to >= 1.7.0

### DIFF
--- a/debian/bookworm/foreman-proxy/changelog
+++ b/debian/bookworm/foreman-proxy/changelog
@@ -1,3 +1,9 @@
+foreman-proxy (3.15.0-2) stable; urgency=low
+
+  * Increase lower version bound for ruby-webrick to ensure that the ruby3.0 package is installed.
+
+ -- Kenyon Ralph <kralph@qti.qualcomm.com>  Tue, 22 Apr 2025 16:06:10 -0700
+
 foreman-proxy (3.15.0-1) stable; urgency=low
 
   * Bump changelog to 3.15.0 to match VERSION

--- a/debian/bookworm/foreman-proxy/control
+++ b/debian/bookworm/foreman-proxy/control
@@ -12,7 +12,7 @@ Package: foreman-proxy
 Section: net
 Priority: extra
 Architecture: all
-Depends: ruby, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext, ruby-concurrent (>= 1.0.0), ruby-concurrent (<< 2.0.0), ruby-rsec, ruby-logging, ruby-sd-notify (>= 0.1.0), ruby-sd-notify (<< 0.2.0), ruby-webrick (>= 1.0.0)
+Depends: ruby, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext, ruby-concurrent (>= 1.0.0), ruby-concurrent (<< 2.0.0), ruby-rsec, ruby-logging, ruby-sd-notify (>= 0.1.0), ruby-sd-notify (<< 0.2.0), ruby-webrick (>= 1.7.0)
 Recommends: sudo, curl, ping, ruby-gssapi, ruby-rubyipmi (>= 0.10.0), ruby-redfish-client (>= 0.5.1), ruby-rkerberos (>= 0.1.1), ruby-libvirt (>= 0.6.0), ruby-rb-inotify, ruby-jwt (>= 1.5.6), ruby-xmlrpc (>= 0.3), foreman-debug
 Suggests: foreman-proxy-journald
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet

--- a/debian/jammy/foreman-proxy/changelog
+++ b/debian/jammy/foreman-proxy/changelog
@@ -1,3 +1,9 @@
+foreman-proxy (3.15.0-2) stable; urgency=low
+
+  * Increase lower version bound for ruby-webrick to ensure that the ruby3.0 package is installed.
+
+ -- Kenyon Ralph <kralph@qti.qualcomm.com>  Tue, 22 Apr 2025 16:05:34 -0700
+
 foreman-proxy (3.15.0-1) stable; urgency=low
 
   * Bump changelog to 3.15.0 to match VERSION

--- a/debian/jammy/foreman-proxy/control
+++ b/debian/jammy/foreman-proxy/control
@@ -12,7 +12,7 @@ Package: foreman-proxy
 Section: net
 Priority: extra
 Architecture: all
-Depends: ruby, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext, ruby-concurrent (>= 1.0.0), ruby-concurrent (<< 2.0.0), ruby-rsec, ruby-logging, ruby-sd-notify (>= 0.1.0), ruby-sd-notify (<< 0.2.0), ruby-webrick (>= 1.0.0)
+Depends: ruby, rake, ruby-sinatra (>= 1.3.3), ruby-rack (>= 1.1.0), ruby-json, ruby-augeas, ruby-bundler-ext, ruby-concurrent (>= 1.0.0), ruby-concurrent (<< 2.0.0), ruby-rsec, ruby-logging, ruby-sd-notify (>= 0.1.0), ruby-sd-notify (<< 0.2.0), ruby-webrick (>= 1.7.0)
 Recommends: sudo, curl, ping, ruby-gssapi, ruby-rubyipmi (>= 0.10.0), ruby-redfish-client (>= 0.5.1), ruby-rkerberos (>= 0.1.1), ruby-libvirt (>= 0.6.0), ruby-rb-inotify, ruby-jwt (>= 1.5.6), ruby-xmlrpc (>= 0.3), foreman-debug
 Suggests: foreman-proxy-journald
 Description: RESTful proxies for DNS, DHCP, TFTP, and Puppet


### PR DESCRIPTION
If the dependency is set to >= 1.0.0, then that allows the ruby-webrick of ruby2.7 to remain installed. This breaks foreman-proxy when upgrading from Ubuntu 20.04 to 22.04, for example, since foreman-proxy uses ruby3.0.

This fixes commit 79c8cf9e05f98c02d35d5dd3c79f0bf5f4de92b1, part of #11109.