### PR TITLE
Drop direct cron for foreman_expire_hosts plugin

### DIFF
--- a/packages/plugins/rubygem-foreman_expire_hosts/foreman_expire_hosts.cron.d
+++ b/packages/plugins/rubygem-foreman_expire_hosts/foreman_expire_hosts.cron.d
@@ -1,8 +1,0 @@
-SHELL=/bin/sh
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-
-RAILS_ENV=production
-FOREMAN_HOME=/usr/share/foreman
-
-# Send out notifications about expired hosts
-45 7 * * *      foreman    /usr/sbin/foreman-rake expired_hosts:deliver_notifications >>/var/log/foreman/expired_hosts.log 2>&1

--- a/packages/plugins/rubygem-foreman_expire_hosts/rubygem-foreman_expire_hosts.spec
+++ b/packages/plugins/rubygem-foreman_expire_hosts/rubygem-foreman_expire_hosts.spec
@@ -1,16 +1,15 @@
 # template: foreman_plugin
 %global gem_name foreman_expire_hosts
 %global plugin_name expire_hosts
-%global foreman_min_version 3.13.0
+%global foreman_min_version 3.18.0
 
 Name: rubygem-%{gem_name}
 Version: 9.0.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman plugin for limiting host lifetime
 License: GPLv3
 URL: https://github.com/theforeman/foreman_expire_hosts
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
-Source1: %{gem_name}.cron.d
 
 # start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
@@ -51,8 +50,6 @@ mkdir -p %{buildroot}%{gem_dir}
 cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
-mkdir -p %{buildroot}%{_sysconfdir}/cron.d/
-mv %{buildroot}%{gem_instdir}/extra/*.cron %{buildroot}%{_sysconfdir}/cron.d/%{gem_name}
 %foreman_bundlerd_file
 
 %files
@@ -66,7 +63,6 @@ mv %{buildroot}%{gem_instdir}/extra/*.cron %{buildroot}%{_sysconfdir}/cron.d/%{g
 %exclude %{gem_cache}
 %{gem_spec}
 %{foreman_bundlerd_plugin}
-%config(noreplace) %{_sysconfdir}/cron.d/%{gem_name}
 
 %files doc
 %doc %{gem_docdir}
@@ -77,6 +73,10 @@ mv %{buildroot}%{gem_instdir}/extra/*.cron %{buildroot}%{_sysconfdir}/cron.d/%{g
 %{foreman_plugin_log}
 
 %changelog
+* Wed Feb 04 2026 Archana Kumari <akumari@redhat.com> - 9.0.1-2
+- Migrate to Foreman::Cron framework, require Foreman >= 3.18
+- Remove cron.d file as task now runs via cron:daily
+
 * Wed Jun 18 2025 David Ochner <ochnerd@yahoo.de> - 9.0.1-1
 - Update to 9.0.1
 


### PR DESCRIPTION
Relates to - https://github.com/theforeman/foreman_expire_hosts/pull/86
The plugin now registers with Foreman::Cron framework, running via cron:daily on traditional installations or systemd timers on container deployments.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
