### PR TITLE
EL10 rebuild: plugins-tier1 (acts_as_list..bcrypt_pbkdf, 10 packages)

### DIFF
--- a/packages/plugins/rubygem-acts_as_list/rubygem-acts_as_list.spec
+++ b/packages/plugins/rubygem-acts_as_list/rubygem-acts_as_list.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.2.4
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A gem adding sorting, reordering capabilities to an active_record model, allowing it to act as a list
 License: MIT
 URL: https://github.com/brendon/acts_as_list
@@ -62,6 +62,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/Rakefile
 
 %changelog
+* Tue Jul 28 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.2.4-2
+- Rebuild for EL10
+
 * Tue Mar 18 2025 Evgeni Golov - 1.2.4-1
 - Update to 1.2.4
 

--- a/packages/plugins/rubygem-angular-rails-templates/rubygem-angular-rails-templates.spec
+++ b/packages/plugins/rubygem-angular-rails-templates/rubygem-angular-rails-templates.spec
@@ -3,7 +3,7 @@
 
 Name:      rubygem-%{gem_name}
 Version:   1.4.0
-Release:   1%{?dist}
+Release:   2%{?dist}
 Epoch:     1
 Summary:   Use your angular templates with rails' asset pipeline
 License:   MIT
@@ -58,6 +58,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Tue Jul 28 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1:1.4.0-2
+- Rebuild for EL10
+
 * Mon Jun 29 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1:1.4.0-1
 - Update to 1.4.0
 

--- a/packages/plugins/rubygem-aws-eventstream/rubygem-aws-eventstream.spec
+++ b/packages/plugins/rubygem-aws-eventstream/rubygem-aws-eventstream.spec
@@ -7,7 +7,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.2
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: AWS Event Stream Library
 Group: Development/Languages
 License: ASL 2.0
@@ -78,6 +78,9 @@ cp -pa .%{gem_dir}/* \
 
 
 %changelog
+* Tue Jul 28 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.2-3
+- Rebuild for EL10
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.0.2-2
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-aws-sigv4/rubygem-aws-sigv4.spec
+++ b/packages/plugins/rubygem-aws-sigv4/rubygem-aws-sigv4.spec
@@ -7,7 +7,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.1.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: AWS Signature Version 4 library
 Group: Development/Languages
 License: ASL 2.0
@@ -81,6 +81,9 @@ cp -pa .%{gem_dir}/* \
 
 
 %changelog
+* Tue Jul 28 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.1.0-3
+- Rebuild for EL10
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.1.0-2
 - Rebuild for Ruby 2.7
 

--- a/packages/plugins/rubygem-azure_mgmt_compute/rubygem-azure_mgmt_compute.spec
+++ b/packages/plugins/rubygem-azure_mgmt_compute/rubygem-azure_mgmt_compute.spec
@@ -6,7 +6,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.22.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Official Ruby client library to consume Microsoft Azure Compute Management services
 Group: Development/Languages
 License: MIT
@@ -79,6 +79,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Tue Jul 28 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.22.0-2
+- Rebuild for EL10
+
 * Thu Apr 08 2021 Amit Upadhye <upadhyeammit@gmail.com> 0.22.0-1
 - Update to 0.22.0
 

--- a/packages/plugins/rubygem-azure_mgmt_network/rubygem-azure_mgmt_network.spec
+++ b/packages/plugins/rubygem-azure_mgmt_network/rubygem-azure_mgmt_network.spec
@@ -6,7 +6,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.26.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Official Ruby client library to consume Microsoft Azure Network Management services
 Group: Development/Languages
 License: MIT
@@ -79,6 +79,9 @@ cp -a .%{gem_dir}/* \
 
 
 %changelog
+* Tue Jul 28 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.26.1-2
+- Rebuild for EL10
+
 * Thu Apr 08 2021 Amit Upadhye <upadhyeammit@gmail.com> 0.26.1-1
 - Update to 0.26.1
 

--- a/packages/plugins/rubygem-azure_mgmt_resources/rubygem-azure_mgmt_resources.spec
+++ b/packages/plugins/rubygem-azure_mgmt_resources/rubygem-azure_mgmt_resources.spec
@@ -6,7 +6,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.18.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Official ruby client library to consume Microsoft Azure Resource Management services
 Group: Development/Languages
 License: MIT
@@ -79,6 +79,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Tue Jul 28 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.18.2-2
+- Rebuild for EL10
+
 * Thu Apr 08 2021 Amit Upadhye <upadhyeammit@gmail.com> 0.18.2-1
 - Update to 0.18.2
 

--- a/packages/plugins/rubygem-azure_mgmt_storage/rubygem-azure_mgmt_storage.spec
+++ b/packages/plugins/rubygem-azure_mgmt_storage/rubygem-azure_mgmt_storage.spec
@@ -6,7 +6,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.23.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Official ruby client library to consume Microsoft Azure Storage Management services
 Group: Development/Languages
 License: MIT
@@ -79,6 +79,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Tue Jul 28 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.23.0-2
+- Rebuild for EL10
+
 * Thu Apr 08 2021 Amit Upadhye <upadhyeammit@gmail.com> 0.23.0-1
 - Update to 0.23.0
 

--- a/packages/plugins/rubygem-azure_mgmt_subscriptions/rubygem-azure_mgmt_subscriptions.spec
+++ b/packages/plugins/rubygem-azure_mgmt_subscriptions/rubygem-azure_mgmt_subscriptions.spec
@@ -7,7 +7,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.18.5
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Official ruby client library to consume Microsoft Azure Subscription Management services
 Group: Development/Languages
 License: MIT
@@ -80,6 +80,9 @@ cp -a .%{gem_dir}/* \
 
 
 %changelog
+* Tue Jul 28 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.18.5-2
+- Rebuild for EL10
+
 * Thu Apr 08 2021 Amit Upadhye <upadhyeammit@gmail.com> 0.18.5-1
 - Update to 0.18.5
 

--- a/packages/plugins/rubygem-bcrypt_pbkdf/rubygem-bcrypt_pbkdf.spec
+++ b/packages/plugins/rubygem-bcrypt_pbkdf/rubygem-bcrypt_pbkdf.spec
@@ -7,7 +7,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.1.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: OpenBSD's bcrypt_pbkdf (a variant of PBKDF2 with bcrypt-based PRF)
 Group: Development/Languages
 License: MIT
@@ -109,6 +109,9 @@ rm -rf gem_ext_test
 %{gem_instdir}/test
 
 %changelog
+* Tue Jul 28 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.1.0-3
+- Rebuild for EL10
+
 * Tue Jan 16 2024 Evgeni Golov - 1.1.0-2
 - Explicitly BuildRequire gcc
 


### PR DESCRIPTION
## EL10 Rebuild — plugins-tier1

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (10)

- [ ] rubygem-acts_as_list
- [ ] rubygem-angular-rails-templates
- [ ] rubygem-aws-eventstream
- [ ] rubygem-aws-sigv4
- [ ] rubygem-azure_mgmt_compute
- [ ] rubygem-azure_mgmt_network
- [ ] rubygem-azure_mgmt_resources
- [ ] rubygem-azure_mgmt_storage
- [ ] rubygem-azure_mgmt_subscriptions
- [ ] rubygem-bcrypt_pbkdf

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
