### PR TITLE
hammer_cli_katello: Allow Ruby < 4

### DIFF
--- a/packages/katello/rubygem-hammer_cli_katello/rubygem-hammer_cli_katello.spec
+++ b/packages/katello/rubygem-hammer_cli_katello/rubygem-hammer_cli_katello.spec
@@ -2,7 +2,7 @@
 %global gem_name hammer_cli_katello
 %global plugin_name katello
 
-%global release 1
+%global release 2
 %global prereleasesource pre.main
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
 
@@ -18,9 +18,9 @@ Source0: https://rubygems.org/gems/%{gem_name}-%{version}%{?prerelease}.gem
 
 # start specfile generated dependencies
 Requires: ruby >= 2.7
-Requires: ruby < 3.2
+Requires: ruby < 4
 BuildRequires: ruby >= 2.7
-BuildRequires: ruby < 3.2
+BuildRequires: ruby < 4
 BuildRequires: rubygems-devel
 BuildArch: noarch
 Provides: hammer-cli-plugin-%{plugin_name} = %{version}
@@ -73,6 +73,9 @@ install -m 0644 .%{gem_instdir}/config/%{plugin_name}.yml \
 %{gem_instdir}/test
 
 %changelog
+* Fri Sep 19 2025 Evgeni Golov - 1.19.0-0.2.pre.main
+- Allow Ruby < 4
+
 * Wed Aug 20 2025 Pavan Soma Shekar <shekarpavan97@gmail.com> - 1.19.0-0.1.pre.main
 - Bump version to 1.19.0
 


### PR DESCRIPTION
This was enabled in the gem [1] but never in packaging.

[1] https://github.com/Katello/hammer-cli-katello/commit/a2797aab925a45f5c88d14cf9baeaf51463137dd

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
