### PR TITLE
Obsolete rubygem-stomp in foreman-obsolete-packages

### DIFF
--- a/packages/foreman/foreman-obsolete-packages/foreman-obsolete-packages.spec
+++ b/packages/foreman/foreman-obsolete-packages/foreman-obsolete-packages.spec
@@ -1,6 +1,6 @@
 Name: foreman-obsolete-packages
 Version: 1.11
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: MIT
 Summary: A package to obsolete retired packages
 URL: https://github.com/theforeman/foreman-packaging
@@ -21,6 +21,8 @@ Obsoletes: rubygem-unf_ext < 0.0.8.2-2
 Obsoletes: rubygem-anemone < 0.7.2-2
 Obsoletes: rubygem-fog-ovirt < 2.0.3-1
 Obsoletes: rubygem-ovirt-engine-sdk < 4.6.0-1
+Obsoletes: rubygem-stomp < 1.4.10-2
+Obsoletes: rubygem-stomp-doc < 1.4.10-2
 
 %description
 This package exists only to obsolete other packages which need to be removed
@@ -35,6 +37,9 @@ from the distribution for some reason.
 %files
 
 %changelog
+* Mon Jun 22 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 1.11-2
+- Obsolete rubygem-stomp
+
 * Tue Apr 01 2025 Leos Stejskal - 1.11-1
 - Obsolete oVirt
 


### PR DESCRIPTION
## Summary
- Add `Obsoletes` for `rubygem-stomp` and `rubygem-stomp-doc` (bump release to 1.11-2)
- `rubygem-stomp` was removed from packaging but never obsoleted
- Users who had it installed via Katello comps (3.17/3.18) keep the stale RPM after upgrading to 3.19
- Verified on a real system: 3.17 → 3.18 → 3.19 → nightly, `rubygem-stomp` persists as orphan
- Uses release bump (1.11-2) instead of version bump to avoid collision with 1.12 on rpm/develop which has different content
- Counterpart of https://github.com/theforeman/foreman-packaging/pull/13643 for rpm/develop