### PR TITLE
Switch from Puppet to OpenVox repositories

### DIFF
--- a/mock/el10.cfg
+++ b/mock/el10.cfg
@@ -21,7 +21,7 @@ config_opts['dnf.conf'] += """
 #name=katello
 #baseurl=https://yum.theforeman.org/katello/nightly/katello/el10/x86_64/
 #
-#[openvox-8]
-#name=openvox-8
-#baseurl=https://yum.voxpupuli.org/openvox8/el/10/x86_64/
+[openvox-8]
+name=openvox-8
+baseurl=https://yum.voxpupuli.org/openvox8/el/10/x86_64/
 """

--- a/mock/el10.cfg
+++ b/mock/el10.cfg
@@ -21,7 +21,7 @@ config_opts['dnf.conf'] += """
 #name=katello
 #baseurl=https://yum.theforeman.org/katello/nightly/katello/el10/x86_64/
 #
-#[puppet-8]
-#name=puppet-8
-#baseurl=https://yum.puppetlabs.com/puppet8/el/10/x86_64/
+#[openvox-8]
+#name=openvox-8
+#baseurl=https://yum.voxpupuli.org/openvox8/el/10/x86_64/
 """

--- a/mock/el8.cfg
+++ b/mock/el8.cfg
@@ -73,7 +73,7 @@ gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[puppet-8]
-name=puppet-8
-baseurl=https://yum.puppetlabs.com/puppet8/el/8/x86_64/
+[openvox-8]
+name=openvox-8
+baseurl=https://yum.voxpupuli.org/openvox8/el/8/x86_64/
 """

--- a/mock/el9.cfg
+++ b/mock/el9.cfg
@@ -112,7 +112,7 @@ baseurl=https://yum.theforeman.org/plugins/nightly/el9/x86_64/
 name=katello
 baseurl=https://yum.theforeman.org/katello/nightly/katello/el9/x86_64/
 
-[puppet-8]
-name=puppet-8
-baseurl=https://yum.puppetlabs.com/puppet8/el/9/x86_64/
+[openvox-8]
+name=openvox-8
+baseurl=https://yum.voxpupuli.org/openvox8/el/9/x86_64/
 """

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -43,9 +43,9 @@ name=CentOS Stream 9 - CRB
 metalink=https://mirrors.centos.org/metalink?repo=centos-crb-9-stream&arch=x86_64&protocol=https,http
 enabled=1
 
-[el9-puppet-8]
-name=el9-puppet-8
-baseurl=https://yum.puppetlabs.com/puppet8/el/9/x86_64/
+[el9-openvox-8]
+name=el9-openvox-8
+baseurl=https://yum.voxpupuli.org/openvox8/el/9/x86_64/
 
 [el10-foreman-client-nightly-staging]
 name=Foreman Client nightly EL10
@@ -90,9 +90,9 @@ mirrorlist=https://mirrors.almalinux.org/mirrorlist/8/powertools
 name=Foreman Client nightly EL8
 baseurl=https://stagingyum.theforeman.org/client/nightly/el8/x86_64/
 
-[el8-puppet-8]
-name=el8-puppet-8
-baseurl=https://yum.puppetlabs.com/puppet8/el/8/x86_64/
+[el8-openvox-8]
+name=el8-openvox-8
+baseurl=https://yum.voxpupuli.org/openvox8/el/8/x86_64/
 
 [el9-foreman-nightly-staging]
 name=Foreman nightly staging EL9


### PR DESCRIPTION
## Summary
Migrates all Puppet 8 repository references to OpenVox 8, following the community-maintained Vox Pupuli fork.

## Changes
Updated repository URLs in mock and repoclosure configurations:
- **yum.puppetlabs.com** → **yum.voxpupuli.org**
- **puppet8** → **openvox8**
- Repository names: `puppet-8` → `openvox-8`

## Files Updated
- `mock/el8.cfg` - Updated openvox-8 repository
- `mock/el9.cfg` - Updated openvox-8 repository
- `mock/el10.cfg` - Updated commented openvox-8 repository
- `repoclosure/yum.conf` - Updated el8 and el9 openvox-8 repositories

## Related
Follows the migration pattern from https://github.com/theforeman/theforeman.org/pull/2291

🤖 Generated with [Claude Code](https://claude.com/claude-code)