### PR TITLE
Fix repoclosure repo names after Puppet to OpenVox switch

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -908,7 +908,7 @@ repoclosures:
         el9:
           - el9-baseos
           - el9-appstream
-          - "el9-puppet-{{ puppet_version }}"
+          - "el9-openvox-{{ puppet_version }}"
           - "el9-candlepin-{{ candlepin_version }}-staging"
           - "el9-foreman-plugins-{{ foreman_version }}-staging"
     plugins-staging-repoclosure-el9:
@@ -921,7 +921,7 @@ repoclosures:
           - el9-baseos
           - el9-appstream
           - el9-configmanagement-salt
-          - "el9-puppet-{{ puppet_version }}"
+          - "el9-openvox-{{ puppet_version }}"
           - "el9-foreman-{{ foreman_version }}-staging"
     katello-staging-repoclosure-el9:
       repoclosure_target_repos:
@@ -932,7 +932,7 @@ repoclosures:
         el9:
           - el9-baseos
           - el9-appstream
-          - "el9-puppet-{{ puppet_version }}"
+          - "el9-openvox-{{ puppet_version }}"
           - "el9-foreman-{{ foreman_version }}-staging"
           - "el9-foreman-plugins-{{ foreman_version }}-staging"
           - "el9-candlepin-{{ candlepin_version }}-staging"
@@ -954,7 +954,7 @@ repoclosures:
         el9:
           - el9-baseos
           - el9-appstream
-          - "el9-puppet-{{ puppet_version }}"
+          - "el9-openvox-{{ puppet_version }}"
     foreman-client-staging-repoclosure-el8:
       repoclosure_target_repos:
         el8:
@@ -967,7 +967,7 @@ repoclosures:
           - el8-powertools
           - el8-epel
           - el8-extras
-          - "el8-puppet-{{ puppet_version }}"
+          - "el8-openvox-{{ puppet_version }}"
 
 foreman_release_packages:
   vars:


### PR DESCRIPTION
## Summary
- Commit 74b8b4e5f renamed repo sections in `repoclosure/yum.conf` from `el{8,9}-puppet-8` to `el{8,9}-openvox-8`, but the corresponding lookaside repo references in `package_manifest.yaml` were not updated
- This causes all RPM PR CI checks to fail with `Error: Unknown repo: 'el9-puppet-8'` during the repoclosure stage
- Updates all 5 repoclosure lookaside repo references to use `openvox` instead of `puppet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)