### PR TITLE
Update ruby-hammer-cli-foreman-webhooks to 0.2.2

### DIFF
--- a/dependencies/bookworm/hammer_cli_foreman_webhooks/changelog
+++ b/dependencies/bookworm/hammer_cli_foreman_webhooks/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-webhooks (0.2.2-1) stable; urgency=low
+
+  * 0.2.2 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Tue, 10 Mar 2026 16:21:09 +0000
+
 ruby-hammer-cli-foreman-webhooks (0.2.1-1) stable; urgency=low
 
   * 0.2.1 released

--- a/dependencies/jammy/hammer_cli_foreman_webhooks/changelog
+++ b/dependencies/jammy/hammer_cli_foreman_webhooks/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-webhooks (0.2.2-1) stable; urgency=low
+
+  * 0.2.2 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Tue, 10 Mar 2026 16:21:10 +0000
+
 ruby-hammer-cli-foreman-webhooks (0.2.1-1) stable; urgency=low
 
   * 0.2.1 released


### PR DESCRIPTION
(cherry picked from commit afcae973a9f5c876c50d4e38470f8c18e5be4aa3)
