### PR TITLE
Rebuild rubygem-ancestry for EL10

### DIFF
--- a/packages/foreman/rubygem-ancestry/rubygem-ancestry.spec
+++ b/packages/foreman/rubygem-ancestry/rubygem-ancestry.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 4.3.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Organize ActiveRecord model into a tree structure
 License: MIT
 URL: https://github.com/stefankroes/ancestry
@@ -63,6 +63,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 4.3.3-2
+- Rebuild for EL10
+
 * Sun Apr 16 2023 Foreman Packaging Automation <packaging@theforeman.org> 4.3.3-1
 - Update to 4.3.3
 


### PR DESCRIPTION
## EL10 Rebuild — ruby-tier1

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (1)

- [ ] rubygem-ancestry

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
