### PR TITLE
EL10 rebuild: ruby-tier2 (puma, sassc, websocket-driver)

### DIFF
--- a/packages/foreman/rubygem-puma/rubygem-puma.spec
+++ b/packages/foreman/rubygem-puma/rubygem-puma.spec
@@ -4,7 +4,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 6.6.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Puma is a simple, fast, threaded, and highly parallel HTTP 1.1 server for Ruby/Rack applications
 License: BSD-3-Clause
 URL: https://puma.io
@@ -97,6 +97,9 @@ rm -rf gem_ext_test
 %doc %{gem_instdir}/docs
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 6.6.1-2
+- Rebuild for EL10
+
 * Sun Aug 03 2025 Foreman Packaging Automation <packaging@theforeman.org> - 6.6.1-1
 - Update to 6.6.1
 

--- a/packages/foreman/rubygem-sassc/rubygem-sassc.spec
+++ b/packages/foreman/rubygem-sassc/rubygem-sassc.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.4.0
-Release: 4%{?dist}
+Release: 5%{?dist}
 Summary: Use libsass with Ruby!
 License: MIT
 URL: https://github.com/sass/sassc-ruby
@@ -81,6 +81,9 @@ ruby -I "%{buildroot}%{gem_libdir}" -e "require '%{gem_require_name}'"
 %{gem_instdir}/test
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.4.0-5
+- Rebuild for EL10
+
 * Fri Feb 02 2024 Patrick Creech <pcreech@redhat.com> - 2.4.0-4
 - Drop noarch
 - Set debug_package to nil

--- a/packages/foreman/rubygem-websocket-driver/rubygem-websocket-driver.spec
+++ b/packages/foreman/rubygem-websocket-driver/rubygem-websocket-driver.spec
@@ -4,7 +4,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.8.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: WebSocket protocol handler with pluggable I/O
 License: Apache-2.0
 URL: https://github.com/faye/websocket-driver-ruby
@@ -84,6 +84,9 @@ rm -rf gem_ext_test
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.8.2-2
+- Rebuild for EL10
+
 * Wed Jun 24 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.8.2-1
 - Update to 0.8.2
 


### PR DESCRIPTION
## EL10 Rebuild — ruby-tier2

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (3)

- [ ] rubygem-puma
- [ ] rubygem-sassc
- [ ] rubygem-websocket-driver

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
