### PR TITLE
Rebuild libsass for EL10

### DIFF
--- a/packages/foreman/libsass/libsass.spec
+++ b/packages/foreman/libsass/libsass.spec
@@ -1,6 +1,6 @@
 Name:           libsass
 Version:        3.6.4
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        C/C++ port of the Sass CSS precompiler
 
 License:        MIT
@@ -66,6 +66,9 @@ find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
 
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.6.4-6
+- Rebuild for EL10
+
 * Thu Jan 20 2022 Fedora Release Engineering <releng@fedoraproject.org> - 3.6.4-5
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_36_Mass_Rebuild
 


### PR DESCRIPTION
## EL10 Rebuild — ruby-tier1

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (1)

- [ ] libsass

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
