### PR TITLE
Update rubygem-safemode to 2.0.0

### DIFF
--- a/packages/foreman/rubygem-safemode/rubygem-safemode.spec
+++ b/packages/foreman/rubygem-safemode/rubygem-safemode.spec
@@ -2,7 +2,7 @@
 %global gem_name safemode
 
 Name: rubygem-%{gem_name}
-Version: 1.5.0
+Version: 2.0.0
 Release: 1%{?dist}
 Summary: A library for safe evaluation of Ruby code based on ParseTree/RubyParser and Ruby2Ruby
 License: MIT
@@ -10,10 +10,10 @@ URL: https://github.com/svenfuchs/safemode
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 
 # start specfile generated dependencies
-Requires: ruby >= 2.7
-Requires: ruby < 3.2
-BuildRequires: ruby >= 2.7
-BuildRequires: ruby < 3.2
+Requires: ruby >= 3.0
+Requires: ruby < 3.4
+BuildRequires: ruby >= 3.0
+BuildRequires: ruby < 3.4
 BuildRequires: rubygems-devel
 BuildArch: noarch
 # end specfile generated dependencies
@@ -65,6 +65,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Thu May 28 2026 Oleh Fedorenko <ofedoren@redhat.com> - 2.0.0-1
+- Update to 2.0.0
+
 * Tue Mar 19 2024 Foreman Packaging Automation <packaging@theforeman.org> - 1.5.0-1
 - Update to 1.5.0
 

--- a/packages/foreman/rubygem-safemode/rubygem-safemode.spec
+++ b/packages/foreman/rubygem-safemode/rubygem-safemode.spec
@@ -4,7 +4,7 @@
 Name: rubygem-%{gem_name}
 Version: 2.0.0
 Release: 1%{?dist}
-Summary: A library for safe evaluation of Ruby code based on ParseTree/RubyParser and Ruby2Ruby
+Summary: A library for safe evaluation of Ruby code based on Prism and Ruby2Ruby
 License: MIT
 URL: https://github.com/svenfuchs/safemode
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem

--- a/packages/foreman/rubygem-safemode/safemode-1.5.0.gem
+++ b/packages/foreman/rubygem-safemode/safemode-1.5.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/Q0/jz/SHA256E-s19968--a779b6ad6af55f6d47b2f8051bd0d135fc8a272c8b37ecce566dc82aa2f79b94.0.gem/SHA256E-s19968--a779b6ad6af55f6d47b2f8051bd0d135fc8a272c8b37ecce566dc82aa2f79b94.0.gem

--- a/packages/foreman/rubygem-safemode/safemode-2.0.0.gem
+++ b/packages/foreman/rubygem-safemode/safemode-2.0.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/fP/9P/SHA256E-s22016--0b3deaae54cb5a58402c1e5c67974fba8f00eb82562c1821072cdab101cc3f44.0.gem/SHA256E-s22016--0b3deaae54cb5a58402c1e5c67974fba8f00eb82562c1821072cdab101cc3f44.0.gem


### PR DESCRIPTION
Is required by https://github.com/theforeman/foreman/pull/11007

Also makes https://github.com/theforeman/foreman-packaging/pull/13515 obsolete

This includes 4 commits:
 - Update safemode to 2.0
 - Make Foreman use that version: https://github.com/theforeman/foreman-packaging/pull/13553
 - Since safemode 2.0 requires Prism gem, add it: https://github.com/theforeman/foreman-packaging/pull/13552
 - Drop ruby_parser because it is replaced with Prism: https://github.com/theforeman/foreman-packaging/pull/13554