### PR TITLE
EL10 rebuild: crass, css_parser, daemons, deacon, declarative, deep_cloneable, domain_name, erubi, eventmachine, execjs

### DIFF
--- a/packages/foreman/rubygem-crass/rubygem-crass.spec
+++ b/packages/foreman/rubygem-crass/rubygem-crass.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.0.7
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: CSS parser based on the CSS Syntax Level 3 spec
 License: MIT
 URL: https://github.com/rgrove/crass/
@@ -63,6 +63,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/crass.gemspec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.7-2
+- Rebuild for EL10
+
 * Mon Jun 29 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.0.7-1
 - Update to 1.0.7
 

--- a/packages/foreman/rubygem-css_parser/rubygem-css_parser.spec
+++ b/packages/foreman/rubygem-css_parser/rubygem-css_parser.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.22.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Ruby CSS parser
 License: MIT
 URL: https://github.com/premailer/css_parser
@@ -56,6 +56,9 @@ cp -a .%{gem_dir}/* \
 
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.22.0-2
+- Rebuild for EL10
+
 * Sun May 17 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.22.0-1
 - Update to 1.22.0
 

--- a/packages/foreman/rubygem-daemons/rubygem-daemons.spec
+++ b/packages/foreman/rubygem-daemons/rubygem-daemons.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.4.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A toolkit to create and control daemons in different ways
 License: MIT
 URL: https://github.com/thuehlinger/daemons
@@ -65,6 +65,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/examples
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.4.1-2
+- Rebuild for EL10
+
 * Wed Jul 13 2022 Foreman Packaging Automation <packaging@theforeman.org> 1.4.1-1
 - Update to 1.4.1
 

--- a/packages/foreman/rubygem-deacon/rubygem-deacon.spec
+++ b/packages/foreman/rubygem-deacon/rubygem-deacon.spec
@@ -6,7 +6,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.0
-Release: 5%{?dist}
+Release: 6%{?dist}
 Summary: Human readable random name generator
 Group: Development/Languages
 License: GPLv3 and Public domain
@@ -77,6 +77,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.0-6
+- Rebuild for EL10
+
 * Thu Mar 11 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.0.0-5
 - Rebuild against rh-ruby27
 

--- a/packages/foreman/rubygem-declarative/rubygem-declarative.spec
+++ b/packages/foreman/rubygem-declarative/rubygem-declarative.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.0.20
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: DSL for nested schemas
 License: MIT
 URL: https://github.com/apotonick/declarative
@@ -62,6 +62,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/declarative.gemspec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.0.20-2
+- Rebuild for EL10
+
 * Fri Jul 22 2022 Foreman Packaging Automation <packaging@theforeman.org> 0.0.20-1
 - Update to 0.0.20
 

--- a/packages/foreman/rubygem-deep_cloneable/rubygem-deep_cloneable.spec
+++ b/packages/foreman/rubygem-deep_cloneable/rubygem-deep_cloneable.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.2.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: This gem gives every ActiveRecord::Base object the possibility to do a deep clone
 License: MIT
 URL: https://github.com/moiristo/deep_cloneable
@@ -64,6 +64,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/readme.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.2.2-2
+- Rebuild for EL10
+
 * Sun Feb 22 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.2.2-1
 - Update to 3.2.2
 

--- a/packages/foreman/rubygem-domain_name/rubygem-domain_name.spec
+++ b/packages/foreman/rubygem-domain_name/rubygem-domain_name.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.6.20240107
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Domain Name manipulation library for Ruby
 License: BSD-2-Clause and BSD-3-Clause and MPL-2.0
 URL: https://github.com/knu/ruby-domain_name
@@ -68,6 +68,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.6.20240107-2
+- Rebuild for EL10
+
 * Wed Jan 31 2024 Foreman Packaging Automation <packaging@theforeman.org> - 0.6.20240107-1
 - Update to 0.6.20240107
 

--- a/packages/foreman/rubygem-erubi/rubygem-erubi.spec
+++ b/packages/foreman/rubygem-erubi/rubygem-erubi.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.13.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Small ERB Implementation
 License: MIT
 URL: https://github.com/jeremyevans/erubi
@@ -58,6 +58,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/Rakefile
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.13.1-2
+- Rebuild for EL10
+
 * Sun Dec 22 2024 Foreman Packaging Automation <packaging@theforeman.org> - 1.13.1-1
 - Update to 1.13.1
 

--- a/packages/foreman/rubygem-eventmachine/rubygem-eventmachine.spec
+++ b/packages/foreman/rubygem-eventmachine/rubygem-eventmachine.spec
@@ -4,7 +4,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.2.7
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Ruby/EventMachine library
 License: Ruby and GPL-2.0
 URL: https://rubyeventmachine.com
@@ -95,6 +95,9 @@ rm -rf gem_ext_test
 %{gem_instdir}/tests
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.2.7-3
+- Rebuild for EL10
+
 * Mon Dec 18 2023 Evgeni Golov - 1.2.7-2
 - Explicitly BuildRequire gcc-c++
 

--- a/packages/foreman/rubygem-execjs/rubygem-execjs.spec
+++ b/packages/foreman/rubygem-execjs/rubygem-execjs.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.10.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Run JavaScript code from Ruby
 License: MIT
 URL: https://github.com/rails/execjs
@@ -56,6 +56,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.10.1-2
+- Rebuild for EL10
+
 * Wed Apr 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.10.1-1
 - Update to 2.10.1
 


### PR DESCRIPTION
## Summary

Bump release for 10 rubygems to rebuild for EL10. All packages are independent (no interdependencies within this PR).

Packages: rubygem-crass, rubygem-css_parser, rubygem-daemons, rubygem-deacon, rubygem-declarative, rubygem-deep_cloneable, rubygem-domain_name, rubygem-erubi, rubygem-eventmachine, rubygem-execjs

🤖 Generated with [Claude Code](https://claude.com/claude-code)