### PR TITLE
Backport rubygem-pg patch to remove rpath

### DIFF
--- a/packages/foreman/rubygem-pg/rubygem-pg-remove-rpath.patch
+++ b/packages/foreman/rubygem-pg/rubygem-pg-remove-rpath.patch
@@ -1,0 +1,17 @@
+diff --git a/ext/extconf.rb b/ext/extconf.rb
+--- a/ext/extconf.rb
++++ b/ext/extconf.rb
+@@ -218,13 +218,6 @@ else
+ 		dlldir = libdir
+ 	end
+ 
+-	# Try to use runtime path linker option, even if RbConfig doesn't know about it.
+-	# The rpath option is usually set implicit by dir_config(), but so far not
+-	# on MacOS-X.
+-	if dlldir && RbConfig::CONFIG["RPATHFLAG"].to_s.empty?
+-		append_ldflags "-Wl,-rpath,#{dlldir.quote}"
+-	end
+-
+ 	if /mswin/ =~ RUBY_PLATFORM
+ 		$libs = append_library($libs, 'ws2_32')
+ 	end

--- a/packages/foreman/rubygem-pg/rubygem-pg.spec
+++ b/packages/foreman/rubygem-pg/rubygem-pg.spec
@@ -4,7 +4,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.6.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Pg is the Ruby interface to the PostgreSQL RDBMS
 # Upstream license clarification (https://bitbucket.org/ged/ruby-pg/issue/72/)
 #
@@ -14,6 +14,8 @@ Summary: Pg is the Ruby interface to the PostgreSQL RDBMS
 License: (GPLv2 or Ruby) and PostgreSQL
 URL: https://github.com/ged/ruby-pg
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
+# https://github.com/ged/ruby-pg/pull/699
+Patch: rubygem-pg-remove-rpath.patch
 
 # start specfile generated dependencies
 Requires: ruby >= 2.7
@@ -41,7 +43,7 @@ BuildArch: noarch
 Documentation for %{name}.
 
 %prep
-%setup -q -n  %{gem_name}-%{version}
+%autosetup -p1 -n %{gem_name}-%{version}
 
 %build
 # Create the gem as gem install only works on a gem file
@@ -101,6 +103,9 @@ rm -rf gem_ext_test
 %exclude %{gem_instdir}/pg.gemspec
 
 %changelog
+* Sat Feb 28 2026 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.6.3-2
+- Add patch to remove rpath
+
 * Thu Jan 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.6.3-1
 - Update to 1.6.3
 


### PR DESCRIPTION
This takes the patch from Fedora that is already merged upstream to fix a failure on EL10.