### PR TITLE
EL10 rebuild: fog-libvirt, fog-openstack, fog-vsphere, fog-xml, font-awesome-sass, foreman_maintain, formatador, friendly_id, get_process_mem, gettext

### DIFF
--- a/packages/foreman/rubygem-fog-libvirt/rubygem-fog-libvirt.spec
+++ b/packages/foreman/rubygem-fog-libvirt/rubygem-fog-libvirt.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.15.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Module for the 'fog' gem to support libvirt
 License: MIT
 URL: https://github.com/fog/fog-libvirt
@@ -64,6 +64,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/tests
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.15.0-2
+- Rebuild for EL10
+
 * Tue Mar 17 2026 Evgeni Golov - 0.15.0-1
 - Update to 0.15.0
 

--- a/packages/foreman/rubygem-fog-openstack/rubygem-fog-openstack.spec
+++ b/packages/foreman/rubygem-fog-openstack/rubygem-fog-openstack.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.1.5
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: OpenStack fog provider gem
 License: MIT
 URL: https://github.com/fog/fog-openstack
@@ -77,6 +77,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/fog-openstack.gemspec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.1.5-2
+- Rebuild for EL10
+
 * Wed Mar 19 2025 Foreman Packaging Automation <packaging@theforeman.org> - 1.1.5-1
 - Update to 1.1.5
 

--- a/packages/foreman/rubygem-fog-vsphere/rubygem-fog-vsphere.spec
+++ b/packages/foreman/rubygem-fog-vsphere/rubygem-fog-vsphere.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.7.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Module for the 'fog' gem to support VMware vSphere
 License: MIT
 URL: https://github.com/fog/fog-vsphere
@@ -69,6 +69,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/fog-vsphere.gemspec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.7.3-2
+- Rebuild for EL10
+
 * Mon Mar 23 2026 Leos Stejskal <lstejska@redhat.com> - 3.7.3-1
 - Update to 3.7.3
 

--- a/packages/foreman/rubygem-fog-xml/rubygem-fog-xml.spec
+++ b/packages/foreman/rubygem-fog-xml/rubygem-fog-xml.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.1.5
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: XML parsing for fog providers
 License: MIT
 URL: https://github.com/fog/fog-xml
@@ -69,6 +69,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.1.5-2
+- Rebuild for EL10
+
 * Wed Jan 08 2025 Foreman Packaging Automation <packaging@theforeman.org> - 0.1.5-1
 - Update to 0.1.5
 

--- a/packages/foreman/rubygem-font-awesome-sass/rubygem-font-awesome-sass.spec
+++ b/packages/foreman/rubygem-font-awesome-sass/rubygem-font-awesome-sass.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 4.6.2
-Release: 10%{?dist}
+Release: 11%{?dist}
 Summary: Font-Awesome SASS
 License: MIT
 URL: https://github.com/FortAwesome/font-awesome-sass
@@ -66,6 +66,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/font-awesome-sass.gemspec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 4.6.2-11
+- Rebuild for EL10
+
 * Fri Feb 14 2025 Adam Ruzicka <aruzicka@redhat.com> - 4.6.2-10
 - Do not use obsolete form of patch macro
 

--- a/packages/foreman/rubygem-foreman_maintain/rubygem-foreman_maintain.spec
+++ b/packages/foreman/rubygem-foreman_maintain/rubygem-foreman_maintain.spec
@@ -7,7 +7,7 @@
 Summary: The Foreman/Satellite maintenance tool
 Name: rubygem-%{gem_name}
 Version: 1.16.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Epoch: 1
 Group: Development/Languages
 License: GPLv3
@@ -115,6 +115,9 @@ install -D -m0644 %{SOURCE1} %{buildroot}%{_sysconfdir}/logrotate.d/%{gem_name}
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1:1.16.0-2
+- Rebuild for EL10
+
 * Fri Jul 17 15:58:20 CEST 2026 Bernhard Suttner <suttner@atix.de> - 1:1.16.0-1
 - Update to 1.16.0
 - Add requirement for pbzip2 to finish

--- a/packages/foreman/rubygem-formatador/rubygem-formatador.spec
+++ b/packages/foreman/rubygem-formatador/rubygem-formatador.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.2.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Ruby STDOUT text formatting
 License: MIT
 URL: https://github.com/geemus/formatador
@@ -68,6 +68,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/tests
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.2.3-2
+- Rebuild for EL10
+
 * Wed Nov 12 2025 Foreman Packaging Automation <packaging@theforeman.org> - 1.2.3-1
 - Update to 1.2.3
 

--- a/packages/foreman/rubygem-friendly_id/rubygem-friendly_id.spec
+++ b/packages/foreman/rubygem-friendly_id/rubygem-friendly_id.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 5.7.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A comprehensive slugging and pretty-URL plugin
 License: MIT
 URL: https://github.com/norman/friendly_id
@@ -68,6 +68,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/friendly_id.gemspec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.7.0-2
+- Rebuild for EL10
+
 * Sun Jun 21 2026 Foreman Packaging Automation <packaging@theforeman.org> - 5.7.0-1
 - Update to 5.7.0
 

--- a/packages/foreman/rubygem-get_process_mem/rubygem-get_process_mem.spec
+++ b/packages/foreman/rubygem-get_process_mem/rubygem-get_process_mem.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.0.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Use GetProcessMem to find out the amount of RAM used by any process
 License: MIT
 URL: https://github.com/schneems/get_process_mem
@@ -65,6 +65,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.0-2
+- Rebuild for EL10
+
 * Fri Jul 26 2024 Foreman Packaging Automation <packaging@theforeman.org> - 1.0.0-1
 - Update to 1.0.0
 

--- a/packages/foreman/rubygem-gettext/rubygem-gettext.spec
+++ b/packages/foreman/rubygem-gettext/rubygem-gettext.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.5.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Gettext is a pure Ruby libary and tools to localize messages
 License: Ruby and LGPLv3+
 URL: https://ruby-gettext.github.io/
@@ -96,6 +96,9 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 %{gem_instdir}/test
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.5.2-2
+- Rebuild for EL10
+
 * Sun Mar 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.5.2-1
 - Update to 3.5.2
 


### PR DESCRIPTION
## Summary
- Bump release for 10 rubygem packages for EL10 rebuild
- All packages are independent (no tier1 interdependencies)

### Packages
- rubygem-fog-libvirt
- rubygem-fog-openstack
- rubygem-fog-vsphere
- rubygem-fog-xml
- rubygem-font-awesome-sass
- rubygem-foreman_maintain
- rubygem-formatador
- rubygem-friendly_id
- rubygem-get_process_mem
- rubygem-gettext