### PR TITLE
Update ruby-hammer-cli-foreman-remote-execution to 0.4.2

### DIFF
--- a/dependencies/bookworm/hammer_cli_foreman_remote_execution/changelog
+++ b/dependencies/bookworm/hammer_cli_foreman_remote_execution/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-remote-execution (0.4.2-1) stable; urgency=low
+
+  * 0.4.2 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Tue, 10 Mar 2026 16:19:02 +0000
+
 ruby-hammer-cli-foreman-remote-execution (0.4.1-1) stable; urgency=low
 
   * 0.4.1 released

--- a/dependencies/jammy/hammer_cli_foreman_remote_execution/changelog
+++ b/dependencies/jammy/hammer_cli_foreman_remote_execution/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-remote-execution (0.4.2-1) stable; urgency=low
+
+  * 0.4.2 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Tue, 10 Mar 2026 16:19:02 +0000
+
 ruby-hammer-cli-foreman-remote-execution (0.4.1-1) stable; urgency=low
 
   * 0.4.1 released


### PR DESCRIPTION
(cherry picked from commit f669c21432c5eec5027027761dda662bb880bc02)