### PR TITLE
EL10 rebuild: rbvmomi2, redis, representable, responders, rest-client, retriable, roadie, roadie-rails, ruby-libvirt, ruby2_keywords

### DIFF
--- a/packages/foreman/rubygem-rbvmomi2/rubygem-rbvmomi2.spec
+++ b/packages/foreman/rubygem-rbvmomi2/rubygem-rbvmomi2.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.10.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Ruby interface to the VMware vSphere API
 License: MIT
 URL: https://github.com/ManageIQ/rbvmomi2
@@ -67,6 +67,9 @@ find %{buildroot}%{gem_instdir}/exe -type f | xargs chmod a+x
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.10.0-2
+- rebuilt
+
 * Thu Apr 23 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.10.0-1
 - Update to 3.10.0
 

--- a/packages/foreman/rubygem-redis/rubygem-redis.spec
+++ b/packages/foreman/rubygem-redis/rubygem-redis.spec
@@ -7,7 +7,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 4.5.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A Ruby client library for Redis
 Group: Development/Languages
 License: MIT
@@ -80,6 +80,9 @@ cp -pa .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 4.5.1-2
+- rebuilt
+
 * Mon Mar 21 2022 Evgeni Golov 4.5.1-1
 - Update to 4.5.1
 

--- a/packages/foreman/rubygem-representable/rubygem-representable.spec
+++ b/packages/foreman/rubygem-representable/rubygem-representable.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.2.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Renders and parses JSON/XML/YAML documents from and to Ruby objects
 License: MIT
 URL: https://github.com/trailblazer/representable/
@@ -66,6 +66,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.2.0-2
+- rebuilt
+
 * Tue Sep 06 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 3.2.0-1
 - Update to 3.2.0
 

--- a/packages/foreman/rubygem-responders/rubygem-responders.spec
+++ b/packages/foreman/rubygem-responders/rubygem-responders.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.2.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A set of Rails responders to dry up your application
 License: MIT
 URL: https://github.com/heartcombo/responders
@@ -57,6 +57,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.2.0-2
+- rebuilt
+
 * Sun Oct 12 2025 Foreman Packaging Automation <packaging@theforeman.org> - 3.2.0-1
 - Update to 3.2.0
 

--- a/packages/foreman/rubygem-rest-client/rubygem-rest-client.spec
+++ b/packages/foreman/rubygem-rest-client/rubygem-rest-client.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.1.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Simple HTTP and REST client for Ruby, inspired by microframework syntax for specifying actions
 License: MIT
 URL: https://github.com/rest-client/rest-client
@@ -79,6 +79,9 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 %{gem_instdir}/spec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.1.0-2
+- rebuilt
+
 * Mon Sep 05 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> 2.1.0-1
 - Update to 2.1.0
 

--- a/packages/foreman/rubygem-retriable/rubygem-retriable.spec
+++ b/packages/foreman/rubygem-retriable/rubygem-retriable.spec
@@ -7,7 +7,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.1.2
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: Retriable is a simple DSL to retry failed code blocks with randomized exponential backoff
 Group: Development/Languages
 License: MIT
@@ -89,6 +89,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.1.2-4
+- rebuilt
+
 * Thu Mar 11 2021 Eric D. Helms <ericdhelms@gmail.com> - 3.1.2-3
 - Rebuild against rh-ruby27
 

--- a/packages/foreman/rubygem-roadie-rails/rubygem-roadie-rails.spec
+++ b/packages/foreman/rubygem-roadie-rails/rubygem-roadie-rails.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.4.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Making HTML emails comfortable for the Rails rockstars
 License: MIT
 URL: https://github.com/Mange/roadie-rails
@@ -70,6 +70,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/roadie-rails.gemspec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.4.0-2
+- rebuilt
+
 * Sun Oct 26 2025 Foreman Packaging Automation <packaging@theforeman.org> - 3.4.0-1
 - Update to 3.4.0
 

--- a/packages/foreman/rubygem-roadie/rubygem-roadie.spec
+++ b/packages/foreman/rubygem-roadie/rubygem-roadie.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 5.2.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Making HTML emails comfortable for the Ruby rockstars
 License: MIT
 URL: https://github.com/Mange/roadie
@@ -68,6 +68,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.2.1-2
+- rebuilt
+
 * Wed Feb 14 2024 Foreman Packaging Automation <packaging@theforeman.org> - 5.2.1-1
 - Update to 5.2.1
 

--- a/packages/foreman/rubygem-ruby-libvirt/rubygem-ruby-libvirt.spec
+++ b/packages/foreman/rubygem-ruby-libvirt/rubygem-ruby-libvirt.spec
@@ -4,7 +4,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.8.4
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Ruby bindings for LIBVIRT
 License: LGPLv2+
 URL: https://libvirt.org/ruby/
@@ -88,6 +88,9 @@ rm -rf gem_ext_test
 %{gem_instdir}/tests
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.8.4-2
+- rebuilt
+
 * Sun Nov 24 2024 Foreman Packaging Automation <packaging@theforeman.org> - 0.8.4-1
 - Update to 0.8.4
 

--- a/packages/foreman/rubygem-ruby2_keywords/rubygem-ruby2_keywords.spec
+++ b/packages/foreman/rubygem-ruby2_keywords/rubygem-ruby2_keywords.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.0.5
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Shim library for Ruby Module ruby2_keywords
 License: Ruby and BSD-2-Clause
 URL: https://github.com/ruby/ruby2_keywords
@@ -58,6 +58,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/logs
 
 %changelog
+* Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.0.5-2
+- rebuilt
+
 * Sun Jul 24 2022 Foreman Packaging Automation <packaging@theforeman.org> 0.0.5-1
 - Update to 0.0.5
 


### PR DESCRIPTION
Bump release for EL10 rebuild. 10 independent tier1 packages, 1 commit per package.