### PR TITLE
EL10 rebuild: frameworks (activesupport..actionmailbox, 10 packages)

### DIFF
--- a/packages/foreman/rubygem-actioncable/rubygem-actioncable.spec
+++ b/packages/foreman/rubygem-actioncable/rubygem-actioncable.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: WebSocket framework for Rails
 License: MIT
 URL: https://rubyonrails.org
@@ -59,6 +59,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.0.10-2
+- Rebuild for EL10
+
 * Wed Oct 29 2025 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.10-1
 - Update to 7.0.10
 

--- a/packages/foreman/rubygem-actionmailbox/rubygem-actionmailbox.spec
+++ b/packages/foreman/rubygem-actionmailbox/rubygem-actionmailbox.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Inbound email handling framework
 License: MIT
 URL: https://rubyonrails.org
@@ -71,6 +71,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.0.10-2
+- Rebuild for EL10
+
 * Wed Oct 29 2025 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.10-1
 - Update to 7.0.10
 

--- a/packages/foreman/rubygem-actionmailer/rubygem-actionmailer.spec
+++ b/packages/foreman/rubygem-actionmailer/rubygem-actionmailer.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Email composition and delivery framework (part of Rails)
 License: MIT
 URL: https://rubyonrails.org
@@ -70,6 +70,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.rdoc
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.0.10-2
+- Rebuild for EL10
+
 * Wed Oct 29 2025 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.10-1
 - Update to 7.0.10
 

--- a/packages/foreman/rubygem-actionpack/rubygem-actionpack.spec
+++ b/packages/foreman/rubygem-actionpack/rubygem-actionpack.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.10
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Web-flow and rendering framework putting the VC in MVC (part of Rails)
 License: MIT
 URL: https://rubyonrails.org
@@ -66,6 +66,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.rdoc
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.0.10-3
+- Rebuild for EL10
+
 * Fri Feb 27 2026 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 7.0.10-2
 - Fix racc dependency on EL10
 

--- a/packages/foreman/rubygem-actionview/rubygem-actionview.spec
+++ b/packages/foreman/rubygem-actionview/rubygem-actionview.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Rendering framework putting the V in MVC (part of Rails)
 License: MIT
 URL: https://rubyonrails.org
@@ -57,6 +57,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.rdoc
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.0.10-2
+- Rebuild for EL10
+
 * Wed Oct 29 2025 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.10-1
 - Update to 7.0.10
 

--- a/packages/foreman/rubygem-activejob/rubygem-activejob.spec
+++ b/packages/foreman/rubygem-activejob/rubygem-activejob.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Job framework with pluggable queues
 License: MIT
 URL: https://rubyonrails.org
@@ -57,6 +57,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.0.10-2
+- Rebuild for EL10
+
 * Wed Oct 29 2025 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.10-1
 - Update to 7.0.10
 

--- a/packages/foreman/rubygem-activemodel/rubygem-activemodel.spec
+++ b/packages/foreman/rubygem-activemodel/rubygem-activemodel.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A toolkit for building modeling frameworks (part of Rails)
 License: MIT
 URL: https://rubyonrails.org
@@ -59,6 +59,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.rdoc
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.0.10-2
+- Rebuild for EL10
+
 * Wed Oct 29 2025 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.10-1
 - Update to 7.0.10
 

--- a/packages/foreman/rubygem-activerecord/rubygem-activerecord.spec
+++ b/packages/foreman/rubygem-activerecord/rubygem-activerecord.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Object-relational mapper framework (part of Rails)
 License: MIT
 URL: https://rubyonrails.org
@@ -60,6 +60,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/examples
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.0.10-2
+- Rebuild for EL10
+
 * Wed Oct 29 2025 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.10-1
 - Update to 7.0.10
 

--- a/packages/foreman/rubygem-activestorage/rubygem-activestorage.spec
+++ b/packages/foreman/rubygem-activestorage/rubygem-activestorage.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Local and cloud file storage framework
 License: MIT
 URL: https://rubyonrails.org
@@ -60,6 +60,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.0.10-2
+- Rebuild for EL10
+
 * Wed Oct 29 2025 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.10-1
 - Update to 7.0.10
 

--- a/packages/foreman/rubygem-activesupport/rubygem-activesupport.spec
+++ b/packages/foreman/rubygem-activesupport/rubygem-activesupport.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.10
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: A toolkit of support libraries and Ruby core extensions extracted from the Rails framework
 License: MIT
 URL: https://rubyonrails.org
@@ -78,6 +78,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.rdoc
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.0.10-3
+- Rebuild for EL10
+
 * Sun Mar 29 2026 Jakub Duchek <jakduch@seznam.cz> - 7.0.10-2
 - Apply CVE-2026-33176 patch for number converter DoS
 


### PR DESCRIPTION
## EL10 Rebuild — frameworks

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (10)

- [ ] rubygem-activesupport
- [ ] rubygem-activemodel
- [ ] rubygem-activerecord
- [ ] rubygem-actionview
- [ ] rubygem-actionpack
- [ ] rubygem-activejob
- [ ] rubygem-actionmailer
- [ ] rubygem-actioncable
- [ ] rubygem-activestorage
- [ ] rubygem-actionmailbox

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
