### PR TITLE
Bump katello 4.19 bindings pins and  release 4.19.2

### DIFF
--- a/packages/katello/rubygem-katello/katello-4.19.1.gem
+++ b/packages/katello/rubygem-katello/katello-4.19.1.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/mp/0v/SHA256E-s9870848--a2e7c9ad1fead56b44b1c45eecc7d361e4aeadaf2c4d1d9fa38d4b33c56b84ce.1.gem/SHA256E-s9870848--a2e7c9ad1fead56b44b1c45eecc7d361e4aeadaf2c4d1d9fa38d4b33c56b84ce.1.gem

--- a/packages/katello/rubygem-katello/katello-4.19.2.gem
+++ b/packages/katello/rubygem-katello/katello-4.19.2.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/8V/kx/SHA256E-s9867776--4be57cdf4c944ce2770d1d9a59bc2daec9bbb64d0f8822fa02f49d986be16936.2.gem/SHA256E-s9867776--4be57cdf4c944ce2770d1d9a59bc2daec9bbb64d0f8822fa02f49d986be16936.2.gem

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -3,8 +3,8 @@
 %global plugin_name katello
 %global foreman_min_version 3.17
 %global foreman_max_version 3.18
-%global mainver 4.19.1
-%global release 2
+%global mainver 4.19.2
+%global release 1
 
 Name: rubygem-%{gem_name}
 Version: %{mainver}
@@ -164,6 +164,9 @@ done
 %{foreman_plugin_log}
 
 %changelog
+* Wed Mar 19 2026 Ian Ballou <ianballou67@gmail.com> - 4.19.2-1
+- Release rubygem-katello 4.19.2
+
 * Wed Mar 19 2026 Ian Ballou <ianballou67@gmail.com> - 4.19.1-2
 - Unpin Pulp bindings
 

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -4,7 +4,7 @@
 %global foreman_min_version 3.17
 %global foreman_max_version 3.18
 %global mainver 4.19.1
-%global release 1
+%global release 2
 
 Name: rubygem-%{gem_name}
 Version: %{mainver}
@@ -44,15 +44,15 @@ BuildRequires: rubygem(fx) < 1.0
 BuildRequires: rubygem(pg)
 BuildRequires: rubygem(spidr)
 BuildRequires: (rubygem(faraday) >= 1.10.2 with rubygem(faraday) < 1.11.0)
-BuildRequires: (rubygem(pulpcore_client) >= 3.85.0 with rubygem(pulpcore_client) < 3.85.4)
-BuildRequires: (rubygem(pulp_file_client) >= 3.85.0 with rubygem(pulp_file_client) < 3.85.4)
-BuildRequires: (rubygem(pulp_ansible_client) >= 0.28.0 with rubygem(pulp_ansible_client) < 0.28.1)
-BuildRequires: (rubygem(pulp_container_client) >= 2.26.0 with rubygem(pulp_container_client) < 2.26.3)
-BuildRequires: (rubygem(pulp_deb_client) >= 3.7.0 with rubygem(pulp_deb_client) < 3.7.1)
-BuildRequires: (rubygem(pulp_rpm_client) >= 3.32.0 with rubygem(pulp_rpm_client) < 3.32.3)
-BuildRequires: (rubygem(pulp_certguard_client) >= 3.85.0 with rubygem(pulp_certguard_client) < 3.85.4)
-BuildRequires: (rubygem(pulp_python_client) >= 3.19.0 with rubygem(pulp_python_client) < 3.19.2)
-BuildRequires: (rubygem(pulp_ostree_client) >= 2.5.0 with rubygem(pulp_ostree_client) < 2.5.1)
+BuildRequires: (rubygem(pulpcore_client) >= 3.85.0 with rubygem(pulpcore_client) < 3.86.0)
+BuildRequires: (rubygem(pulp_file_client) >= 3.85.0 with rubygem(pulp_file_client) < 3.86.0)
+BuildRequires: (rubygem(pulp_ansible_client) >= 0.28.0 with rubygem(pulp_ansible_client) < 0.29.0)
+BuildRequires: (rubygem(pulp_container_client) >= 2.26.0 with rubygem(pulp_container_client) < 2.27.0)
+BuildRequires: (rubygem(pulp_deb_client) >= 3.8.0 with rubygem(pulp_deb_client) < 3.9.0)
+BuildRequires: (rubygem(pulp_rpm_client) >= 3.32.0 with rubygem(pulp_rpm_client) < 3.33.0)
+BuildRequires: (rubygem(pulp_certguard_client) >= 3.85.0 with rubygem(pulp_certguard_client) < 3.86.0)
+BuildRequires: (rubygem(pulp_python_client) >= 3.19.0 with rubygem(pulp_python_client) < 3.20.0)
+BuildRequires: (rubygem(pulp_ostree_client) >= 2.5.0 with rubygem(pulp_ostree_client) < 2.6.0)
 BuildRequires: (rubygem(deface) >= 1.0.2 with rubygem(deface) < 2.0.0)
 BuildRequires: (rubygem(angular-rails-templates) >= 1.1 with rubygem(angular-rails-templates) < 2)
 BuildRequires: (rubygem(jquery-ui-rails) >= 6.0 with rubygem(jquery-ui-rails) < 7.0)
@@ -164,6 +164,9 @@ done
 %{foreman_plugin_log}
 
 %changelog
+* Wed Mar 19 2026 Ian Ballou <ianballou67@gmail.com> - 4.19.1-2
+- Unpin Pulp bindings
+
 * Mon Mar 16 2026 Zach Huntington-Meath <zhunting@redhat.com> - 4.19.1-1
 - Release rubygem-katello 4.19.1
 


### PR DESCRIPTION
Bumps Pulp bindings and releases Katello 4.19.2.  Requires first that the 4.19.2 gem is released.