### PR TITLE
Disable EL8 Foreman/Katello mock repos

### DIFF
--- a/mock/el8.cfg
+++ b/mock/el8.cfg
@@ -73,18 +73,6 @@ gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[foreman]
-name=foreman
-baseurl=https://yum.theforeman.org/nightly/el8/x86_64/
-
-[foreman-plugins]
-name=foreman-plugins
-baseurl=https://yum.theforeman.org/plugins/nightly/el8/x86_64/
-
-[katello]
-name=katello
-baseurl=https://yum.theforeman.org/katello/nightly/katello/el8/x86_64/
-
 [puppet-8]
 name=puppet-8
 baseurl=https://yum.puppetlabs.com/puppet8/el/8/x86_64/


### PR DESCRIPTION
## Summary
Foreman and Katello are no longer built for EL8. This PR removes the foreman, foreman-plugins, and katello repository configurations from the EL8 mock config.

## Changes
- Removed `[foreman]`, `[foreman-plugins]`, and `[katello]` repo sections from `mock/el8.cfg`
- Kept all base EL8 repos since foreman-client is still built for EL8
- No changes to `repoclosure/yum.conf` as it only contains foreman-client repos for EL8

🤖 Generated with [Claude Code](https://claude.com/claude-code)