### PR TITLE
Update ruby-hammer-cli-foreman-bootdisk to 0.4.3

### DIFF
--- a/dependencies/bookworm/hammer_cli_foreman_bootdisk/changelog
+++ b/dependencies/bookworm/hammer_cli_foreman_bootdisk/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-bootdisk (0.4.3-1) stable; urgency=low
+
+  * 0.4.3 released
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Mon, 25 May 2026 16:23:56 +0200
+
 ruby-hammer-cli-foreman-bootdisk (0.4.2-1) stable; urgency=low
 
   * 0.4.2 released

--- a/dependencies/jammy/hammer_cli_foreman_bootdisk/changelog
+++ b/dependencies/jammy/hammer_cli_foreman_bootdisk/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-bootdisk (0.4.3-1) stable; urgency=low
+
+  * 0.4.3 released
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Mon, 25 May 2026 16:23:56 +0200
+
 ruby-hammer-cli-foreman-bootdisk (0.4.2-1) stable; urgency=low
 
   * 0.4.2 released


### PR DESCRIPTION
Bump ruby-hammer-cli-foreman-bootdisk to 0.4.3.

This release relaxes the hammer_cli_foreman upper bound from `< 4.0.0` to `< 6.0.0`, fixing compatibility with hammer_cli_foreman 5.0.0 on nightly.