### PR TITLE
Relax hammer_cli_foreman deb dependency to allow 5.x

### DIFF
--- a/dependencies/bookworm/hammer_cli_foreman_puppet/control
+++ b/dependencies/bookworm/hammer_cli_foreman_puppet/control
@@ -14,7 +14,7 @@ Package: ruby-hammer-cli-foreman-puppet
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ruby | ruby-interpreter,
-         ruby-hammer-cli-foreman (<< 4.0.0),
+         ruby-hammer-cli-foreman (<< 6.0.0),
          ruby-hammer-cli-foreman (>> 2.6.0)
          ${misc:Depends},
          ${shlibs:Depends}

--- a/dependencies/bookworm/hammer_cli_foreman_remote_execution/control
+++ b/dependencies/bookworm/hammer_cli_foreman_remote_execution/control
@@ -11,6 +11,6 @@ Package: ruby-hammer-cli-foreman-remote-execution
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli-foreman (>= 0.1.3), ruby-hammer-cli-foreman (<< 4.0.0), ruby-hammer-cli-foreman-tasks (>= 0.0.3), ruby-hammer-cli-foreman-tasks (<< 0.1.0)
+         ruby-hammer-cli-foreman (>= 0.1.3), ruby-hammer-cli-foreman (<< 6.0.0), ruby-hammer-cli-foreman-tasks (>= 0.0.3), ruby-hammer-cli-foreman-tasks (<< 0.1.0)
 Description: foreman_remote_execution commands for Hammer CLI
  This Hammer CLI plugin contains the commands for foreman_remote_execution

--- a/dependencies/bookworm/hammer_cli_foreman_tasks/control
+++ b/dependencies/bookworm/hammer_cli_foreman_tasks/control
@@ -11,6 +11,6 @@ Package: ruby-hammer-cli-foreman-tasks
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli-foreman (>= 0.1.1), ruby-hammer-cli-foreman (<< 4.0.0)
+         ruby-hammer-cli-foreman (>= 0.1.1), ruby-hammer-cli-foreman (<< 6.0.0)
 Description: foreman_tasks commands for Hammer CLI
  This Hammer CLI plugin contains the commands for foreman_tasks

--- a/dependencies/bookworm/hammer_cli_foreman_templates/control
+++ b/dependencies/bookworm/hammer_cli_foreman_templates/control
@@ -11,6 +11,6 @@ Package: ruby-hammer-cli-foreman-templates
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli-foreman (>= 0.1.1), ruby-hammer-cli-foreman (<< 4.0.0)
+         ruby-hammer-cli-foreman (>= 0.1.1), ruby-hammer-cli-foreman (<< 6.0.0)
 Description: foreman_templates commands for Hammer CLI
  This Hammer CLI plugin contains the commands for foreman_templates

--- a/dependencies/bookworm/hammer_cli_foreman_webhooks/control
+++ b/dependencies/bookworm/hammer_cli_foreman_webhooks/control
@@ -5,7 +5,7 @@ Maintainer: Debian Ruby Extras Maintainers <pkg-ruby-extras-maintainers@lists.al
 Uploaders: <>
 Build-Depends: debhelper (>= 11~),
                gem2deb,
-               ruby-hammer-cli-foreman (<< 4.0.0),
+               ruby-hammer-cli-foreman (<< 6.0.0),
                ruby-hammer-cli-foreman (>= 2.0.0)
 Standards-Version: 4.1.3
 Vcs-Git: https://salsa.debian.org/ruby-team/ruby-hammer-cli-foreman-webhooks.git
@@ -18,7 +18,7 @@ Package: ruby-hammer-cli-foreman-webhooks
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ruby | ruby-interpreter,
-         ruby-hammer-cli-foreman (<< 4.0.0),
+         ruby-hammer-cli-foreman (<< 6.0.0),
          ruby-hammer-cli-foreman (>= 2.0.0),
          ${misc:Depends},
          ${shlibs:Depends}

--- a/dependencies/jammy/hammer_cli_foreman_puppet/control
+++ b/dependencies/jammy/hammer_cli_foreman_puppet/control
@@ -14,7 +14,7 @@ Package: ruby-hammer-cli-foreman-puppet
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ruby | ruby-interpreter,
-         ruby-hammer-cli-foreman (<< 4.0.0),
+         ruby-hammer-cli-foreman (<< 6.0.0),
          ruby-hammer-cli-foreman (>> 2.6.0)
          ${misc:Depends},
          ${shlibs:Depends}

--- a/dependencies/jammy/hammer_cli_foreman_remote_execution/control
+++ b/dependencies/jammy/hammer_cli_foreman_remote_execution/control
@@ -11,6 +11,6 @@ Package: ruby-hammer-cli-foreman-remote-execution
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli-foreman (>= 0.1.3), ruby-hammer-cli-foreman (<< 4.0.0), ruby-hammer-cli-foreman-tasks (>= 0.0.3), ruby-hammer-cli-foreman-tasks (<< 0.1.0)
+         ruby-hammer-cli-foreman (>= 0.1.3), ruby-hammer-cli-foreman (<< 6.0.0), ruby-hammer-cli-foreman-tasks (>= 0.0.3), ruby-hammer-cli-foreman-tasks (<< 0.1.0)
 Description: foreman_remote_execution commands for Hammer CLI
  This Hammer CLI plugin contains the commands for foreman_remote_execution

--- a/dependencies/jammy/hammer_cli_foreman_tasks/control
+++ b/dependencies/jammy/hammer_cli_foreman_tasks/control
@@ -11,6 +11,6 @@ Package: ruby-hammer-cli-foreman-tasks
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli-foreman (>= 0.1.1), ruby-hammer-cli-foreman (<< 4.0.0)
+         ruby-hammer-cli-foreman (>= 0.1.1), ruby-hammer-cli-foreman (<< 6.0.0)
 Description: foreman_tasks commands for Hammer CLI
  This Hammer CLI plugin contains the commands for foreman_tasks

--- a/dependencies/jammy/hammer_cli_foreman_templates/control
+++ b/dependencies/jammy/hammer_cli_foreman_templates/control
@@ -11,6 +11,6 @@ Package: ruby-hammer-cli-foreman-templates
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
-         ruby-hammer-cli-foreman (>= 0.1.1), ruby-hammer-cli-foreman (<< 4.0.0)
+         ruby-hammer-cli-foreman (>= 0.1.1), ruby-hammer-cli-foreman (<< 6.0.0)
 Description: foreman_templates commands for Hammer CLI
  This Hammer CLI plugin contains the commands for foreman_templates

--- a/dependencies/jammy/hammer_cli_foreman_webhooks/control
+++ b/dependencies/jammy/hammer_cli_foreman_webhooks/control
@@ -5,7 +5,7 @@ Maintainer: Debian Ruby Extras Maintainers <pkg-ruby-extras-maintainers@lists.al
 Uploaders: <>
 Build-Depends: debhelper (>= 11~),
                gem2deb,
-               ruby-hammer-cli-foreman (<< 4.0.0),
+               ruby-hammer-cli-foreman (<< 6.0.0),
                ruby-hammer-cli-foreman (>= 2.0.0)
 Standards-Version: 4.1.3
 Vcs-Git: https://salsa.debian.org/ruby-team/ruby-hammer-cli-foreman-webhooks.git
@@ -18,7 +18,7 @@ Package: ruby-hammer-cli-foreman-webhooks
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ruby | ruby-interpreter,
-         ruby-hammer-cli-foreman (<< 4.0.0),
+         ruby-hammer-cli-foreman (<< 6.0.0),
          ruby-hammer-cli-foreman (>= 2.0.0),
          ${misc:Depends},
          ${shlibs:Depends}


### PR DESCRIPTION
## Summary
- Update ruby-hammer-cli-foreman upper bound from `<< 4.0.0` to `<< 6.0.0` in bookworm and jammy control files
- Affected packages: puppet, remote_execution, tasks, templates, webhooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)