### PR TITLE
kafo: allow highline 3.x

### DIFF
--- a/dependencies/bookworm/kafo/changelog
+++ b/dependencies/bookworm/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (7.8.0-2) stable; urgency=low
+
+  * Allow highline 3.x
+
+ -- Evgeni Golov <evgeni@debian.org>  Tue, 28 Jul 2026 11:48:26 +0200
+
 ruby-kafo (7.8.0-1) stable; urgency=low
 
   * 7.8.0 released

--- a/dependencies/bookworm/kafo/control
+++ b/dependencies/bookworm/kafo/control
@@ -14,7 +14,7 @@ XB-Ruby-Versions: ${ruby:Versions}
 Depends: ruby | ruby-interpreter,
          ruby-clamp (>= 1.3.1),
          ruby-clamp (<< 2),
-         ruby-highline (<< 3.0),
+         ruby-highline (<< 4.0),
          ruby-highline (>= 1.6.21),
          ruby-kafo-parsers (>= 0.1.6),
          ruby-kafo-wizards,

--- a/dependencies/jammy/kafo/changelog
+++ b/dependencies/jammy/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (7.8.0-2) stable; urgency=low
+
+  * Allow highline 3.x
+
+ -- Evgeni Golov <evgeni@debian.org>  Tue, 28 Jul 2026 11:48:26 +0200
+
 ruby-kafo (7.8.0-1) stable; urgency=low
 
   * 7.8.0 released

--- a/dependencies/jammy/kafo/control
+++ b/dependencies/jammy/kafo/control
@@ -14,7 +14,7 @@ XB-Ruby-Versions: ${ruby:Versions}
 Depends: ruby | ruby-interpreter,
          ruby-clamp (>= 1.3.1),
          ruby-clamp (<< 2),
-         ruby-highline (<< 3.0),
+         ruby-highline (<< 4.0),
          ruby-highline (>= 1.6.21),
          ruby-kafo-parsers (>= 0.1.6),
          ruby-kafo-wizards,

--- a/dependencies/trixie/kafo/changelog
+++ b/dependencies/trixie/kafo/changelog
@@ -1,3 +1,9 @@
+ruby-kafo (7.8.0-2) stable; urgency=low
+
+  * Allow highline 3.x
+
+ -- Evgeni Golov <evgeni@debian.org>  Tue, 28 Jul 2026 11:48:26 +0200
+
 ruby-kafo (7.8.0-1) stable; urgency=low
 
   * 7.8.0 released

--- a/dependencies/trixie/kafo/control
+++ b/dependencies/trixie/kafo/control
@@ -14,7 +14,7 @@ XB-Ruby-Versions: ${ruby:Versions}
 Depends: ruby | ruby-interpreter,
          ruby-clamp (>= 1.3.1),
          ruby-clamp (<< 2),
-         ruby-highline (<< 3.0),
+         ruby-highline (<< 4.0),
          ruby-highline (>= 1.6.21),
          ruby-kafo-parsers (>= 0.1.6),
          ruby-kafo-wizards,


### PR DESCRIPTION
this was allowed upstream in 7.8.0, but wasn't reflected in the packages

<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->
