### PR TITLE
Backport: Add support for OpenVox agent

### DIFF
--- a/debian/bookworm/foreman-installer/changelog
+++ b/debian/bookworm/foreman-installer/changelog
@@ -1,3 +1,9 @@
+foreman-installer (3.18.1-2) stable; urgency=low
+
+  * Add support for OpenVox agent
+
+ -- Dirk Goetz <dirk.goetz@netways.de>  Thu, 16 Apr 2026 17:21:00 +0100
+
 foreman-installer (3.18.1-1) stable; urgency=low
 
   * 3.18.1 released

--- a/debian/bookworm/foreman-installer/control
+++ b/debian/bookworm/foreman-installer/control
@@ -15,7 +15,7 @@ Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-kafo (>= 7.6.0), ruby-kafo (<< 8.0.0),
-         puppet-agent (>= 8.0.0) | puppet (>= 8.0.0),
+         openvox-agent (>= 8.23.1) | puppet-agent (>= 8.0.0) | puppet (>= 8.0.0),
          curl,
          lsb-release
 Description: Automated puppet-based installer for The Foreman

--- a/debian/jammy/foreman-installer/changelog
+++ b/debian/jammy/foreman-installer/changelog
@@ -1,3 +1,9 @@
+foreman-installer (3.18.1-2) stable; urgency=low
+
+  * Add support for OpenVox agent
+
+ -- Dirk Goetz <dirk.goetz@netways.de>  Thu, 16 Apr 2026 17:21:00 +0100
+
 foreman-installer (3.18.1-1) stable; urgency=low
 
   * 3.18.1 released

--- a/debian/jammy/foreman-installer/control
+++ b/debian/jammy/foreman-installer/control
@@ -15,7 +15,7 @@ Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter,
          ruby-kafo (>= 7.6.0), ruby-kafo (<< 8.0.0),
-         puppet-agent (>= 8.0.0) | puppet (>= 8.0.0),
+         openvox-agent (>= 8.23.1) | puppet-agent (>= 8.0.0) | puppet (>= 8.0.0),
          curl,
          lsb-release
 Description: Automated puppet-based installer for The Foreman

--- a/plugins/puppet-agent-oauth/debian/changelog
+++ b/plugins/puppet-agent-oauth/debian/changelog
@@ -1,3 +1,9 @@
+puppet-agent-oauth (0.5.5-2) stable; urgency=low
+
+  * Add support for OpenVox agent
+
+ -- Dirk Goetz <dirk.goetz@netways.de>  Thu, 16 Apr 2026 17:21:00 +0100
+
 puppet-agent-oauth (0.5.5-1) stable; urgency=low
 
   * Update puppet-agent-oauth to 0.5.5

--- a/plugins/puppet-agent-oauth/debian/control
+++ b/plugins/puppet-agent-oauth/debian/control
@@ -8,5 +8,5 @@ Homepage: https://github.com/oauth-xx/oauth-ruby
 
 Package: puppet-agent-oauth
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, puppet-agent
+Depends: ${shlibs:Depends}, ${misc:Depends}, openvox-agent | puppet-agent
 Description: OAuth Core Ruby implementation for Puppet Agent

--- a/plugins/puppet-agent-puppet-strings/debian/changelog
+++ b/plugins/puppet-agent-puppet-strings/debian/changelog
@@ -1,3 +1,9 @@
+puppet-agent-puppet-strings (3.0.1-3) stable; urgency=low
+
+  * Add support for OpenVox agent
+
+ -- Dirk Goetz <dirk.goetz@netways.de>  Thu, 16 Apr 2026 17:21:00 +0100
+
 puppet-agent-puppet-strings (3.0.1-2) stable; urgency=low
 
   * Update depends to require rgen ~> 0.9.0

--- a/plugins/puppet-agent-puppet-strings/debian/control
+++ b/plugins/puppet-agent-puppet-strings/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/puppetlabs/puppet-strings
 
 Package: puppet-agent-puppet-strings
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, puppet-agent,
+Depends: ${shlibs:Depends}, ${misc:Depends}, openvox-agent | puppet-agent,
   puppet-agent-yard (>= 0.9.5), puppet-agent-yard (<< 1.0.0),
   puppet-agent-rgen (>= 0.9.0), puppet-agent-rgen (<< 1.0.0)
 Description: Puppet documentation via YARD

--- a/plugins/puppet-agent-rgen/debian/changelog
+++ b/plugins/puppet-agent-rgen/debian/changelog
@@ -1,3 +1,9 @@
+puppet-agent-rgen (0.9.0-2) stable; urgency=low
+
+  * Add support for OpenVox agent
+
+ -- Dirk Goetz <dirk.goetz@netways.de>  Thu, 16 Apr 2026 17:21:00 +0100
+
 puppet-agent-rgen (0.9.0-1) stable; urgency=low
 
   * 0.9.0 released

--- a/plugins/puppet-agent-rgen/debian/control
+++ b/plugins/puppet-agent-rgen/debian/control
@@ -8,5 +8,5 @@ Homepage: http://rgenoc.org/
 
 Package: puppet-agent-rgen
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, puppet-agent
+Depends: ${shlibs:Depends}, ${misc:Depends}, openvox-agent | puppet-agent
 Description: RGen is a framework for Model Driven Software Development (MDSD) in Ruby.

--- a/plugins/puppet-agent-yard/debian/changelog
+++ b/plugins/puppet-agent-yard/debian/changelog
@@ -1,3 +1,9 @@
+puppet-agent-yard (0.9.37-2) stable; urgency=low
+
+  * Add support for OpenVox agent
+
+ -- Dirk Goetz <dirk.goetz@netways.de>  Thu, 16 Apr 2026 17:21:00 +0100
+
 puppet-agent-yard (0.9.37-1) stable; urgency=low
 
   * 0.9.37 released

--- a/plugins/puppet-agent-yard/debian/control
+++ b/plugins/puppet-agent-yard/debian/control
@@ -8,5 +8,5 @@ Homepage: http://yardoc.org/
 
 Package: puppet-agent-yard
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, puppet-agent
+Depends: ${shlibs:Depends}, ${misc:Depends}, openvox-agent | puppet-agent
 Description: YARD is a Ruby Documentation tool. The Y stands for "Yay!"


### PR DESCRIPTION
Backport of #11839 to deb/3.18

Adds `openvox-agent` as an alternative dependency to `puppet-agent` in foreman-installer and puppet-agent-* plugin packages. Changelog entries adapted to 3.18.1-2 version. Kept `ruby-kafo >= 7.6.0` from 3.18 branch (not bumped to 7.7.0).