### PR TITLE
Rebuild rubygem-apipie-bindings for EL10

### DIFF
--- a/packages/foreman/rubygem-apipie-bindings/rubygem-apipie-bindings.spec
+++ b/packages/foreman/rubygem-apipie-bindings/rubygem-apipie-bindings.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.7.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: The Ruby bindings for Apipie documented APIs
 License: MIT
 URL: https://github.com/Apipie/apipie-bindings
@@ -59,6 +59,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Fri Jul 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.7.1-2
+- Rebuild for EL10
+
 * Sun May 18 2025 Foreman Packaging Automation <packaging@theforeman.org> - 0.7.1-1
 - Update to 0.7.1
 


### PR DESCRIPTION
## EL10 Rebuild — ruby-tier1

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (1)

- [ ] rubygem-apipie-bindings

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
