### PR TITLE
hammer_cli_foreman: Update ruby-hammer-cli to 3.18.0

### DIFF
--- a/dependencies/bookworm/hammer_cli_foreman/changelog
+++ b/dependencies/bookworm/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (3.18.0-2) stable; urgency=low
+
+  * 3.18.0-2 Dependency update ruby-hammer-cli (>= 3.18.0)
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Tue, 17 Feb 2026 16:09:39 +0100
+
 ruby-hammer-cli-foreman (3.18.0-1) stable; urgency=low
 
   * 3.18.0 released

--- a/dependencies/bookworm/hammer_cli_foreman/control
+++ b/dependencies/bookworm/hammer_cli_foreman/control
@@ -12,7 +12,7 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 3.17.0),
+         ruby-hammer-cli (>= 3.18.0),
          ruby-apipie-bindings (>= 0.7.0),
          ruby-jwt (>= 2.2.1),
          ruby-rest-client (>= 1.8.0),

--- a/dependencies/jammy/hammer_cli_foreman/changelog
+++ b/dependencies/jammy/hammer_cli_foreman/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman (3.18.0-2) stable; urgency=low
+
+  * Dependency update ruby-hammer-cli (>= 3.18.0)
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Tue, 17 Feb 2026 16:09:39 +0100
+
 ruby-hammer-cli-foreman (3.18.0-1) stable; urgency=low
 
   * 3.18.0 released

--- a/dependencies/jammy/hammer_cli_foreman/control
+++ b/dependencies/jammy/hammer_cli_foreman/control
@@ -12,7 +12,7 @@ Package: ruby-hammer-cli-foreman
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli (>= 3.17.0),
+         ruby-hammer-cli (>= 3.18.0),
          ruby-apipie-bindings (>= 0.7.0),
          ruby-jwt (>= 2.2.1),
          ruby-rest-client (>= 1.8.0),


### PR DESCRIPTION
Bot misses updates to the `control` file during the automated version bump. This patch fixes the version of ruby-hammer-cli that hammer_cli_foreman depends on.
