### PR TITLE
Rebuild rubygem-addressable for EL10

### DIFF
--- a/packages/foreman/rubygem-addressable/rubygem-addressable.spec
+++ b/packages/foreman/rubygem-addressable/rubygem-addressable.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.9.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: URI Implementation
 License: Apache-2.0
 URL: https://github.com/sporkmonger/addressable
@@ -58,6 +58,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.9.0-2
+- Rebuild for EL10
+
 * Sun Jun 21 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.9.0-1
 - Update to 2.9.0
 


### PR DESCRIPTION
## EL10 Rebuild — ruby-tier1

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (1)

- [ ] rubygem-addressable

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
