### PR TITLE
Drop foreman-tasks upper bound from ruby-foreman-ansible

### DIFF
--- a/plugins/ruby-foreman-ansible/debian/changelog
+++ b/plugins/ruby-foreman-ansible/debian/changelog
@@ -1,3 +1,9 @@
+ruby-foreman-ansible (17.0.9-2) stable; urgency=low
+
+  * Drop foreman-tasks upper bound
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Mon, 29 Jun 2026 14:32:23 +0000
+
 ruby-foreman-ansible (17.0.9-1) stable; urgency=low
 
   * 17.0.9 released

--- a/plugins/ruby-foreman-ansible/debian/control
+++ b/plugins/ruby-foreman-ansible/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper, git | git-core, foreman (>= 3.16.0~rc1),
   foreman-nulldb (>= 3.16.0~rc1),
   ruby-foreman-deface (<<2.0.0),
   ruby-foreman-remote-execution (>= 4.4.0-1),
-  ruby-foreman-tasks (>= 10.0.0), ruby-foreman-tasks (< 13.0.0)
+  ruby-foreman-tasks (>= 10.0.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/theforeman/foreman_ansible
 
@@ -16,6 +16,6 @@ Architecture: all
 Depends: ${misc:Depends}, bundler, foreman (>= 3.16.0~rc1),
   ruby-foreman-deface (<<2.0.0),
   ruby-foreman-remote-execution (>= 4.4.0-1),
-  ruby-foreman-tasks (>= 10.0.0), ruby-foreman-tasks (< 13.0.0)
+  ruby-foreman-tasks (>= 10.0.0)
 Description: Foreman Ansible plugin
  Integration with Ansible in Foreman.


### PR DESCRIPTION
## Summary
- Remove `ruby-foreman-tasks (< 13.0.0)` constraint from both Build-Depends and Depends
- Upstream dropped the upper bound in theforeman/foreman_ansible@143fe3e2 (Redmine #39449)
- Fixes nightly build failure: `foreman-tasks 13.0.0-1` (Debian revision) is treated as `> 13.0.0` by apt, breaking the `< 13.0.0` constraint

## Context
- Nightly failure: [foreman-pipeline-plugins-deb-nightly #745](https://jenkins-foreman.apps.ocp.cloud.ci.centos.org/job/foreman-pipeline-plugins-deb-nightly/745/)
- Error: `ruby-foreman-ansible : Depends: ruby-foreman-tasks (<= 13.0.0) but 13.0.0-1 is to be installed`
- Upstream gemspec now has only `>= 10.0` with no upper bound