### PR TITLE
Migrate Katello cron to consolidated entrypoint

### DIFF
--- a/packages/katello/katello/katello.cron
+++ b/packages/katello/katello/katello.cron
@@ -1,8 +1,0 @@
-SHELL=/bin/sh
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-
-# Script for initiating removal of orphaned content
-00 22 * * 0	root	foreman-rake katello:delete_orphaned_content RAILS_ENV=production >/dev/null 2>&1
-
-# Script to refresh all alternate content sources
-00 18 * * 0     root    foreman-rake katello:refresh_alternate_content_sources >/dev/null 2>&1

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,7 +5,7 @@
 %global confdir common
 %global prereleasesource master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 1
+%global release 2
 
 Name:       katello
 Version:    4.21.0
@@ -21,7 +21,6 @@ Source11:   katello-change-hostname
 Source13:   katello-change-hostname.8.asciidoc
 Source16:   hostname-change.rb
 Source17:   helper.rb
-Source18:   katello.cron
 
 BuildRequires: asciidoc
 BuildRequires: util-linux
@@ -53,10 +52,6 @@ popd
 %install
 mkdir -p %{buildroot}/%{_mandir}/man8
 
-#copy cron scripts to be scheduled
-install -d -m0755 %{buildroot}%{_sysconfdir}/cron.d
-install -m 644 %{SOURCE18} %{buildroot}%{_sysconfdir}/cron.d/katello
-
 # symlink script libraries
 mkdir -p %{buildroot}%{_datarootdir}/katello
 install -m 644 %{SOURCE16} %{buildroot}%{_datarootdir}/katello/hostname-change.rb
@@ -79,7 +74,6 @@ install -m 644 ./manpages/katello-change-hostname.8.gz %{buildroot}/%{_mandir}/m
 %{__rm} -rf %{buildroot}
 
 %files
-%config(missingok) %{_sysconfdir}/cron.d/katello
 
 # ------ Common ------------------
 
@@ -129,6 +123,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Thu Mar 05 2026 Archana Kumari <akumari@redhat.com> - 4.21.0-0.2.master
+- Remove katello.cron, tasks now run via Foreman::Cron framework
+
 * Tue Feb 10 2026 Zach Huntington-Meath <zhunting@redhat.com> - 4.21.0-0.1.master
 - Bump version to 4.21.0
 


### PR DESCRIPTION
Relates to https://github.com/Katello/katello/pull/11633
Replace individual katello task cron entries with `cron:weekly` entrypoint. Update Katello packaging to require Foreman >= 3.18.0 for Foreman::Cron framework support.

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
