### PR TITLE
Add foreman-opentofu-selinux to comps file

### DIFF
--- a/comps/comps-foreman-plugins-el9.xml
+++ b/comps/comps-foreman-plugins-el9.xml
@@ -101,6 +101,7 @@
       <packagereq type="default">rubygem-foreman_opennebula</packagereq>
       <packagereq type="default">rubygem-foreman_openscap</packagereq>
       <packagereq type="default">rubygem-foreman_opentofu</packagereq>
+      <packagereq type="default">foreman-opentofu-selinux</packagereq>
       <packagereq type="default">rubygem-foreman_ovirt</packagereq>
       <packagereq type="default">rubygem-foreman_puppet</packagereq>
       <packagereq type="default">rubygem-foreman_remote_execution</packagereq>


### PR DESCRIPTION
The rubygem-foreman_opentofu package added a SELinux subpackage in version
0.0.4 with a conditional dependency. The subpackage was built successfully
in COPR but was missing from the repository composition, causing repoclosure
failures.

This adds the foreman-opentofu-selinux package to the comps file so it gets
included in the staging repository.

Fixes: https://ci.theforeman.org/view/Foreman%20Nightly/job/foreman-plugins-nightly-rpm-pipeline/2552/
