### PR TITLE
Enable bootstrap and buildroot packages for EL10 chroots

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -38,11 +38,12 @@ copr_projects:
       copr_project_fork_from: "{{ 'foreman-nightly-staging' if foreman_version != 'nightly' else False }}"
       copr_project_chroots:
         - name: "rhel-{{ rhel_10 }}-x86_64"
+          rpmbuild_with: "{{ ['bootstrap'] if bootstrap|bool else []}}"
           external_repos:
             - "{{ puppet_baseurl }}/el/$releasever/$basearch/"
             - "{{ foreman_staging }}"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-el{{ rhel_10 }}.xml"
-          buildroot_packages: [] # needs to be "{{ core_buildroot_packages }}" once foreman is built
+          buildroot_packages: "{{ core_buildroot_packages }}"
         - name: "rhel-{{ rhel_9 }}-x86_64"
           modules: "{{ core_modules_el9 }}"
           rpmbuild_with: "{{ ['bootstrap'] if bootstrap|bool else []}}"
@@ -60,7 +61,7 @@ copr_projects:
             - "{{ foreman_staging }}"
             - "{{ plugins_staging }}"
           comps_file: "{{ inventory_dir }}/comps/comps-foreman-plugins-el{{ rhel_10 }}.xml"
-          buildroot_packages: [] # needs to be "{{ core_buildroot_packages }}" once foreman is built
+          buildroot_packages: "{{ core_buildroot_packages }}"
         - name: "rhel-{{ rhel_9 }}-x86_64"
           modules: "{{ core_modules_el9 }}"
           external_repos:
@@ -78,7 +79,7 @@ copr_projects:
             - "{{ plugins_staging }}"
             - "{{ katello_staging }}"
           comps_file: "{{ inventory_dir }}/comps/comps-katello-el{{ rhel_10 }}.xml"
-          buildroot_packages: [] # needs to be "{{ core_buildroot_packages }}" once foreman is built
+          buildroot_packages: "{{ core_buildroot_packages }}"
         - name: "rhel-{{ rhel_9 }}-x86_64"
           modules: "{{ core_modules_el9 }}"
           external_repos:


### PR DESCRIPTION
## Summary

- Add `rpmbuild_with` bootstrap support to the `foreman-copr` EL10 chroot, matching the existing EL9 configuration from #12768
- Update `buildroot_packages` from `[]` to `{{ core_buildroot_packages }}` on all three EL10 Copr projects (foreman, plugins, katello)

This wires up the bootstrap mechanism for EL10 so we can build `foreman-build` (which provides `macros.foreman-dist` / `%{foremandist}`) before building everything else.

After merge, the bootstrap sequence is:
```
obal copr-project foreman-copr -e bootstrap=true
obal release foreman
obal copr-project foreman-copr
```

Addresses @ekohl's feedback on #13755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)