### PR TITLE
EL10 rebuild: ruby-tier1 (apipie-rails..concurrent-ruby, 10 packages)

### DIFF
--- a/packages/foreman/rubygem-apipie-rails/rubygem-apipie-rails.spec
+++ b/packages/foreman/rubygem-apipie-rails/rubygem-apipie-rails.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.5.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Rails REST API documentation tool
 #This gem is released under MIT license. Copy is included in file MIT-LICENSE.
 #
@@ -81,6 +81,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.5.1-2
+- Rebuild for EL10
+
 * Fri Jun 26 2026 Oleh Fedorenko <ofedoren@redhat.com> - 1.5.1-1
 - Update to 1.5.1
 

--- a/packages/foreman/rubygem-audited/rubygem-audited.spec
+++ b/packages/foreman/rubygem-audited/rubygem-audited.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 5.8.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Log all changes to your models
 License: MIT
 URL: https://github.com/collectiveidea/audited
@@ -61,6 +61,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/audited.gemspec
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.8.0-2
+- Rebuild for EL10
+
 * Tue Nov 12 2024 Foreman Packaging Automation <packaging@theforeman.org> - 5.8.0-1
 - Update to 5.8.0
 

--- a/packages/foreman/rubygem-autoprefixer-rails/rubygem-autoprefixer-rails.spec
+++ b/packages/foreman/rubygem-autoprefixer-rails/rubygem-autoprefixer-rails.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 10.4.21.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Parse CSS and add vendor prefixes to CSS rules using values from the Can I Use website
 License: MIT
 URL: https://github.com/ai/autoprefixer-rails
@@ -59,6 +59,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 10.4.21.0-2
+- Rebuild for EL10
+
 * Wed Apr 23 2025 Foreman Packaging Automation <packaging@theforeman.org> - 10.4.21.0-1
 - Update to 10.4.21.0
 

--- a/packages/foreman/rubygem-bcrypt/rubygem-bcrypt.spec
+++ b/packages/foreman/rubygem-bcrypt/rubygem-bcrypt.spec
@@ -4,7 +4,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.1.22
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: OpenBSD's bcrypt() password hashing algorithm
 License: MIT
 URL: https://github.com/bcrypt-ruby/bcrypt-ruby
@@ -82,6 +82,9 @@ rm -rf gem_ext_test
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.1.22-2
+- Rebuild for EL10
+
 * Sun Apr 12 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.1.22-1
 - Update to 3.1.22
 

--- a/packages/foreman/rubygem-bootstrap-sass/rubygem-bootstrap-sass.spec
+++ b/packages/foreman/rubygem-bootstrap-sass/rubygem-bootstrap-sass.spec
@@ -6,7 +6,7 @@
 Summary: bootstrap-sass is a Sass-powered version of Bootstrap 3
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.4.1
-Release: 3%{?dist}
+Release: 4%{?dist}
 Group: Development/Languages
 License: MIT
 URL: https://github.com/twbs/bootstrap-sass
@@ -74,6 +74,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/Rakefile
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.4.1-4
+- Rebuild for EL10
+
 * Wed May 21 2025 Zach Huntington-Meath <zhunting@redhat.com> - 3.4.1-3
 - Removed unversioned obsoletes
 

--- a/packages/foreman/rubygem-builder/rubygem-builder.spec
+++ b/packages/foreman/rubygem-builder/rubygem-builder.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.3.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Builders for MarkUp
 License: MIT
 URL: https://github.com/rails/builder
@@ -69,6 +69,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.3.0-2
+- Rebuild for EL10
+
 * Thu Jul 11 2024 Foreman Packaging Automation <packaging@theforeman.org> - 3.3.0-1
 - Update to 3.3.0
 

--- a/packages/foreman/rubygem-bundler_ext/rubygem-bundler_ext.spec
+++ b/packages/foreman/rubygem-bundler_ext/rubygem-bundler_ext.spec
@@ -7,7 +7,7 @@
 Summary: Load system gems via Bundler DSL
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.4.1
-Release: 7%{?dist}
+Release: 8%{?dist}
 Group: Development/Languages
 License: ASL 2.0
 URL: https://github.com/bundlerext/bundler_ext
@@ -75,6 +75,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/spec/
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.4.1-8
+- Rebuild for EL10
+
 * Wed May 21 2025 Zach Huntington-Meath <zhunting@redhat.com> - 0.4.1-7
 - Removed unversioned obsoletes
 

--- a/packages/foreman/rubygem-clamp/rubygem-clamp.spec
+++ b/packages/foreman/rubygem-clamp/rubygem-clamp.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.5.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: a minimal framework for command-line utilities
 License: MIT
 URL: https://github.com/mdub/clamp
@@ -61,6 +61,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/examples
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.5.2-2
+- Rebuild for EL10
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.5.2-1
 - Update to 1.5.2
 

--- a/packages/foreman/rubygem-colorize/rubygem-colorize.spec
+++ b/packages/foreman/rubygem-colorize/rubygem-colorize.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.8.1
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: Ruby gem for colorizing text using ANSI escape sequences
 License: GPL-2.0
 URL: http://github.com/fazibear/colorize
@@ -61,6 +61,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.8.1-4
+- Rebuild for EL10
+
 * Wed Jul 22 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.8.1-3
 - Re-add package, convert from SCL to default template
 

--- a/packages/foreman/rubygem-concurrent-ruby/rubygem-concurrent-ruby.spec
+++ b/packages/foreman/rubygem-concurrent-ruby/rubygem-concurrent-ruby.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.1.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 Epoch: 1
 Summary: Modern concurrency tools for Ruby
 License: MIT
@@ -63,6 +63,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/Rakefile
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1:1.1.10-2
+- Rebuild for EL10
+
 * Wed Jul 27 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1:1.1.10-1
 - Update to 1.1.10
 


### PR DESCRIPTION
## EL10 Rebuild — ruby-tier1

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (10)

- [ ] rubygem-apipie-rails
- [ ] rubygem-audited
- [ ] rubygem-autoprefixer-rails
- [ ] rubygem-bcrypt
- [ ] rubygem-bootstrap-sass
- [ ] rubygem-builder
- [ ] rubygem-bundler_ext
- [ ] rubygem-clamp
- [ ] rubygem-colorize
- [ ] rubygem-concurrent-ruby

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
