### PR TITLE
install which as rubyipmi dependency

### DIFF
--- a/packages/foreman/rubygem-rubyipmi/rubygem-rubyipmi.spec
+++ b/packages/foreman/rubygem-rubyipmi/rubygem-rubyipmi.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.13.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A ruby wrapper for ipmi command line tools that supports ipmitool and freeipmi
 License: LGPLv2.1
 URL: https://github.com/logicminds/rubyipmi
@@ -20,6 +20,7 @@ Requires: (rubygem(logger) or ruby-default-gems < 3.5)
 Requires: (rubygem(observer) or ruby-default-gems < 3.4)
 
 Requires: ipmitool
+Requires: which
 
 %description
 Controls IPMI devices via command line wrapper for ipmitool and freeipmi.

--- a/packages/foreman/rubygem-rubyipmi/rubygem-rubyipmi.spec
+++ b/packages/foreman/rubygem-rubyipmi/rubygem-rubyipmi.spec
@@ -72,6 +72,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/rubyipmi.gemspec
 
 %changelog
+* Thu Apr 30 2026 Arvind Jangir <ajangir@redhat.com> 0.13.0-2
+- Add which as dependency
+
 * Thu Feb 05 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.13.0-1
 - Update to 0.13.0
 


### PR DESCRIPTION
rubyipmi has runtime dependency on `which`  and wothout it fails at https://github.com/logicminds/rubyipmi/blob/main/lib/rubyipmi.rb#L155 with
Error details for No such file or directory - which: Errno::ENOENT: No such file or directory - which

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
