### PR TITLE
Update ruby-amazing-print to 2.0.0 (bookworm/noble/resolute/trixie)

### DIFF
--- a/dependencies/bookworm/amazing_print/changelog
+++ b/dependencies/bookworm/amazing_print/changelog
@@ -1,3 +1,9 @@
+ruby-amazing-print (2.0.0-1) stable; urgency=low
+
+  * 2.0.0 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Mon, 22 Jun 2026 05:57:12 +0000
+
 ruby-amazing-print (1.7.2-1) stable; urgency=low
 
   * 1.7.2 released

--- a/dependencies/noble/amazing_print/changelog
+++ b/dependencies/noble/amazing_print/changelog
@@ -1,3 +1,9 @@
+ruby-amazing-print (2.0.0-1) stable; urgency=low
+
+  * 2.0.0 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Mon, 22 Jun 2026 05:57:12 +0000
+
 ruby-amazing-print (1.7.2-1) stable; urgency=low
 
   * 1.7.2 released

--- a/dependencies/resolute/amazing_print/changelog
+++ b/dependencies/resolute/amazing_print/changelog
@@ -1,3 +1,9 @@
+ruby-amazing-print (2.0.0-1) stable; urgency=low
+
+  * 2.0.0 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Mon, 22 Jun 2026 05:57:12 +0000
+
 ruby-amazing-print (1.7.2-1) stable; urgency=low
 
   * 1.7.2 released

--- a/dependencies/trixie/amazing_print/changelog
+++ b/dependencies/trixie/amazing_print/changelog
@@ -1,3 +1,9 @@
+ruby-amazing-print (2.0.0-1) stable; urgency=low
+
+  * 2.0.0 released
+
+ -- Foreman Packaging Automation <packaging@theforeman.org>  Mon, 22 Jun 2026 05:57:12 +0000
+
 ruby-amazing-print (1.7.2-1) stable; urgency=low
 
   * 1.7.2 released


### PR DESCRIPTION
Alternative to #12007.

amazing_print 2.0.0 requires Ruby >= 3.1.0. Jammy ships Ruby 3.0.2, so jammy stays at 1.7.2. Bookworm, noble, resolute, and trixie all have Ruby >= 3.1 and are bumped to 2.0.0.