### PR TITLE
EL10 rebuild: net-ping, net-scp, net-ssh, net_http_unix, netrc, nio4r, nokogiri, oauth, oauth-tty, optimist

### DIFF
--- a/packages/foreman/rubygem-net-ping/rubygem-net-ping.spec
+++ b/packages/foreman/rubygem-net-ping/rubygem-net-ping.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.0.8
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A ping interface for Ruby
 License: Artistic 2.0
 URL: https://github.com/chernesk/net-ping
@@ -67,6 +67,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.0.8-2
+- rebuilt
+
 * Fri Jul 22 2022 Foreman Packaging Automation <packaging@theforeman.org> 2.0.8-1
 - Update to 2.0.8
 

--- a/packages/foreman/rubygem-net-scp/rubygem-net-scp.spec
+++ b/packages/foreman/rubygem-net-scp/rubygem-net-scp.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 4.1.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A pure Ruby implementation of the SCP client protocol
 License: MIT
 URL: https://github.com/net-ssh/net-scp
@@ -66,6 +66,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/net-scp.gemspec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 4.1.0-2
+- rebuilt
+
 * Mon Jan 27 2025 Foreman Packaging Automation <packaging@theforeman.org> - 4.1.0-1
 - Update to 4.1.0
 

--- a/packages/foreman/rubygem-net-ssh/rubygem-net-ssh.spec
+++ b/packages/foreman/rubygem-net-ssh/rubygem-net-ssh.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.3.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Net::SSH: a pure-Ruby implementation of the SSH2 client protocol
 License: MIT
 URL: https://github.com/net-ssh/net-ssh
@@ -79,6 +79,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/net-ssh.gemspec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.3.3-2
+- rebuilt
+
 * Mon Jun 29 2026 Foreman Packaging Automation <packaging@theforeman.org> - 7.3.3-1
 - Update to 7.3.3
 

--- a/packages/foreman/rubygem-net_http_unix/rubygem-net_http_unix.spec
+++ b/packages/foreman/rubygem-net_http_unix/rubygem-net_http_unix.spec
@@ -6,7 +6,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.2.2
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Wrapper around Net::HTTP with AF_UNIX support
 Group: Development/Languages
 License: Apache 2.0
@@ -92,6 +92,9 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 %{gem_instdir}/spec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.2.2-3
+- rebuilt
+
 * Thu Mar 11 2021 Eric D. Helms <ericdhelms@gmail.com> - 0.2.2-2
 - Rebuild against rh-ruby27
 

--- a/packages/foreman/rubygem-netrc/rubygem-netrc.spec
+++ b/packages/foreman/rubygem-netrc/rubygem-netrc.spec
@@ -7,7 +7,7 @@
 Summary: Library to read and write netrc files
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.11.0
-Release: 7%{?dist}
+Release: 8%{?dist}
 Group: Development/Languages
 License: MIT
 URL: https://github.com/geemus/netrc
@@ -71,6 +71,9 @@ popd
 %{gem_instdir}/test
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.11.0-8
+- rebuilt
+
 * Wed May 21 2025 Zach Huntington-Meath <zhunting@redhat.com> - 0.11.0-7
 - Removed unversioned obsoletes
 

--- a/packages/foreman/rubygem-nio4r/rubygem-nio4r.spec
+++ b/packages/foreman/rubygem-nio4r/rubygem-nio4r.spec
@@ -4,7 +4,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.7.5
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: New IO for Ruby
 License: MIT
 URL: https://github.com/socketry/nio4r
@@ -79,6 +79,9 @@ rm -rf gem_ext_test
 %doc %{gem_instdir}/releases.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.7.5-2
+- rebuilt
+
 * Mon Nov 03 2025 Foreman Packaging Automation <packaging@theforeman.org> - 2.7.5-1
 - Update to 2.7.5
 

--- a/packages/foreman/rubygem-nokogiri/rubygem-nokogiri.spec
+++ b/packages/foreman/rubygem-nokogiri/rubygem-nokogiri.spec
@@ -4,7 +4,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.17.2
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby
 # MIT: see LICENSE.md
 # ASL 2.0
@@ -188,6 +188,9 @@ rm -rf gem_ext_test
 %doc %{gem_instdir}/gumbo-parser/src/README.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.17.2-4
+- rebuilt
+
 * Mon Jun 29 2026 Eric D. Helms <ericdhelms@gmail.com> - 1.17.2-3
 - Add CVE-2026-57236 patch for use-after-free in document encoding setter
 

--- a/packages/foreman/rubygem-oauth-tty/rubygem-oauth-tty.spec
+++ b/packages/foreman/rubygem-oauth-tty/rubygem-oauth-tty.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.0.13
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: OAuth 1.0 TTY CLI
 License: MIT
 URL: https://github.com/ruby-oauth/oauth-tty
@@ -74,6 +74,9 @@ find %{buildroot}%{gem_instdir}/exe -type f | xargs chmod a+x
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.13-2
+- rebuilt
+
 * Sun Jul 19 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.0.13-1
 - Update to 1.0.13
 

--- a/packages/foreman/rubygem-oauth/rubygem-oauth.spec
+++ b/packages/foreman/rubygem-oauth/rubygem-oauth.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.1.8
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: OAuth Core Ruby implementation
 License: MIT
 URL: https://github.com/oauth-xx/oauth-ruby
@@ -69,6 +69,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/SECURITY.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.1.8-2
+- rebuilt
+
 * Sun Jul 19 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.1.8-1
 - Update to 1.1.8
 

--- a/packages/foreman/rubygem-optimist/rubygem-optimist.spec
+++ b/packages/foreman/rubygem-optimist/rubygem-optimist.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.2.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Optimist is a commandline option parser for Ruby that just gets out of your way
 License: MIT
 URL: https://manageiq.github.io/optimist/
@@ -75,6 +75,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.2.1-2
+- rebuilt
+
 * Thu Mar 20 2025 Foreman Packaging Automation <packaging@theforeman.org> - 3.2.1-1
 - Update to 3.2.1
 


### PR DESCRIPTION
Bump release for EL10 rebuild. 10 independent tier1 packages, 1 commit per package.