### PR TITLE
Add libffi-dev build dependency for locale gem 2.1.5 compatibility

### DIFF
--- a/debian/bookworm/foreman/changelog
+++ b/debian/bookworm/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (3.19.0-2) stable; urgency=low
+
+  * Add libffi-dev build and runtime dependency for locale gem 2.1.5 compatibility
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Tue, 25 Feb 2026 11:00:00 +0100
+
 foreman (3.19.0-1) stable; urgency=low
 
   * Bump changelog to 3.19.0 to match VERSION

--- a/debian/bookworm/foreman/control
+++ b/debian/bookworm/foreman/control
@@ -5,7 +5,7 @@ Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 9.20160709), ruby-dev (>= 1:2.7), git,
                zlib1g-dev, libpq-dev, pkg-config, libvirt-dev, libyaml-dev,
-               build-essential, curl, nodejs (>= 22.0), npm,
+               build-essential, curl, nodejs (>= 22.0), npm, libffi-dev,
                python3, libsystemd-dev, libcurl4-openssl-dev, libxml2-dev, tzdata,
                libfontconfig1, libfreetype6
 Homepage: http://www.theforeman.org/
@@ -15,7 +15,7 @@ Architecture: any
 Section: web
 Priority: extra
 Depends: ruby (>= 1:2.7), ruby-dev, zlib1g-dev,
-         build-essential, tzdata, libyaml-dev,
+         build-essential, tzdata, libyaml-dev, libffi-dev,
          rake (>=0.8.4), gawk, ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug (= ${binary:Version})
 Conflicts: ruby-activerecord-deprecated-finders, ruby-foreman-tasks (<< 0.10.1), ruby-sequel-pg, ruby-foreman-hooks (<= 0.3.17)

--- a/debian/jammy/foreman/changelog
+++ b/debian/jammy/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (3.19.0-2) stable; urgency=low
+
+  * Add libffi-dev build and runtime dependency for locale gem 2.1.5 compatibility
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Tue, 25 Feb 2026 11:00:00 +0100
+
 foreman (3.19.0-1) stable; urgency=low
 
   * Bump changelog to 3.19.0 to match VERSION

--- a/debian/jammy/foreman/control
+++ b/debian/jammy/foreman/control
@@ -5,7 +5,7 @@ Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 9.20160709), ruby-dev (>= 1:2.7), git,
                zlib1g-dev, libpq-dev, pkg-config, libvirt-dev,
-               build-essential, curl, nodejs (>= 22.0),
+               build-essential, curl, nodejs (>= 22.0), libffi-dev,
                python3, libsystemd-dev, libcurl4-openssl-dev, libxml2-dev, tzdata,
                libfontconfig1, libfreetype6
 Homepage: http://www.theforeman.org/
@@ -15,7 +15,7 @@ Architecture: any
 Section: web
 Priority: extra
 Depends: ruby (>= 1:2.7), ruby-dev, zlib1g-dev,
-         build-essential, tzdata,
+         build-essential, tzdata, libffi-dev,
          rake (>=0.8.4), gawk, ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug (= ${binary:Version})
 Conflicts: ruby-activerecord-deprecated-finders, ruby-foreman-tasks (<< 0.10.1), ruby-sequel-pg, ruby-foreman-hooks (<= 0.3.17)


### PR DESCRIPTION
Based on discussion in #13103, this patch introduces new build dependency to satisfy locale 2.1.5 gem's dependencies.
