### PR TITLE
EL10 rebuild: ruby-tier1 (libsass..apipie-dsl, 10 packages)

### DIFF
--- a/packages/foreman/libsass/libsass.spec
+++ b/packages/foreman/libsass/libsass.spec
@@ -1,6 +1,6 @@
 Name:           libsass
 Version:        3.6.4
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        C/C++ port of the Sass CSS precompiler
 
 License:        MIT
@@ -66,6 +66,9 @@ find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
 
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.6.4-6
+- Rebuild for EL10
+
 * Thu Jan 20 2022 Fedora Release Engineering <releng@fedoraproject.org> - 3.6.4-5
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_36_Mass_Rebuild
 

--- a/packages/foreman/rubygem-activerecord-nulldb-adapter/rubygem-activerecord-nulldb-adapter.spec
+++ b/packages/foreman/rubygem-activerecord-nulldb-adapter/rubygem-activerecord-nulldb-adapter.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.2.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: The Null Object pattern as applied to ActiveRecord database adapters
 License: MIT
 URL: https://github.com/nulldb/nulldb
@@ -67,6 +67,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.2.2-2
+- Rebuild for EL10
+
 * Wed Dec 10 2025 Foreman Packaging Automation <packaging@theforeman.org> - 1.2.2-1
 - Update to 1.2.2
 

--- a/packages/foreman/rubygem-activerecord-session_store/rubygem-activerecord-session_store.spec
+++ b/packages/foreman/rubygem-activerecord-session_store/rubygem-activerecord-session_store.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.2.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: An Action Dispatch session store backed by an Active Record class
 License: MIT
 URL: https://github.com/rails/activerecord-session_store
@@ -61,6 +61,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.2.0-2
+- Rebuild for EL10
+
 * Thu Mar 27 2025 Foreman Packaging Automation <packaging@theforeman.org> - 2.2.0-1
 - Update to 2.2.0
 

--- a/packages/foreman/rubygem-addressable/rubygem-addressable.spec
+++ b/packages/foreman/rubygem-addressable/rubygem-addressable.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.9.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: URI Implementation
 License: Apache-2.0
 URL: https://github.com/sporkmonger/addressable
@@ -58,6 +58,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.9.0-2
+- Rebuild for EL10
+
 * Sun Jun 21 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.9.0-1
 - Update to 2.9.0
 

--- a/packages/foreman/rubygem-algebrick/rubygem-algebrick.spec
+++ b/packages/foreman/rubygem-algebrick/rubygem-algebrick.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.7.5
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Algebraic types and pattern matching for Ruby
 License: Apache-2.0
 URL: https://github.com/pitr-ch/algebrick
@@ -59,6 +59,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/doc
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.7.5-2
+- Rebuild for EL10
+
 * Wed Jul 13 2022 Foreman Packaging Automation <packaging@theforeman.org> 0.7.5-1
 - Update to 0.7.5
 

--- a/packages/foreman/rubygem-amazing_print/rubygem-amazing_print.spec
+++ b/packages/foreman/rubygem-amazing_print/rubygem-amazing_print.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.7.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Pretty print Ruby objects with proper indentation and colors
 License: MIT
 URL: https://github.com/amazing-print/amazing_print
@@ -61,6 +61,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.7.2-2
+- Rebuild for EL10
+
 * Sun Jul 12 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.7.2-1
 - Update to 1.7.2
 

--- a/packages/foreman/rubygem-ancestry/rubygem-ancestry.spec
+++ b/packages/foreman/rubygem-ancestry/rubygem-ancestry.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 4.3.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Organize ActiveRecord model into a tree structure
 License: MIT
 URL: https://github.com/stefankroes/ancestry
@@ -63,6 +63,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 4.3.3-2
+- Rebuild for EL10
+
 * Sun Apr 16 2023 Foreman Packaging Automation <packaging@theforeman.org> 4.3.3-1
 - Update to 4.3.3
 

--- a/packages/foreman/rubygem-anonymous_loader/rubygem-anonymous_loader.spec
+++ b/packages/foreman/rubygem-anonymous_loader/rubygem-anonymous_loader.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.1.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Load Ruby source files inside anonymous namespaces
 License: MIT
 URL: https://github.com/ruby-oauth/anonymous_loader
@@ -68,6 +68,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/SECURITY.md
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.1.3-2
+- Rebuild for EL10
+
 * Sun Jul 19 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.1.3-1
 - Update to 0.1.3
 

--- a/packages/foreman/rubygem-apipie-bindings/rubygem-apipie-bindings.spec
+++ b/packages/foreman/rubygem-apipie-bindings/rubygem-apipie-bindings.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.7.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: The Ruby bindings for Apipie documented APIs
 License: MIT
 URL: https://github.com/Apipie/apipie-bindings
@@ -59,6 +59,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.7.1-2
+- Rebuild for EL10
+
 * Sun May 18 2025 Foreman Packaging Automation <packaging@theforeman.org> - 0.7.1-1
 - Update to 0.7.1
 

--- a/packages/foreman/rubygem-apipie-dsl/rubygem-apipie-dsl.spec
+++ b/packages/foreman/rubygem-apipie-dsl/rubygem-apipie-dsl.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.6.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Ruby DSL documentation tool
 License: MIT
 URL: https://github.com/Apipie/apipie-dsl
@@ -59,6 +59,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.6.3-2
+- Rebuild for EL10
+
 * Fri Jun 26 2026 Oleh Fedorenko <ofedoren@redhat.com> - 2.6.3-1
 - Update to 2.6.3
 


### PR DESCRIPTION
## EL10 Rebuild — ruby-tier1

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (10)

- [ ] libsass
- [ ] rubygem-activerecord-nulldb-adapter
- [ ] rubygem-activerecord-session_store
- [ ] rubygem-addressable
- [ ] rubygem-algebrick
- [ ] rubygem-amazing_print
- [ ] rubygem-ancestry
- [ ] rubygem-anonymous_loader
- [ ] rubygem-apipie-bindings
- [ ] rubygem-apipie-dsl

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
