### PR TITLE
Update katello-repos pulpcore_version to 3.105

### DIFF
--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -1,4 +1,4 @@
-%global pulpcore_version nightly
+%global pulpcore_version 3.105
 %global candlepin_version 4.7
 
 %define repo_dir %{_sysconfdir}/yum.repos.d


### PR DESCRIPTION
Update pulpcore_version from nightly to 3.105 for Katello 4.21 branching