### PR TITLE
Rebuild rubygem-activerecord-nulldb-adapter for EL10

### DIFF
--- a/packages/foreman/rubygem-activerecord-nulldb-adapter/rubygem-activerecord-nulldb-adapter.spec
+++ b/packages/foreman/rubygem-activerecord-nulldb-adapter/rubygem-activerecord-nulldb-adapter.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.2.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: The Null Object pattern as applied to ActiveRecord database adapters
 License: MIT
 URL: https://github.com/nulldb/nulldb
@@ -67,6 +67,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.2.2-2
+- Rebuild for EL10
+
 * Wed Dec 10 2025 Foreman Packaging Automation <packaging@theforeman.org> - 1.2.2-1
 - Update to 1.2.2
 


### PR DESCRIPTION
## EL10 Rebuild — ruby-tier1

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (1)

- [ ] rubygem-activerecord-nulldb-adapter

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
