### PR TITLE
Add Provides to REX subpackage cockpit

### DIFF
--- a/packages/plugins/rubygem-foreman_remote_execution/rubygem-foreman_remote_execution.spec
+++ b/packages/plugins/rubygem-foreman_remote_execution/rubygem-foreman_remote_execution.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 16.7.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: A plugin bringing remote execution to the Foreman, completing the config management functionality with remote management functionality
 License: GPLv3
 URL: https://github.com/theforeman/foreman_remote_execution
@@ -47,6 +47,7 @@ Requires: %{name} = %{version}-%{release}
 Requires(post): systemd-units
 Requires(preun): systemd-units
 Summary: Cockpit integration using remote execution connection
+Provides: rubygem(%{gem_name}-cockpit) = %{version}
 
 %description cockpit
 This package contains files related to Cockpit, mainly foreman-cockpit service
@@ -131,6 +132,9 @@ install -Dp -m0644 %{buildroot}%{gem_instdir}/extra/cockpit/settings.yml.example
 %{foreman_plugin_log}
 
 %changelog
+* Wed Jul 22 2026 Maximilian Kolb <kolb@atix.de> - 16.7.0-2
+- Add provides to subpackage cockpit
+
 * Mon Jul 13 2026 Adam Lazík <alazik@redhat.com> - 16.7.0-1
 - Update to 16.7.0
 


### PR DESCRIPTION
This patch allows users to install the "cockpit" subpackage similar to other plugins.

Prior to this patch:
````
# dnf install "rubygem(foreman_remote_execution-cockpit)"
No match for argument: rubygem(foreman_remote_execution-cockpit)
Error: Unable to find a match: rubygem(foreman_remote_execution-cockpit)
````

With this patch:

````
# dnf install "rubygem(foreman_remote_execution-cockpit)" Installing:
 rubygem-foreman_remote_execution-cockpit                 noarch                 16.5.3-6.0.2.custom.el9                   pulp                                          15 k
Upgrading:
 rubygem-foreman_remote_execution                         noarch                 16.5.3-6.0.2.custom.el9                   pulp                                         1.4 M
````

Refs [Containerfile for foreman in foreman-oci-images](https://github.com/theforeman/foreman-oci-images/blob/master/images/foreman/Containerfile#L20)