### PR TITLE
Bump version to 5.0-develop

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -2,7 +2,7 @@
 all:
   vars:
     bootstrap: false
-    foremandist: .fm3_20
+    foremandist: .fm5_0
     foreman_version: 'nightly'
     katello_version: 'nightly'
     candlepin_version: '4.4'

--- a/packages/foreman/foreman-installer/foreman-installer.spec
+++ b/packages/foreman/foreman-installer/foreman-installer.spec
@@ -4,7 +4,7 @@
 
 Name:       foreman-installer
 Epoch:      1
-Version:    3.20.0
+Version:    5.0.0
 Release:    %{?prerelease:0.}%{release}%{?prerelease:.}%{?prerelease}%{?nightly}%{?dist}
 Summary:    Puppet-based installer for The Foreman
 Group:      Applications/System
@@ -126,6 +126,9 @@ foreman-installer --scenario katello --migrations-only > /dev/null
 %{_sbindir}/foreman-proxy-certs-generate
 
 %changelog
+* Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1:5.0.0-0.1.develop
+- Bump version to 5.0-develop
+
 * Tue May 12 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 1:3.20.0-0.1.develop
 - Bump version to 3.20-develop
 

--- a/packages/foreman/foreman-proxy/foreman-proxy.spec
+++ b/packages/foreman/foreman-proxy/foreman-proxy.spec
@@ -6,7 +6,7 @@
 %global prerelease %{?prereleasesource}
 
 Name:           foreman-proxy
-Version:        3.20.0
+Version:        5.0.0
 Release:        %{?prerelease:0.}%{release}%{?prerelease:.}%{?prerelease}%{?nightly}%{?dist}
 Summary:        Restful Proxy for DNS, DHCP, TFTP, PuppetCA and Puppet
 
@@ -239,6 +239,9 @@ exit 0
 
 
 %changelog
+* Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.develop
+- Bump version to 5.0-develop
+
 * Tue May 12 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 3.20.0-0.1.develop
 - Bump version to 3.20-develop
 

--- a/packages/foreman/foreman-release/foreman-release.spec
+++ b/packages/foreman/foreman-release/foreman-release.spec
@@ -21,7 +21,7 @@
 %global prerelease %{?prereleasesource}
 
 Name:     foreman-release
-Version:  3.20.0
+Version:  5.0.0
 Release:  %{?prerelease:0.}%{release}%{?prerelease:.}%{?prerelease}%{?dist}
 
 Summary:  Foreman repositories meta-package
@@ -84,6 +84,9 @@ install -Dpm0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-f
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-foreman
 
 %changelog
+* Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.develop
+- Bump version to 5.0-develop
+
 * Tue May 12 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 3.20.0-0.1.develop
 - Bump version to 3.20-develop
 

--- a/packages/foreman/foreman-selinux/foreman-selinux.spec
+++ b/packages/foreman/foreman-selinux/foreman-selinux.spec
@@ -26,7 +26,7 @@
 %global prerelease %{?prereleasesource}
 
 Name:           foreman-selinux
-Version:        3.20.0
+Version:        5.0.0
 Release:        %{?prerelease:0.}%{release}%{?prerelease:.}%{?prerelease}%{?nightly}%{?dist}
 Summary:        SELinux policy module for Foreman
 
@@ -173,6 +173,9 @@ fi
 %{_mandir}/man8/foreman-proxy-selinux-relabel.8.gz
 
 %changelog
+* Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.develop
+- Bump version to 5.0-develop
+
 * Tue May 12 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 3.20.0-0.1.develop
 - Bump version to 3.20-develop
 

--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -11,7 +11,7 @@
 %global prerelease %{?prereleasesource}
 
 Name:    foreman
-Version: 3.20.0
+Version: 5.0.0
 Release: %{?prerelease:0.}%{release}%{?prerelease:.}%{?prerelease}%{?nightly}%{?dist}
 Summary: Systems Management web application
 
@@ -860,6 +860,9 @@ exit 0
 %endif
 
 %changelog
+* Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.develop
+- Bump version to 5.0-develop
+
 * Tue May 12 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 3.20.0-0.1.develop
 - Bump version to 3.20-develop
 

--- a/packages/foreman/rubygem-hammer_cli/rubygem-hammer_cli.spec
+++ b/packages/foreman/rubygem-hammer_cli/rubygem-hammer_cli.spec
@@ -8,7 +8,7 @@
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
 
 Name: rubygem-%{gem_name}
-Version: 3.20.0
+Version: 5.0.0
 Release: %{?prerelease:0.}%{release}%{?prerelease}%{?nightly}%{?dist}
 Summary: Universal command-line interface
 License: GPLv3
@@ -97,6 +97,9 @@ install -m 0644 .%{gem_instdir}/config/cli_config.template.yml \
 %{gem_instdir}/test
 
 %changelog
+* Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.pre.develop
+- Bump version to 5.0-develop
+
 * Tue May 12 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 3.20.0-0.1.pre.develop
 - Bump version to 3.20-develop
 

--- a/packages/foreman/rubygem-hammer_cli_foreman/rubygem-hammer_cli_foreman.spec
+++ b/packages/foreman/rubygem-hammer_cli_foreman/rubygem-hammer_cli_foreman.spec
@@ -9,7 +9,7 @@
 %global hammer_confdir %{_sysconfdir}/hammer
 
 Name: rubygem-%{gem_name}
-Version: 3.20.0
+Version: 5.0.0
 Release: %{?prerelease:0.}%{release}%{?prerelease}%{?nightly}%{?dist}
 Summary: Foreman commands for Hammer
 License: GPLv3+
@@ -74,6 +74,9 @@ install -m 0644 .%{gem_instdir}/config/%{plugin_name}.yml \
 %{gem_instdir}/test
 
 %changelog
+* Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.pre.develop
+- Bump version to 5.0-develop
+
 * Tue May 12 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 3.20.0-0.1.pre.develop
 - Bump version to 3.20-develop
 

--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -9,7 +9,7 @@
 %global release 1
 
 Name:           katello-repos
-Version:        4.22
+Version:        5.0
 Release:        %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:        Definition of yum repositories for Katello
 
@@ -73,6 +73,9 @@ rm -rf %{buildroot}
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-candlepin
 
 %changelog
+* Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0-0.1.nightly
+- Bump version to 5.0.0
+
 * Mon May 18 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 4.22-0.1.nightly
 - Bump version to 4.22.0
 

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -8,7 +8,7 @@
 %global release 1
 
 Name:       katello
-Version:    4.22.0
+Version:    5.0.0
 Release:    %{?prerelease:0.}%{release}%{?prerelease}%{?dist}
 Summary:    A package for managing application life-cycle for Linux systems
 BuildArch:  noarch
@@ -123,6 +123,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.master
+- Bump version to 5.0.0
+
 * Mon May 18 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 4.22.0-0.1.master
 - Bump version to 4.22.0
 

--- a/packages/katello/rubygem-hammer_cli_katello/rubygem-hammer_cli_katello.spec
+++ b/packages/katello/rubygem-hammer_cli_katello/rubygem-hammer_cli_katello.spec
@@ -9,7 +9,7 @@
 %global hammer_confdir %{_sysconfdir}/hammer
 
 Name: rubygem-%{gem_name}
-Version: 1.22.0
+Version: 5.0.0
 Release: %{?prerelease:0.}%{release}%{?prerelease}%{?nightly}%{?dist}
 Summary: Katello commands for Hammer
 License: GPLv3
@@ -73,6 +73,9 @@ install -m 0644 .%{gem_instdir}/config/%{plugin_name}.yml \
 %{gem_instdir}/test
 
 %changelog
+* Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.pre.main
+- Bump version to 5.0.0
+
 * Mon May 18 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 1.22.0-0.1.pre.main
 - Bump version to 1.22.0
 

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -1,11 +1,11 @@
 # template: foreman_plugin
 %global gem_name katello
 %global plugin_name katello
-%global foreman_min_version 3.20
-%global foreman_max_version 3.21
+%global foreman_min_version 5.0
+%global foreman_max_version 5.1
 %global prereleasesource pre.master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global mainver 4.22.0
+%global mainver 5.0.0
 %global release 1
 
 Name: rubygem-%{gem_name}
@@ -165,6 +165,9 @@ done
 %{foreman_plugin_log}
 
 %changelog
+* Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.pre.master
+- Bump version to 5.0.0
+
 * Mon May 18 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 4.22.0-0.1.pre.master
 - Bump version to 4.22.0
 


### PR DESCRIPTION
## Summary
- Bump Foreman version from 3.20.0 to 5.0.0
- Bump Katello version from 4.22.0 to 5.0.0
- Bump hammer_cli and hammer_cli_foreman to 5.0.0
- Bump hammer_cli_katello from 1.22.0 to 5.0.0
- Bump katello-repos from 4.22 to 5.0
- Update rubygem-katello foreman version constraints to 5.0–5.1
- Update foremandist macro from .fm3_20 to .fm5_0

## Test plan
- [ ] Verify nightly builds succeed with new version numbers
- [ ] Confirm repoclosure passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)