### PR TITLE
Bump version to 5.0-develop

### DIFF
--- a/debian/bookworm/foreman-installer/changelog
+++ b/debian/bookworm/foreman-installer/changelog
@@ -1,3 +1,9 @@
+foreman-installer (5.0.0-1) stable; urgency=low
+
+  * Bump changelog to 5.0.0 to match VERSION
+
+ -- Zach Huntington-Meath <zhunting@redhat.com>  Wed, 20 May 2026 12:00:00 -0400
+
 foreman-installer (3.20.0-1) stable; urgency=low
 
   * Bump changelog to 3.20.0 to match VERSION

--- a/debian/bookworm/foreman-proxy/changelog
+++ b/debian/bookworm/foreman-proxy/changelog
@@ -1,3 +1,9 @@
+foreman-proxy (5.0.0-1) stable; urgency=low
+
+  * Bump changelog to 5.0.0 to match VERSION
+
+ -- Zach Huntington-Meath <zhunting@redhat.com>  Wed, 20 May 2026 12:00:00 -0400
+
 foreman-proxy (3.20.0-1) stable; urgency=low
 
   * Bump changelog to 3.20.0 to match VERSION

--- a/debian/bookworm/foreman-release/changelog
+++ b/debian/bookworm/foreman-release/changelog
@@ -1,3 +1,9 @@
+foreman-release (5.0.0-1) stable; urgency=low
+
+  * Bump changelog to 5.0.0 to match VERSION
+
+ -- Zach Huntington-Meath <zhunting@redhat.com>  Wed, 20 May 2026 12:00:00 -0400
+
 foreman-release (3.20.0-1) stable; urgency=low
 
   * Bump changelog to 3.20.0 to match VERSION

--- a/debian/bookworm/foreman/changelog
+++ b/debian/bookworm/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (5.0.0-1) stable; urgency=low
+
+  * Bump changelog to 5.0.0 to match VERSION
+
+ -- Zach Huntington-Meath <zhunting@redhat.com>  Wed, 20 May 2026 12:00:00 -0400
+
 foreman (3.20.0-1) stable; urgency=low
 
   * Bump changelog to 3.20.0 to match VERSION

--- a/debian/jammy/foreman-installer/changelog
+++ b/debian/jammy/foreman-installer/changelog
@@ -1,3 +1,9 @@
+foreman-installer (5.0.0-1) stable; urgency=low
+
+  * Bump changelog to 5.0.0 to match VERSION
+
+ -- Zach Huntington-Meath <zhunting@redhat.com>  Wed, 20 May 2026 12:00:00 -0400
+
 foreman-installer (3.20.0-1) stable; urgency=low
 
   * Bump changelog to 3.20.0 to match VERSION

--- a/debian/jammy/foreman-proxy/changelog
+++ b/debian/jammy/foreman-proxy/changelog
@@ -1,3 +1,9 @@
+foreman-proxy (5.0.0-1) stable; urgency=low
+
+  * Bump changelog to 5.0.0 to match VERSION
+
+ -- Zach Huntington-Meath <zhunting@redhat.com>  Wed, 20 May 2026 12:00:00 -0400
+
 foreman-proxy (3.20.0-1) stable; urgency=low
 
   * Bump changelog to 3.20.0 to match VERSION

--- a/debian/jammy/foreman-release/changelog
+++ b/debian/jammy/foreman-release/changelog
@@ -1,3 +1,9 @@
+foreman-release (5.0.0-1) stable; urgency=low
+
+  * Bump changelog to 5.0.0 to match VERSION
+
+ -- Zach Huntington-Meath <zhunting@redhat.com>  Wed, 20 May 2026 12:00:00 -0400
+
 foreman-release (3.20.0-1) stable; urgency=low
 
   * Bump changelog to 3.20.0 to match VERSION

--- a/debian/jammy/foreman/changelog
+++ b/debian/jammy/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (5.0.0-1) stable; urgency=low
+
+  * Bump changelog to 5.0.0 to match VERSION
+
+ -- Zach Huntington-Meath <zhunting@redhat.com>  Wed, 20 May 2026 12:00:00 -0400
+
 foreman (3.20.0-1) stable; urgency=low
 
   * Bump changelog to 3.20.0 to match VERSION


### PR DESCRIPTION
## Summary
- Bump Debian changelog versions from 3.20.0 to 5.0.0 for bookworm and jammy
- Covers foreman, foreman-installer, foreman-proxy, and foreman-release

## Test plan
- [ ] Verify nightly DEB builds succeed with new version numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)