### PR TITLE
Fixes #39189 - backport CVE-2026-33658 fix for activestorage 7.0.10

### DIFF
--- a/packages/foreman/rubygem-activestorage/CVE-2026-33658-limit-range-requests.patch
+++ b/packages/foreman/rubygem-activestorage/CVE-2026-33658-limit-range-requests.patch
@@ -1,0 +1,31 @@
+--- a/app/controllers/concerns/active_storage/streaming.rb
++++ b/app/controllers/concerns/active_storage/streaming.rb
+@@ -15,6 +15,7 @@
+       ranges = Rack::Utils.get_byte_ranges(range_header, blob.byte_size)
+
+       return head(:range_not_satisfiable) if ranges.blank? || ranges.all?(&:blank?)
++      return head(:range_not_satisfiable) if ranges.length > ActiveStorage.streaming_max_ranges
+
+       if ranges.length == 1
+         range = ranges.first
+--- a/lib/active_storage.rb
++++ b/lib/active_storage.rb
+@@ -360,6 +360,18 @@
+   mattr_accessor :replace_on_assign_to_many, default: false
+   mattr_accessor :track_variants, default: false
+
++  singleton_class.attr_accessor :checksum_implementation
++  @checksum_implementation = OpenSSL::Digest::MD5
++  begin
++    @checksum_implementation.hexdigest("test")
++  rescue # OpenSSL may have MD5 disabled
++    require "digest/md5"
++    @checksum_implementation = Digest::MD5
++  end
++
++  singleton_class.attr_accessor :streaming_max_ranges
++  @streaming_max_ranges = 1
++
+   mattr_accessor :video_preview_arguments, default: "-y -vframes 1 -f image2"
+
+   mattr_accessor :silence_invalid_content_types_warning, default: false

--- a/packages/foreman/rubygem-activestorage/rubygem-activestorage.spec
+++ b/packages/foreman/rubygem-activestorage/rubygem-activestorage.spec
@@ -3,11 +3,12 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Local and cloud file storage framework
 License: MIT
 URL: https://rubyonrails.org
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
+Patch0: CVE-2026-33658-limit-range-requests.patch
 
 # start specfile generated dependencies
 Requires: ruby >= 2.7.0
@@ -29,7 +30,7 @@ BuildArch: noarch
 Documentation for %{name}.
 
 %prep
-%setup -q -n  %{gem_name}-%{version}
+%autosetup -p1 -n  %{gem_name}-%{version}
 
 %build
 # Create the gem as gem install only works on a gem file
@@ -60,6 +61,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Sat Mar 28 2026 Jakub Duchek <jakduch@seznam.cz> - 7.0.10-2
+- Backport fix for CVE-2026-33658 (Active Storage DoS via HTTP Range header)
+
 * Wed Oct 29 2025 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.10-1
 - Update to 7.0.10
 


### PR DESCRIPTION
## Summary

**Redmine:** https://projects.theforeman.org/issues/39189

Backport of the upstream security fix for CVE-2026-33658 (Active Storage DoS via HTTP Range header) to the rubygem-activestorage 7.0.10 package.

Active Storage proxy controller does not limit the number of byte ranges in an HTTP Range header. A request with thousands of small ranges causes disproportionate CPU usage, resulting in a potential DoS vulnerability.

This adds a patch that limits range requests to a single range by default via `ActiveStorage.streaming_max_ranges = 1`.

## Changes

- Added `CVE-2026-33658-limit-range-requests.patch` based on upstream commit rails/rails@b8a1665
- Updated spec to apply patch via `%autosetup -p1`
- Bumped release to 7.0.10-2

## References

- Upstream commit: https://github.com/rails/rails/commit/b8a1665824a43d71cd6406cf9adcae842ceb1c22
- Advisory: https://github.com/rails/rails/security/advisories/GHSA-p9fm-f462-ggrg
