### PR TITLE
Bump katello repos to 4.22 versions

### DIFF
--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -6,10 +6,10 @@
 
 %global prereleasesource nightly
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 2
+%global release 1
 
 Name:           katello-repos
-Version:        4.21
+Version:        4.22
 Release:        %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:        Definition of yum repositories for Katello
 
@@ -73,6 +73,9 @@ rm -rf %{buildroot}
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-candlepin
 
 %changelog
+* Mon May 18 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 4.22-0.1.nightly
+- Bump version to 4.22.0
+
 * Thu Feb 12 2026 Eric D. Helms <ericdhelms@gmail.com> - 4.21-0.2.nightly
 - Update Candlepin to 4.7
 

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,10 +5,10 @@
 %global confdir common
 %global prereleasesource master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 2
+%global release 1
 
 Name:       katello
-Version:    4.21.0
+Version:    4.22.0
 Release:    %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:    A package for managing application life-cycle for Linux systems
 BuildArch:  noarch
@@ -123,6 +123,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Mon May 18 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 4.22.0-0.1.master
+- Bump version to 4.22.0
+
 * Thu Mar 05 2026 Archana Kumari <akumari@redhat.com> - 4.21.0-0.2.master
 - Remove katello.cron, tasks now run via Foreman::Cron framework
 

--- a/packages/katello/rubygem-hammer_cli_katello/rubygem-hammer_cli_katello.spec
+++ b/packages/katello/rubygem-hammer_cli_katello/rubygem-hammer_cli_katello.spec
@@ -9,7 +9,7 @@
 %global hammer_confdir %{_sysconfdir}/hammer
 
 Name: rubygem-%{gem_name}
-Version: 1.21.0
+Version: 1.22.0
 Release: %{?prerelease:0.}%{release}%{?prerelease}%{?nightly}%{?dist}
 Summary: Katello commands for Hammer
 License: GPLv3
@@ -73,6 +73,9 @@ install -m 0644 .%{gem_instdir}/config/%{plugin_name}.yml \
 %{gem_instdir}/test
 
 %changelog
+* Mon May 18 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 1.22.0-0.1.pre.main
+- Bump version to 1.22.0
+
 * Tue Feb 10 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.21.0-0.1.pre.main
 - Bump version to 1.21.0
 

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -1,12 +1,12 @@
 # template: foreman_plugin
 %global gem_name katello
 %global plugin_name katello
-%global foreman_min_version 3.19
-%global foreman_max_version 3.20
+%global foreman_min_version 3.20
+%global foreman_max_version 3.21
 %global prereleasesource pre.master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global mainver 4.21.0
-%global release 5
+%global mainver 4.22.0
+%global release 1
 
 Name: rubygem-%{gem_name}
 Version: %{mainver}
@@ -165,6 +165,9 @@ done
 %{foreman_plugin_log}
 
 %changelog
+* Mon May 18 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 4.22.0-0.1.pre.master
+- Bump version to 4.22.0
+
 * Tue Apr 21 2026 Samir Jha <samirjha1525@gmail.com> - 4.21.0-0.5.pre.master
 - Bump Pulp binding requirements to 3.105 versions
 


### PR DESCRIPTION
## Summary
- Bump rubygem-katello to 4.22.0, update foreman version bounds (3.20–3.21)
- Bump katello meta-package to 4.22.0
- Bump katello-repos to 4.22
- Bump rubygem-hammer_cli_katello to 1.22.0

## Test plan
- [ ] Verify scratch builds pass for all 4 packages
- [ ] Verify repoclosure passes
- [ ] Confirm automated dependency bump PRs pass CI after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)