### PR TITLE
EL10 rebuild: ruby-tier1 (dynflow..sassc-rails, 5 packages)

### DIFF
--- a/packages/foreman/rubygem-dynflow/rubygem-dynflow.spec
+++ b/packages/foreman/rubygem-dynflow/rubygem-dynflow.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.0.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: DYNamic workFLOW engine
 License: MIT
 URL: https://github.com/Dynflow/dynflow
@@ -79,6 +79,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Tue Jul 28 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.0.1-2
+- Rebuild for EL10
+
 * Wed Apr 29 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.0.1-1
 - Update to 2.0.1
 

--- a/packages/foreman/rubygem-powerbar/rubygem-powerbar.spec
+++ b/packages/foreman/rubygem-powerbar/rubygem-powerbar.spec
@@ -7,7 +7,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 2.0.1
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: The last progressbar-library you'll ever need
 Group: Development/Languages
 License: MIT
@@ -84,6 +84,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/powerbar.gemspec
 
 %changelog
+* Tue Jul 28 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.0.1-4
+- Rebuild for EL10
+
 * Thu Mar 11 2021 Eric D. Helms <ericdhelms@gmail.com> - 2.0.1-3
 - Rebuild against rh-ruby27
 

--- a/packages/foreman/rubygem-rack-jsonp/rubygem-rack-jsonp.spec
+++ b/packages/foreman/rubygem-rack-jsonp/rubygem-rack-jsonp.spec
@@ -6,7 +6,7 @@
 Summary: A Rack middleware for providing JSON-P support
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.3.1
-Release: 11%{?dist}
+Release: 12%{?dist}
 Group: Development/Languages
 License: MIT
 URL: https://github.com/crohr/rack-jsonp
@@ -63,6 +63,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/Rakefile
 
 %changelog
+* Tue Jul 28 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.3.1-12
+- Rebuild for EL10
+
 * Wed May 21 2025 Zach Huntington-Meath <zhunting@redhat.com> - 1.3.1-11
 - Removed unversioned obsoletes
 

--- a/packages/foreman/rubygem-sass-rails/rubygem-sass-rails.spec
+++ b/packages/foreman/rubygem-sass-rails/rubygem-sass-rails.spec
@@ -6,7 +6,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 6.0.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Sass adapter for the Rails asset pipeline
 Group: Development/Languages
 License: MIT
@@ -80,6 +80,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Tue Jul 28 2026 Zach Huntington-Meath <zhunting@redhat.com> - 6.0.0-3
+- Rebuild for EL10
+
 * Thu Mar 11 2021 Eric D. Helms <ericdhelms@gmail.com> - 6.0.0-2
 - Rebuild against rh-ruby27
 

--- a/packages/foreman/rubygem-sassc-rails/rubygem-sassc-rails.spec
+++ b/packages/foreman/rubygem-sassc-rails/rubygem-sassc-rails.spec
@@ -6,7 +6,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 2.1.2
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: Integrate SassC-Ruby into Rails
 Group: Development/Languages
 License: MIT
@@ -90,6 +90,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Tue Jul 28 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.1.2-4
+- Rebuild for EL10
+
 * Thu Mar 11 2021 Eric D. Helms <ericdhelms@gmail.com> - 2.1.2-3
 - Rebuild against rh-ruby27
 


### PR DESCRIPTION
## EL10 Rebuild — ruby-tier1

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (5)

- [ ] rubygem-dynflow
- [ ] rubygem-powerbar
- [ ] rubygem-rack-jsonp
- [ ] rubygem-sass-rails
- [ ] rubygem-sassc-rails

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
