### PR TITLE
EL10 rebuild: jquery-ui-rails, jwt, ldap_fluff, little-plugger, locale, logging, logging-journald, loofah, mail, marcel

### DIFF
--- a/packages/foreman/rubygem-jquery-ui-rails/rubygem-jquery-ui-rails.spec
+++ b/packages/foreman/rubygem-jquery-ui-rails/rubygem-jquery-ui-rails.spec
@@ -6,7 +6,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 6.0.1
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: jQuery UI packaged for the Rails asset pipeline
 Group: Development/Languages
 License: MIT
@@ -87,6 +87,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/Rakefile
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 6.0.1-3
+- Rebuild for EL10
+
 * Thu Mar 11 2021 Eric D. Helms <ericdhelms@gmail.com> - 6.0.1-2
 - Rebuild against rh-ruby27
 

--- a/packages/foreman/rubygem-jwt/rubygem-jwt.spec
+++ b/packages/foreman/rubygem-jwt/rubygem-jwt.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.10.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: JSON Web Token implementation in Ruby
 License: MIT
 URL: https://github.com/jwt/ruby-jwt
@@ -66,6 +66,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/ruby-jwt.gemspec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.10.1-2
+- Rebuild for EL10
+
 * Sun Jan 26 2025 Foreman Packaging Automation <packaging@theforeman.org> - 2.10.1-1
 - Update to 2.10.1
 

--- a/packages/foreman/rubygem-ldap_fluff/rubygem-ldap_fluff.spec
+++ b/packages/foreman/rubygem-ldap_fluff/rubygem-ldap_fluff.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.9.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: LDAP querying tools for Active Directory, FreeIPA and POSIX-style
 License: GPL-2.0-only
 URL: https://github.com/theforeman/ldap_fluff
@@ -60,6 +60,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.9.0-2
+- Rebuild for EL10
+
 * Wed May 07 2025 Foreman Packaging Automation <packaging@theforeman.org> - 0.9.0-1
 - Update to 0.9.0
 

--- a/packages/foreman/rubygem-little-plugger/rubygem-little-plugger.spec
+++ b/packages/foreman/rubygem-little-plugger/rubygem-little-plugger.spec
@@ -7,7 +7,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.1.4
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: LittlePlugger is a module that provides Gem based plugin management
 Group: Development/Languages
 License: MIT
@@ -84,6 +84,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.1.4-4
+- Rebuild for EL10
+
 * Thu Mar 11 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.1.4-3
 - Rebuild against rh-ruby27
 

--- a/packages/foreman/rubygem-locale/rubygem-locale.spec
+++ b/packages/foreman/rubygem-locale/rubygem-locale.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.1.5
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Pure ruby library which provides basic APIs for localization
 License: Ruby and LGPLv3+
 URL: https://github.com/ruby-gettext/locale
@@ -68,6 +68,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.1.5-2
+- Rebuild for EL10
+
 * Sun Jun 07 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.1.5-1
 - Update to 2.1.5
 - Strip fiddle dependency from gemspec (Windows-only, not available on EL)

--- a/packages/foreman/rubygem-logging-journald/rubygem-logging-journald.spec
+++ b/packages/foreman/rubygem-logging-journald/rubygem-logging-journald.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.1.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Journald appender for logging gem
 License: MIT
 URL: https://github.com/lzap/logging-journald
@@ -65,6 +65,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.1.0-2
+- Rebuild for EL10
+
 * Sun Jul 24 2022 Foreman Packaging Automation <packaging@theforeman.org> 2.1.0-1
 - Update to 2.1.0
 

--- a/packages/foreman/rubygem-logging/rubygem-logging.spec
+++ b/packages/foreman/rubygem-logging/rubygem-logging.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.4.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A flexible and extendable logging library for Ruby
 License: MIT
 URL: https://rubygems.org/gems/logging
@@ -68,6 +68,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.4.0-2
+- Rebuild for EL10
+
 * Tue Aug 13 2024 Foreman Packaging Automation <packaging@theforeman.org> - 2.4.0-1
 - Update to 2.4.0
 

--- a/packages/foreman/rubygem-loofah/rubygem-loofah.spec
+++ b/packages/foreman/rubygem-loofah/rubygem-loofah.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.25.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Loofah is a general library for manipulating and transforming HTML/XML documents and fragments, built on top of Nokogiri
 License: MIT
 URL: https://github.com/flavorjones/loofah
@@ -66,6 +66,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.25.2-2
+- Rebuild for EL10
+
 * Sun Jul 19 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.25.2-1
 - Update to 2.25.2
 

--- a/packages/foreman/rubygem-mail/rubygem-mail.spec
+++ b/packages/foreman/rubygem-mail/rubygem-mail.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.9.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Mail provides a nice Ruby DSL for making, sending and reading emails
 License: MIT
 URL: https://github.com/mikel/mail
@@ -71,6 +71,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.9.1-2
+- Rebuild for EL10
+
 * Thu Jul 02 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.9.1-1
 - Update to 2.9.1
 

--- a/packages/foreman/rubygem-marcel/rubygem-marcel.spec
+++ b/packages/foreman/rubygem-marcel/rubygem-marcel.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.2.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Simple mime type detection using magic numbers, filenames, and extensions
 License: MIT and Apache-2.0
 URL: https://github.com/rails/marcel
@@ -57,6 +57,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.2.1-2
+- Rebuild for EL10
+
 * Sun Jun 07 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.2.1-1
 - Update to 1.2.1
 


### PR DESCRIPTION
## Summary
- Bump release for 10 rubygem packages for EL10 rebuild
- All packages are independent (no tier1 interdependencies)

### Packages
- rubygem-jquery-ui-rails
- rubygem-jwt
- rubygem-ldap_fluff
- rubygem-little-plugger
- rubygem-locale
- rubygem-logging
- rubygem-logging-journald
- rubygem-loofah
- rubygem-mail
- rubygem-marcel