### PR TITLE
Fix find_gemfile_lock_specs to find packages across all subdirectories

### DIFF
--- a/list_updatable_packages
+++ b/list_updatable_packages
@@ -106,37 +106,35 @@ class Spec:
         return hash(self.path)
 
 
-def find_gemfile_lock_specs(ci_job: str, subdir: str, project: str) -> Generator[Tuple[Spec, str, str], None, None]:
+def find_gemfile_lock_specs(ci_job: str, project: str) -> Generator[Tuple[Spec, str, str], None, None]:
     """
     Find all specs based on what's in the bundler lockfile. This Gemfile.lock is retrieved from
     the last successful build in CI.
     """
     url = f'https://ci.theforeman.org/job/{ci_job}/lastSuccessfulBuild/artifact/Gemfile.lock'
-    base_path = Path('packages') / subdir
 
     for gem in parse_gemfile_lock(fetch_gemfile_lock(url)):
         package_name = f'rubygem-{gem["name"]}'
-        path = base_path / package_name / f'{package_name}.spec'
-        if path.is_file():
-            spec = Spec(path)
+        paths = list(Path('packages').glob(f'*/{package_name}/{package_name}.spec'))
+        if paths:
+            spec = Spec(paths[0])
             if spec.is_updateable:
                 yield spec, gem['version'], project
 
 
-def find_package_lock_specs(ci_job: str, subdir: str, project: str) -> Generator[Tuple[Spec, str, str], None, None]:
+def find_package_lock_specs(ci_job: str, project: str) -> Generator[Tuple[Spec, str, str], None, None]:
     """
     Find all specs based on what's in the NPM package-lock.json. This package-lock.json is retrieved from
     the last successful build in CI.
     """
     url = f'https://ci.theforeman.org/job/{ci_job}/lastSuccessfulBuild/artifact/package-lock.json'
-    base_path = Path('packages') / subdir
 
     for npm_module in parse_package_lock(fetch_package_lock(url)):
         npm_name = npm_module['name'].replace('@', '').replace('/', '-')
         package_name = f'nodejs-{npm_name}'
-        path = base_path / package_name / f'{package_name}.spec'
-        if path.is_file():
-            spec = Spec(path)
+        paths = list(Path('packages').glob(f'*/{package_name}/{package_name}.spec'))
+        if paths:
+            spec = Spec(paths[0])
             if spec.is_updateable:
                 yield spec, npm_module['version'], project
 
@@ -265,13 +263,13 @@ def main() -> None:
 
     specs = chain(
         find_packaged_specs(),
-        find_gemfile_lock_specs('foreman-develop-source-release', 'foreman', 'foreman'),
-        find_gemfile_lock_specs('smart-proxy-develop-source-release', 'foreman', 'smart-proxy'),
-        find_gemfile_lock_specs('katello-master-source-release', 'katello', 'katello'),
-        find_gemfile_lock_specs('hammer-cli-master-source-release', 'foreman', 'hammer-cli'),
-        find_gemfile_lock_specs('hammer-cli-foreman-master-source-release', 'foreman', 'hammer-cli-foreman'),
-        find_package_lock_specs('foreman-develop-source-release', 'foreman', 'foreman'),
-        find_package_lock_specs('katello-master-source-release', 'katello', 'katello'),
+        find_gemfile_lock_specs('foreman-develop-source-release', 'foreman'),
+        find_gemfile_lock_specs('smart-proxy-develop-source-release', 'smart-proxy'),
+        find_gemfile_lock_specs('katello-master-source-release', 'katello'),
+        find_gemfile_lock_specs('hammer-cli-master-source-release', 'hammer-cli'),
+        find_gemfile_lock_specs('hammer-cli-foreman-master-source-release', 'hammer-cli-foreman'),
+        find_package_lock_specs('foreman-develop-source-release', 'foreman'),
+        find_package_lock_specs('katello-master-source-release', 'katello'),
     )
 
     matrix = list(build_matrix(merge_specs(specs), package_filter=args.filter))


### PR DESCRIPTION
Dependencies don't always live in a single subdirectory, so searching only within a hardcoded subdir caused critical updates to be missed.
