### PR TITLE
Revert "Update ruby-foreman-tasks to 12.2.5"

### DIFF
--- a/plugins/ruby-foreman-tasks/debian/changelog
+++ b/plugins/ruby-foreman-tasks/debian/changelog
@@ -1,9 +1,3 @@
-ruby-foreman-tasks (12.2.5-1) stable; urgency=low
-
-  * 12.2.5 released
-
- -- Foreman Packaging Automation <packaging@theforeman.org>  Tue, 23 Jun 2026 08:21:35 +0000
-
 ruby-foreman-tasks (12.2.4-1) stable; urgency=low
 
   * 12.2.4 released

--- a/plugins/ruby-foreman-tasks/debian/gem.list
+++ b/plugins/ruby-foreman-tasks/debian/gem.list
@@ -1,5 +1,5 @@
 # list of gem urls to download via Jenkins, space separated
-GEMS="https://rubygems.org/downloads/foreman-tasks-12.2.5.gem"
+GEMS="https://rubygems.org/downloads/foreman-tasks-12.2.4.gem"
 GEMS="$GEMS https://rubygems.org/downloads/fugit-1.8.1.gem"
 GEMS="$GEMS https://rubygems.org/downloads/et-orbi-1.2.7.gem"
 GEMS="$GEMS https://rubygems.org/downloads/raabro-1.4.0.gem"

--- a/plugins/ruby-foreman-tasks/foreman-tasks.rb
+++ b/plugins/ruby-foreman-tasks/foreman-tasks.rb
@@ -1,1 +1,1 @@
-gem 'foreman-tasks', '12.2.5'
+gem 'foreman-tasks', '12.2.4'


### PR DESCRIPTION
12.2.5 that got pushed to rubygems contained no changes over 12.2.4
except for the version string change.

This reverts commit 8c1f40fc0889b548d67da9423aa7255d2e81ba0e.
