### PR TITLE
Update rubygem-ovirt-engine-sdk to 4.6.1

### DIFF
--- a/packages/plugins/rubygem-ovirt-engine-sdk/ovirt-engine-sdk-4.6.0.gem
+++ b/packages/plugins/rubygem-ovirt-engine-sdk/ovirt-engine-sdk-4.6.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/6G/05/SHA256E-s353280--4ab79266194bdb4b2a1bf0ed22113de483bf33e5272e5f97b33c229cfa66aaee.0.gem/SHA256E-s353280--4ab79266194bdb4b2a1bf0ed22113de483bf33e5272e5f97b33c229cfa66aaee.0.gem

--- a/packages/plugins/rubygem-ovirt-engine-sdk/ovirt-engine-sdk-4.6.1.gem
+++ b/packages/plugins/rubygem-ovirt-engine-sdk/ovirt-engine-sdk-4.6.1.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/q0/K8/SHA256E-s354816--6eb7a849fe4393d76e7c70aa8ea988e1490c89a62c6f59f0ed3ebf7ff0ab6891.1.gem/SHA256E-s354816--6eb7a849fe4393d76e7c70aa8ea988e1490c89a62c6f59f0ed3ebf7ff0ab6891.1.gem

--- a/packages/plugins/rubygem-ovirt-engine-sdk/rubygem-ovirt-engine-sdk.spec
+++ b/packages/plugins/rubygem-ovirt-engine-sdk/rubygem-ovirt-engine-sdk.spec
@@ -3,8 +3,8 @@
 %global gem_require_name ovirtsdk4
 
 Name: rubygem-%{gem_name}
-Version: 4.6.0
-Release: 2%{?dist}
+Version: 4.6.1
+Release: 1%{?dist}
 Summary: oVirt SDK
 License: Apache-2.0
 URL: https://ovirt.org
@@ -83,6 +83,9 @@ rm -rf gem_ext_test
 %doc %{gem_instdir}/README.adoc
 
 %changelog
+* Wed Mar 04 2026 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 4.6.1-1
+- Update to 4.6.1
+
 * Tue Aug 12 2025 Evgeni Golov - 4.6.0-2
 - Rebuild for plugins
 


### PR DESCRIPTION
This contains EL10 fixes.