### PR TITLE
Update ruby-hammer-cli-foreman-salt to 0.1.1

### DIFF
--- a/dependencies/bookworm/hammer_cli_foreman_salt/changelog
+++ b/dependencies/bookworm/hammer_cli_foreman_salt/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-salt (0.1.1-1) stable; urgency=low
+
+  * 0.1.1 released
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Mon, 25 May 2026 16:25:27 +0200
+
 ruby-hammer-cli-foreman-salt (0.1.0-1) stable; urgency=low
 
   * 0.1.0 released

--- a/dependencies/jammy/hammer_cli_foreman_salt/changelog
+++ b/dependencies/jammy/hammer_cli_foreman_salt/changelog
@@ -1,3 +1,9 @@
+ruby-hammer-cli-foreman-salt (0.1.1-1) stable; urgency=low
+
+  * 0.1.1 released
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Mon, 25 May 2026 16:25:27 +0200
+
 ruby-hammer-cli-foreman-salt (0.1.0-1) stable; urgency=low
 
   * 0.1.0 released


### PR DESCRIPTION
Bump ruby-hammer-cli-foreman-salt to 0.1.1.

This release relaxes the hammer_cli_foreman upper bound from `< 4.0.0` to `< 6.0.0`, fixing compatibility with hammer_cli_foreman 5.0.0 on nightly.