### PR TITLE
Update rubygem-smart_proxy_container_gateway to 3.5.0

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_container_gateway/rubygem-smart_proxy_container_gateway.spec
+++ b/packages/plugins/rubygem-smart_proxy_container_gateway/rubygem-smart_proxy_container_gateway.spec
@@ -9,7 +9,7 @@
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
 Name: rubygem-%{gem_name}
-Version: 3.4.2
+Version: 3.5.0
 Release: 1%{?foremandist}%{?dist}
 Summary: Pulp 3 container registry support for Foreman/Katello Smart-Proxy
 License: GPLv3
@@ -79,6 +79,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/container_gateway.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Feb 23 2026 ianballou <ianballou67@gmail.com> - 3.5.0-1
+- Update to 3.5.0
+
 * Fri Dec 05 2025 Samir Jha <smirjha1525@gmail.com> - 3.4.2-1
 - Update to 3.4.2
 

--- a/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-3.4.2.gem
+++ b/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-3.4.2.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/0x/Z7/SHA256E-s26624--a7b80501b0b6553ecffa22763edc072453329bdcf6eaa8b0327ec41491e7dd7a.2.gem/SHA256E-s26624--a7b80501b0b6553ecffa22763edc072453329bdcf6eaa8b0327ec41491e7dd7a.2.gem

--- a/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-3.5.0.gem
+++ b/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-3.5.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/VM/WQ/SHA256E-s27136--cbd31898261183f10a18752fa87cf90aba49efe5c8bfd2548f75d7133c5d19ae.0.gem/SHA256E-s27136--cbd31898261183f10a18752fa87cf90aba49efe5c8bfd2548f75d7133c5d19ae.0.gem


### PR DESCRIPTION
Bump to add support for the new database connection tuning. https://projects.theforeman.org/issues/39093