### PR TITLE
EL10 rebuild: memoist, method_source, mime-types, mime-types-data, mini_mime, msgpack, multi_json, multipart-post, mustermann, net-ldap

### DIFF
--- a/packages/foreman/rubygem-memoist/rubygem-memoist.spec
+++ b/packages/foreman/rubygem-memoist/rubygem-memoist.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.16.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: memoize methods invocation
 License: MIT
 URL: https://github.com/matthewrudy/memoist
@@ -64,6 +64,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.16.2-2
+- rebuilt
+
 * Wed Jul 13 2022 Foreman Packaging Automation <packaging@theforeman.org> 0.16.2-1
 - Update to 0.16.2
 

--- a/packages/foreman/rubygem-method_source/rubygem-method_source.spec
+++ b/packages/foreman/rubygem-method_source/rubygem-method_source.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.1.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: retrieve the sourcecode for a method
 License: MIT
 URL: https://banisterfiend.wordpress.com
@@ -64,6 +64,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.1.0-3
+- rebuilt
+
 * Thu Jul 23 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.1.0-2
 - Re-add package, convert from SCL to default template
 

--- a/packages/foreman/rubygem-mime-types-data/rubygem-mime-types-data.spec
+++ b/packages/foreman/rubygem-mime-types-data/rubygem-mime-types-data.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.2026.0701
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: mime-types-data provides a registry for information about MIME media type definitions
 License: MIT
 URL: https://github.com/mime-types/mime-types-data/
@@ -70,6 +70,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/Rakefile
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.2026.0701-2
+- rebuilt
+
 * Thu Jul 02 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.2026.0701-1
 - Update to 3.2026.0701
 

--- a/packages/foreman/rubygem-mime-types/rubygem-mime-types.spec
+++ b/packages/foreman/rubygem-mime-types/rubygem-mime-types.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.7.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: The mime-types library provides a library and registry for information about MIME content type definitions
 License: MIT
 URL: https://github.com/mime-types/ruby-mime-types/
@@ -80,6 +80,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.7.0-2
+- rebuilt
+
 * Thu May 08 2025 Foreman Packaging Automation <packaging@theforeman.org> - 3.7.0-1
 - Update to 3.7.0
 

--- a/packages/foreman/rubygem-mini_mime/rubygem-mini_mime.spec
+++ b/packages/foreman/rubygem-mini_mime/rubygem-mini_mime.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.1.5
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A minimal mime type library
 License: MIT
 URL: https://github.com/discourse/mini_mime
@@ -66,6 +66,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/mini_mime.gemspec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.1.5-2
+- rebuilt
+
 * Fri Aug 11 2023 Foreman Packaging Automation <packaging@theforeman.org> 1.1.5-1
 - Update to 1.1.5
 

--- a/packages/foreman/rubygem-msgpack/rubygem-msgpack.spec
+++ b/packages/foreman/rubygem-msgpack/rubygem-msgpack.spec
@@ -4,7 +4,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.8.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: MessagePack, a binary-based efficient data interchange format
 License: Apache 2.0
 URL: https://msgpack.org/
@@ -82,6 +82,9 @@ rm -rf gem_ext_test
 %{gem_instdir}/msgpack.gemspec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.8.3-2
+- rebuilt
+
 * Wed Jun 17 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.8.3-1
 - Update to 1.8.3
 

--- a/packages/foreman/rubygem-multi_json/rubygem-multi_json.spec
+++ b/packages/foreman/rubygem-multi_json/rubygem-multi_json.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.19.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A common interface to multiple JSON libraries
 License: MIT
 URL: https://github.com/intridea/multi_json
@@ -60,6 +60,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.19.1-2
+- rebuilt
+
 * Sun Jul 12 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.19.1-1
 - Update to 1.19.1
 

--- a/packages/foreman/rubygem-multipart-post/rubygem-multipart-post.spec
+++ b/packages/foreman/rubygem-multipart-post/rubygem-multipart-post.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.4.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A multipart form post accessory for Net::HTTP
 License: MIT
 URL: https://github.com/socketry/multipart-post
@@ -58,6 +58,9 @@ cp -a .%{gem_dir}/* \
 
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.4.1-2
+- rebuilt
+
 * Wed Jul 01 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.4.1-1
 - Update to 2.4.1
 

--- a/packages/foreman/rubygem-mustermann/rubygem-mustermann.spec
+++ b/packages/foreman/rubygem-mustermann/rubygem-mustermann.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.0.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Your personal string matching expert
 License: MIT
 URL: https://github.com/sinatra/mustermann
@@ -59,6 +59,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.0.2-2
+- rebuilt
+
 * Mon Aug 01 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 2.0.2-1
 - Update to 2.0.2
 

--- a/packages/foreman/rubygem-net-ldap/rubygem-net-ldap.spec
+++ b/packages/foreman/rubygem-net-ldap/rubygem-net-ldap.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.20.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Net::LDAP for Ruby implements client access LDAP protocol
 License: MIT
 URL: https://github.com/ruby-ldap/ruby-net-ldap
@@ -74,6 +74,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.rdoc
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.20.0-2
+- rebuilt
+
 * Sun Oct 26 2025 Foreman Packaging Automation <packaging@theforeman.org> - 0.20.0-1
 - Update to 0.20.0
 


### PR DESCRIPTION
Bump release for EL10 rebuild. 10 independent tier1 packages, 1 commit per package.