### PR TITLE
Fix racc dependencies on EL10

### DIFF
--- a/packages/foreman/rubygem-actionpack/rubygem-actionpack.spec
+++ b/packages/foreman/rubygem-actionpack/rubygem-actionpack.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Web-flow and rendering framework putting the VC in MVC (part of Rails)
 License: MIT
 URL: https://rubyonrails.org
@@ -16,7 +16,9 @@ BuildRequires: rubygems-devel
 BuildArch: noarch
 # end specfile generated dependencies
 
+%if 0%{?rhel} == 9
 Requires: (bundled(rubygem-racc) >= 1.4 with bundled(rubygem-racc) < 2)
+%endif
 
 %description
 Web apps on Rails. Simple, battle-tested conventions for building and testing
@@ -34,7 +36,9 @@ Documentation for %{name}.
 %prep
 %setup -q -n  %{gem_name}-%{version}
 
+%if 0%{?rhel} == 9
 %gemspec_remove_dep -g racc
+%endif
 
 %build
 # Create the gem as gem install only works on a gem file
@@ -62,6 +66,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.rdoc
 
 %changelog
+* Fri Feb 27 2026 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 7.0.10-2
+- Fix racc dependency on EL10
+
 * Wed Oct 29 2025 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.10-1
 - Update to 7.0.10
 

--- a/packages/foreman/rubygem-gettext/rubygem-gettext.spec
+++ b/packages/foreman/rubygem-gettext/rubygem-gettext.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.5.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Gettext is a pure Ruby libary and tools to localize messages
 License: Ruby and LGPLv3+
 URL: https://ruby-gettext.github.io/
@@ -16,12 +16,14 @@ BuildRequires: rubygems-devel
 BuildArch: noarch
 # end specfile generated dependencies
 
+%if 0%{?rhel} == 9
 # prime is a default gem in Ruby < 3.1, bundled in >= 3.1
 Requires: (rubygem(prime) or ruby-default-gems < 3.1)
 
 # Prefer to consume racc as a default gem. ruby-default-gems provides the gemspec, ruby-libs the files
 Requires: ruby-default-gems
 Requires: bundled(rubygem-racc)
+%endif
 
 %description
 Gettext is a GNU gettext-like program for Ruby.
@@ -40,12 +42,14 @@ Documentation for %{name}.
 %prep
 %setup -q -n  %{gem_name}-%{version}
 
+%if 0%{?rhel} == 9
 # prime is a default gem in Ruby < 3.1, bundled in >= 3.1
 %gemspec_remove_dep -g prime
 
-# On EL8 rubygem-racc is bundled into ruby-libs + ruby-default-libs and
+# On EL9 rubygem-racc is bundled into ruby-libs + ruby-default-libs and
 # auto-generated dependencies will break dependency resolution
 %gemspec_remove_dep -g racc
+%endif
 
 %build
 # Create the gem as gem install only works on a gem file
@@ -92,6 +96,9 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 %{gem_instdir}/test
 
 %changelog
+* Fri Feb 27 2026 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.5.1-2
+- Fix racc dependency on EL10
+
 * Wed Jan 29 2025 Foreman Packaging Automation <packaging@theforeman.org> - 3.5.1-1
 - Update to 3.5.1
 

--- a/packages/foreman/rubygem-nokogiri/rubygem-nokogiri.spec
+++ b/packages/foreman/rubygem-nokogiri/rubygem-nokogiri.spec
@@ -4,7 +4,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.17.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby
 # MIT: see LICENSE.md
 # ASL 2.0
@@ -31,13 +31,11 @@ BuildRequires: gcc
 BuildRequires:	libxml2-devel
 BuildRequires:	libxslt-devel
 
-# Prefer to consume racc as a default gem
-Requires: ruby-default-gems
-BuildRequires: ruby-default-gems
-# CI runs rpmlint on EL7 and doesn't understand rich dependencies
-%if 0%{?rhel} >= 8
+%if 0%{?rhel} == 9
 Requires: (bundled(rubygem-racc) >= 1.4 with bundled(rubygem-racc) < 2)
 BuildRequires: (bundled(rubygem-racc) >= 1.4 with bundled(rubygem-racc) < 2)
+%else
+BuildRequires: (rubygem(racc) >= 1.4 with rubygem(racc) < 2)
 %endif
 
 %description
@@ -58,9 +56,11 @@ Documentation for %{name}.
 %prep
 %setup -q -n  %{gem_name}-%{version}
 
-# On EL8 rubygem-racc is bundled into ruby-libs package and
+%if 0%{?rhel} == 9
+# On EL9 rubygem-racc is bundled into ruby-libs package and
 # auto-generated dependencies will break dependency resolution
 %gemspec_remove_dep -g racc "~> 1.4"
+%endif
 
 # patches
 %patch -P0 -p1
@@ -186,6 +186,9 @@ rm -rf gem_ext_test
 %doc %{gem_instdir}/gumbo-parser/src/README.md
 
 %changelog
+* Fri Feb 27 2026 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.17.2-2
+- Fix racc dependency on EL10
+
 * Wed Dec 17 2025 Ondřej Gajdušek <ogajduse@redhat.com> - 1.17.2-1
 - Update to 1.17.2
 

--- a/packages/foreman/rubygem-ruby_parser/rubygem-ruby_parser.spec
+++ b/packages/foreman/rubygem-ruby_parser/rubygem-ruby_parser.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.21.1
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: A ruby parser written in pure ruby
 License: MIT
 URL: https://github.com/seattlerb/ruby_parser
@@ -18,9 +18,12 @@ BuildRequires: rubygems-devel
 BuildArch: noarch
 # end specfile generated dependencies
 
-# Prefer to consume racc as a default gem
+%if 0%{?rhel} == 9
 Requires: (bundled(rubygem-racc) >= 1.4 with bundled(rubygem-racc) < 2)
 BuildRequires: (bundled(rubygem-racc) >= 1.4 with bundled(rubygem-racc) < 2)
+%else
+BuildRequires: (rubygem(racc) >= 1.4 with rubygem(racc) < 2)
+%endif
 
 %description
 ruby_parser (RP) is a ruby parser written in pure ruby (utilizing
@@ -40,9 +43,11 @@ Documentation for %{name}.
 %prep
 %setup -q -n  %{gem_name}-%{version}
 
+%if 0%{?rhel} == 9
 # rubygem-racc is bundled into ruby-libs package and
 # auto-generated dependencies will break dependency resolution
 %gemspec_remove_dep -g racc "~> 1.5"
+%endif
 
 %build
 # Create the gem as gem install only works on a gem file
@@ -86,6 +91,9 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 %{gem_instdir}/test
 
 %changelog
+* Fri Feb 27 2026 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.21.1-3
+- Fix racc dependency on EL10
+
 * Fri Dec 19 2025 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.21.1-2
 - Drop EL8 requirement workaround
 


### PR DESCRIPTION
On EL10 there is now ruby4.0 which provides bundled(rubygem-racc) and that confuses the dependency generator, leading to broken packages. It now only applies the hack on EL9, falling back to default behavior on other platforms.