### PR TITLE
EL10 rebuild: gettext_i18n_rails, gettext_i18n_rails_js, gitlab-sidekiq-fetcher, globalid, google-apis-compute_v1, google-apis-core, google-cloud-env, googleauth, graphql, graphql-batch

### DIFF
--- a/packages/foreman/rubygem-gettext_i18n_rails/rubygem-gettext_i18n_rails.spec
+++ b/packages/foreman/rubygem-gettext_i18n_rails/rubygem-gettext_i18n_rails.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.13.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Simple FastGettext Rails integration
 License: MIT
 URL: https://github.com/grosser/gettext_i18n_rails
@@ -56,6 +56,9 @@ cp -a .%{gem_dir}/* \
 
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.13.0-2
+- Rebuild for EL10
+
 * Sun Aug 11 2024 Foreman Packaging Automation <packaging@theforeman.org> - 1.13.0-1
 - Update to 1.13.0
 

--- a/packages/foreman/rubygem-gettext_i18n_rails_js/rubygem-gettext_i18n_rails_js.spec
+++ b/packages/foreman/rubygem-gettext_i18n_rails_js/rubygem-gettext_i18n_rails_js.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.4.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Extends gettext_i18n_rails making your .po files available to client side javascript as JSON
 License: MIT
 URL: https://github.com/webhippie/gettext_i18n_rails_js
@@ -62,6 +62,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/spec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.4.0-2
+- Rebuild for EL10
+
 * Wed May 17 2023 Foreman Packaging Automation <packaging@theforeman.org> 1.4.0-1
 - Update to 1.4.0
 

--- a/packages/foreman/rubygem-gitlab-sidekiq-fetcher/rubygem-gitlab-sidekiq-fetcher.spec
+++ b/packages/foreman/rubygem-gitlab-sidekiq-fetcher/rubygem-gitlab-sidekiq-fetcher.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.9.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Reliable fetch extension for Sidekiq
 License: LGPL-3.0
 URL: https://gitlab.com/gitlab-org/sidekiq-reliable-fetch/
@@ -69,6 +69,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/tests
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.9.0-3
+- Rebuild for EL10
+
 * Mon Nov 07 2022 Evgeni Golov - 0.9.0-2
 - Remove json >= 2.5 dependency
 

--- a/packages/foreman/rubygem-globalid/rubygem-globalid.spec
+++ b/packages/foreman/rubygem-globalid/rubygem-globalid.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.4.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Refer to any model with a URI: gid://app/class/id
 License: MIT
 URL: https://www.rubyonrails.org
@@ -56,6 +56,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.4.0-2
+- Rebuild for EL10
+
 * Wed Jun 24 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.4.0-1
 - Update to 1.4.0
 

--- a/packages/foreman/rubygem-google-apis-compute_v1/rubygem-google-apis-compute_v1.spec
+++ b/packages/foreman/rubygem-google-apis-compute_v1/rubygem-google-apis-compute_v1.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.54.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Simple REST client for Compute Engine API V1
 License: Apache-2.0
 URL: https://github.com/google/google-api-ruby-client
@@ -65,6 +65,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/CHANGELOG.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.54.0-2
+- Rebuild for EL10
+
 * Thu Nov 03 2022 Foreman Packaging Automation <packaging@theforeman.org> 0.54.0-1
 - Update to 0.54.0
 

--- a/packages/foreman/rubygem-google-apis-core/rubygem-google-apis-core.spec
+++ b/packages/foreman/rubygem-google-apis-core/rubygem-google-apis-core.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.9.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Common utility and base classes for legacy Google REST clients
 License: Apache-2.0
 URL: https://github.com/google/google-api-ruby-client
@@ -66,6 +66,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/CHANGELOG.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.9.1-2
+- Rebuild for EL10
+
 * Sun Oct 23 2022 Foreman Packaging Automation <packaging@theforeman.org> 0.9.1-1
 - Update to 0.9.1
 

--- a/packages/foreman/rubygem-google-cloud-env/rubygem-google-cloud-env.spec
+++ b/packages/foreman/rubygem-google-cloud-env/rubygem-google-cloud-env.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.6.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Google Cloud Platform hosting environment information
 License: Apache-2.0
 URL: https://github.com/googleapis/ruby-cloud-env
@@ -64,6 +64,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/SECURITY.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.6.0-2
+- Rebuild for EL10
+
 * Tue Jul 26 2022 Foreman Packaging Automation <packaging@theforeman.org> 1.6.0-1
 - Update to 1.6.0
 

--- a/packages/foreman/rubygem-googleauth/rubygem-googleauth.spec
+++ b/packages/foreman/rubygem-googleauth/rubygem-googleauth.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.3.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Google Auth Library for Ruby
 License: Apache-2.0
 URL: https://github.com/googleapis/google-auth-library-ruby
@@ -61,6 +61,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/SECURITY.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.3.0-2
+- Rebuild for EL10
+
 * Sun Oct 23 2022 Foreman Packaging Automation <packaging@theforeman.org> 1.3.0-1
 - Update to 1.3.0
 

--- a/packages/foreman/rubygem-graphql-batch/rubygem-graphql-batch.spec
+++ b/packages/foreman/rubygem-graphql-batch/rubygem-graphql-batch.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.6.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A query batching executor for the graphql gem
 License: MIT
 URL: https://github.com/Shopify/graphql-batch
@@ -67,6 +67,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/graphql-batch.gemspec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.6.1-2
+- Rebuild for EL10
+
 * Sun Sep 28 2025 Foreman Packaging Automation <packaging@theforeman.org> - 0.6.1-1
 - Update to 0.6.1
 

--- a/packages/foreman/rubygem-graphql/rubygem-graphql.spec
+++ b/packages/foreman/rubygem-graphql/rubygem-graphql.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.13.25
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A GraphQL language and runtime for Ruby
 License: MIT
 URL: https://github.com/rmosolgo/graphql-ruby
@@ -61,6 +61,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/readme.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.13.25-2
+- Rebuild for EL10
+
 * Wed Mar 26 2025 Foreman Packaging Automation <packaging@theforeman.org> - 1.13.25-1
 - Update to 1.13.25
 


### PR DESCRIPTION
## Summary
- Bump release for 10 rubygem packages for EL10 rebuild
- All packages are independent (no tier1 interdependencies)

### Packages
- rubygem-gettext_i18n_rails
- rubygem-gettext_i18n_rails_js
- rubygem-gitlab-sidekiq-fetcher
- rubygem-globalid
- rubygem-google-apis-compute_v1
- rubygem-google-apis-core
- rubygem-google-cloud-env
- rubygem-googleauth
- rubygem-graphql
- rubygem-graphql-batch