### PR TITLE
EL10 rebuild: ruby-tier1 (concurrent-ruby-edge..dynflow, 10 packages)

### DIFF
--- a/packages/foreman/rubygem-concurrent-ruby-edge/rubygem-concurrent-ruby-edge.spec
+++ b/packages/foreman/rubygem-concurrent-ruby-edge/rubygem-concurrent-ruby-edge.spec
@@ -6,7 +6,7 @@
 Summary: Edge concepts for the modern concurrency tools for Ruby
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.6.0
-Release: 4%{?foremandist}%{?dist}
+Release: 5%{?foremandist}%{?dist}
 Epoch: 1
 Group: Development/Languages
 
@@ -74,6 +74,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_docdir}
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1:0.6.0-5
+- Rebuild for EL10
+
 * Wed Jun 04 2025 Zach Huntington-Meath <zhunting@redhat.com> - 1:0.6.0-4
 - Removed unversioned obsoletes
 

--- a/packages/foreman/rubygem-connection_pool/rubygem-connection_pool.spec
+++ b/packages/foreman/rubygem-connection_pool/rubygem-connection_pool.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.5.5
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Generic connection pool for Ruby
 License: MIT
 URL: https://github.com/mperham/connection_pool
@@ -58,6 +58,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/connection_pool.gemspec
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.5.5-2
+- Rebuild for EL10
+
 * Wed Dec 10 2025 Foreman Packaging Automation <packaging@theforeman.org> - 2.5.5-1
 - Update to 2.5.5
 

--- a/packages/foreman/rubygem-crass/rubygem-crass.spec
+++ b/packages/foreman/rubygem-crass/rubygem-crass.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.0.7
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: CSS parser based on the CSS Syntax Level 3 spec
 License: MIT
 URL: https://github.com/rgrove/crass/
@@ -63,6 +63,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/crass.gemspec
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.7-2
+- Rebuild for EL10
+
 * Mon Jun 29 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.0.7-1
 - Update to 1.0.7
 

--- a/packages/foreman/rubygem-css_parser/rubygem-css_parser.spec
+++ b/packages/foreman/rubygem-css_parser/rubygem-css_parser.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.22.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Ruby CSS parser
 License: MIT
 URL: https://github.com/premailer/css_parser
@@ -56,6 +56,9 @@ cp -a .%{gem_dir}/* \
 
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.22.0-2
+- Rebuild for EL10
+
 * Sun May 17 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.22.0-1
 - Update to 1.22.0
 

--- a/packages/foreman/rubygem-daemons/rubygem-daemons.spec
+++ b/packages/foreman/rubygem-daemons/rubygem-daemons.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.4.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A toolkit to create and control daemons in different ways
 License: MIT
 URL: https://github.com/thuehlinger/daemons
@@ -65,6 +65,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/examples
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.4.1-2
+- Rebuild for EL10
+
 * Wed Jul 13 2022 Foreman Packaging Automation <packaging@theforeman.org> 1.4.1-1
 - Update to 1.4.1
 

--- a/packages/foreman/rubygem-deacon/rubygem-deacon.spec
+++ b/packages/foreman/rubygem-deacon/rubygem-deacon.spec
@@ -6,7 +6,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.0
-Release: 5%{?dist}
+Release: 6%{?dist}
 Summary: Human readable random name generator
 Group: Development/Languages
 License: GPLv3 and Public domain
@@ -77,6 +77,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.0-6
+- Rebuild for EL10
+
 * Thu Mar 11 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.0.0-5
 - Rebuild against rh-ruby27
 

--- a/packages/foreman/rubygem-declarative/rubygem-declarative.spec
+++ b/packages/foreman/rubygem-declarative/rubygem-declarative.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.0.20
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: DSL for nested schemas
 License: MIT
 URL: https://github.com/apotonick/declarative
@@ -62,6 +62,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/declarative.gemspec
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.0.20-2
+- Rebuild for EL10
+
 * Fri Jul 22 2022 Foreman Packaging Automation <packaging@theforeman.org> 0.0.20-1
 - Update to 0.0.20
 

--- a/packages/foreman/rubygem-deep_cloneable/rubygem-deep_cloneable.spec
+++ b/packages/foreman/rubygem-deep_cloneable/rubygem-deep_cloneable.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.2.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: This gem gives every ActiveRecord::Base object the possibility to do a deep clone
 License: MIT
 URL: https://github.com/moiristo/deep_cloneable
@@ -64,6 +64,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/readme.md
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.2.2-2
+- Rebuild for EL10
+
 * Sun Feb 22 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.2.2-1
 - Update to 3.2.2
 

--- a/packages/foreman/rubygem-domain_name/rubygem-domain_name.spec
+++ b/packages/foreman/rubygem-domain_name/rubygem-domain_name.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.6.20240107
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Domain Name manipulation library for Ruby
 License: BSD-2-Clause and BSD-3-Clause and MPL-2.0
 URL: https://github.com/knu/ruby-domain_name
@@ -68,6 +68,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.6.20240107-2
+- Rebuild for EL10
+
 * Wed Jan 31 2024 Foreman Packaging Automation <packaging@theforeman.org> - 0.6.20240107-1
 - Update to 0.6.20240107
 

--- a/packages/foreman/rubygem-dynflow/rubygem-dynflow.spec
+++ b/packages/foreman/rubygem-dynflow/rubygem-dynflow.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.0.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: DYNamic workFLOW engine
 License: MIT
 URL: https://github.com/Dynflow/dynflow
@@ -79,6 +79,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.0.1-2
+- Rebuild for EL10
+
 * Wed Apr 29 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.0.1-1
 - Update to 2.0.1
 


### PR DESCRIPTION
## EL10 Rebuild — ruby-tier1

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (10)

- [ ] rubygem-concurrent-ruby-edge
- [ ] rubygem-connection_pool
- [ ] rubygem-crass
- [ ] rubygem-css_parser
- [ ] rubygem-daemons
- [ ] rubygem-deacon
- [ ] rubygem-declarative
- [ ] rubygem-deep_cloneable
- [ ] rubygem-domain_name
- [ ] rubygem-dynflow

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
