### PR TITLE
Update ruby-hammer-cli-foreman-google to 1.1.3

### DIFF
--- a/dependencies/bookworm/hammer_cli_foreman_google/changelog
+++ b/dependencies/bookworm/hammer_cli_foreman_google/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-google (1.1.3-1) stable; urgency=low
+
+  * 1.1.3 released
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Mon, 25 May 2026 16:25:10 +0200
+
 ruby-hammer-cli-foreman-google (1.1.2-1) stable; urgency=low
 
   * 1.1.2 released

--- a/dependencies/jammy/hammer_cli_foreman_google/changelog
+++ b/dependencies/jammy/hammer_cli_foreman_google/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-google (1.1.3-1) stable; urgency=low
+
+  * 1.1.3 released
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Mon, 25 May 2026 16:25:10 +0200
+
 ruby-hammer-cli-foreman-google (1.1.2-1) stable; urgency=low
 
   * 1.1.2 released


### PR DESCRIPTION
Bump ruby-hammer-cli-foreman-google to 1.1.3.

This release relaxes the hammer_cli_foreman upper bound from `< 4.0.0` to `< 6.0.0`, fixing compatibility with hammer_cli_foreman 5.0.0 on nightly.