### PR TITLE
Update ruby-hammer-cli-foreman-discovery to 1.4.0

### DIFF
--- a/dependencies/bookworm/hammer_cli_foreman_discovery/changelog
+++ b/dependencies/bookworm/hammer_cli_foreman_discovery/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-discovery (1.4.0-1) stable; urgency=low
+
+  * 1.4.0 released
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Mon, 25 May 2026 16:24:35 +0200
+
 ruby-hammer-cli-foreman-discovery (1.3.1-1) stable; urgency=low
 
   * 1.3.1 released

--- a/dependencies/jammy/hammer_cli_foreman_discovery/changelog
+++ b/dependencies/jammy/hammer_cli_foreman_discovery/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-discovery (1.4.0-1) stable; urgency=low
+
+  * 1.4.0 released
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Mon, 25 May 2026 16:24:35 +0200
+
 ruby-hammer-cli-foreman-discovery (1.3.1-1) stable; urgency=low
 
   * 1.3.1 released


### PR DESCRIPTION
Bump ruby-hammer-cli-foreman-discovery to 1.4.0.

This release relaxes the hammer_cli_foreman upper bound from `< 4.0.0` to `< 6.0.0`, fixing compatibility with hammer_cli_foreman 5.0.0 on nightly.