### PR TITLE
Bump foreman-tasks min version to 3.18.0

### DIFF
--- a/packages/plugins/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
+++ b/packages/plugins/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
@@ -1,7 +1,7 @@
 # template: foreman_plugin
 %global gem_name foreman-tasks
 %global plugin_name foreman-tasks
-%global foreman_min_version 3.15
+%global foreman_min_version 3.18.0
 
 Name: rubygem-%{gem_name}
 Version: 11.0.6
@@ -152,6 +152,9 @@ type foreman-selinux-relabel >/dev/null 2>&1 && foreman-selinux-relabel 2>&1 >/d
 %{foreman_plugin_log}
 
 %changelog
+* Mon Feb 10 2026 Archana Kumari <akumari@redhat.com> - 11.0.6-2
+- Migrate to Foreman::Cron framework, require Foreman >= 3.18
+
 * Sun Nov 02 2025 Foreman Packaging Automation <packaging@theforeman.org> - 11.0.6-1
 - Update to 11.0.6
 


### PR DESCRIPTION
Relates to https://github.com/theforeman/foreman-tasks/pull/794
Update rubygem-foreman-tasks to require Foreman >= 3.18.0 for Foreman::Cron framework integration.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
