### PR TITLE
Update ruby-hammer-cli to 3.18.0

### DIFF
--- a/dependencies/bookworm/hammer_cli/changelog
+++ b/dependencies/bookworm/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (3.18.0-1) stable; urgency=low
+
+  * 3.18.0 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Sun, 15 Feb 2026 04:45:53 +0000
+
 ruby-hammer-cli (3.17.0-1) stable; urgency=low
 
   * 3.17.0 released

--- a/dependencies/jammy/hammer_cli/changelog
+++ b/dependencies/jammy/hammer_cli/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli (3.18.0-1) stable; urgency=low
+
+  * 3.18.0 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Sun, 15 Feb 2026 04:45:53 +0000
+
 ruby-hammer-cli (3.17.0-1) stable; urgency=low
 
   * 3.17.0 released


### PR DESCRIPTION
Cherry-pick of #13010
Bump hammer-cli to 3.18.0


```
[2026-02-24T10:58:09.295Z]         Error 1: Puppet Package resource 'foreman-cli' failed. Logs:
[2026-02-24T10:58:09.295Z]           /Stage[main]/Foreman::Cli/Package[foreman-cli]/before
[2026-02-24T10:58:09.296Z]             before to Class[Foreman]
[2026-02-24T10:58:09.296Z]             before to File[/etc/hammer/cli.modules.d/foreman.yml]
[2026-02-24T10:58:09.296Z]           /Package[foreman-cli]
[2026-02-24T10:58:09.296Z]             Evaluated in 0.30 seconds
[2026-02-24T10:58:09.296Z]           /Stage[main]/Foreman::Cli/Package[foreman-cli]/ensure
[2026-02-24T10:58:09.296Z]             change from 'purged' to 'present' failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install foreman-cli' returned 100: Reading package lists...
[2026-02-24T10:58:09.296Z]         Building dependency tree...
[2026-02-24T10:58:09.296Z]         Reading state information...
[2026-02-24T10:58:09.296Z]         Some packages could not be installed. This may mean that you have
[2026-02-24T10:58:09.296Z]         requested an impossible situation or if you are using the unstable
[2026-02-24T10:58:09.296Z]         distribution that some required packages have not yet been created
[2026-02-24T10:58:09.296Z]         or been moved out of Incoming.
[2026-02-24T10:58:09.296Z]         The following information may help to resolve the situation:
[2026-02-24T10:58:09.296Z] 
[2026-02-24T10:58:09.296Z]         The following packages have unmet dependencies:
[2026-02-24T10:58:09.296Z]          ruby-hammer-cli-foreman : Depends: ruby-hammer-cli (>= 3.18.0) but 3.17.0-1+debian12 is to be installed
[2026-02-24T10:58:09.296Z]         E: Unable to correct problems, you have held broken packages.
```


https://jenkins-foreman.apps.ocp.cloud.ci.centos.org/blue/organizations/jenkins/foreman-pipeline-foreman-deb-3.18/detail/foreman-pipeline-foreman-deb-3.18/3/pipeline
