### PR TITLE
Rebuild rubygem-algebrick for EL10

### DIFF
--- a/packages/foreman/rubygem-algebrick/rubygem-algebrick.spec
+++ b/packages/foreman/rubygem-algebrick/rubygem-algebrick.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.7.5
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Algebraic types and pattern matching for Ruby
 License: Apache-2.0
 URL: https://github.com/pitr-ch/algebrick
@@ -59,6 +59,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/doc
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.7.5-2
+- Rebuild for EL10
+
 * Wed Jul 13 2022 Foreman Packaging Automation <packaging@theforeman.org> 0.7.5-1
 - Update to 0.7.5
 


### PR DESCRIPTION
## EL10 Rebuild — ruby-tier1

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (1)

- [ ] rubygem-algebrick

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
