### PR TITLE
Bump pulp_deb_client requirement for rubygem-katello

### DIFF
--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -6,7 +6,7 @@
 %global prereleasesource pre.master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
 %global mainver 4.21.0
-%global release 1
+%global release 2
 
 Name: rubygem-%{gem_name}
 Version: %{mainver}
@@ -50,7 +50,7 @@ BuildRequires: (rubygem(pulpcore_client) >= 3.85.0 with rubygem(pulpcore_client)
 BuildRequires: (rubygem(pulp_file_client) >= 3.85.0 with rubygem(pulp_file_client) < 3.85.4)
 BuildRequires: (rubygem(pulp_ansible_client) >= 0.28.0 with rubygem(pulp_ansible_client) < 0.28.1)
 BuildRequires: (rubygem(pulp_container_client) >= 2.26.0 with rubygem(pulp_container_client) < 2.26.3)
-BuildRequires: (rubygem(pulp_deb_client) >= 3.7.0 with rubygem(pulp_deb_client) < 3.7.1)
+BuildRequires: (rubygem(pulp_deb_client) >= 3.8.0 with rubygem(pulp_deb_client) < 3.9.0)
 BuildRequires: (rubygem(pulp_rpm_client) >= 3.32.0 with rubygem(pulp_rpm_client) < 3.32.3)
 BuildRequires: (rubygem(pulp_certguard_client) >= 3.85.0 with rubygem(pulp_certguard_client) < 3.85.4)
 BuildRequires: (rubygem(pulp_python_client) >= 3.19.0 with rubygem(pulp_python_client) < 3.19.2)
@@ -166,6 +166,9 @@ done
 %{foreman_plugin_log}
 
 %changelog
+* Fri Feb 13 2026 Quirin Pamp <pamp@atix.de> - 4.21.0-0.2.pre.master
+- Bump pulp_deb_client requirement to >= 3.8.0
+
 * Tue Feb 10 2026 Zach Huntington-Meath <zhunting@redhat.com> - 4.21.0-0.1.pre.master
 - Bump version to 4.21.0
 


### PR DESCRIPTION
Relates to:

- https://github.com/theforeman/foreman-packaging/pull/13013
- https://github.com/Katello/katello/pull/11632
- https://github.com/theforeman/pulpcore-packaging/pull/2326

However, I am not sure in what order these need to be merged. I am also not sure if they need to be back-ported anywhere.

Need help on these questions. :wink: 