### PR TITLE
EL10 rebuild: frameworks (actiontext..python-websockify, 9 packages)

### DIFF
--- a/packages/foreman/dynflow-utils/dynflow-utils.spec
+++ b/packages/foreman/dynflow-utils/dynflow-utils.spec
@@ -2,7 +2,7 @@
 
 Name:    dynflow-utils
 Version: 2.0.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Supplemental Dynflow utilities
 License: GPLv3
 URL:     https://github.com/dynflow/dynflow
@@ -39,6 +39,9 @@ install -D -m755 dynflow-expand %{buildroot}%{_libexecdir}/dynflow-expand
 %{_libexecdir}/dynflow-expand
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.0.1-2
+- Rebuild for EL10
+
 * Tue Apr 28 2026 Adam Ruzicka <aruzicka@redhat.com> - 2.0.1-1
 - Rebuild with newer go 
 

--- a/packages/foreman/foreman-bootloaders-redhat/foreman-bootloaders-redhat.spec
+++ b/packages/foreman/foreman-bootloaders-redhat/foreman-bootloaders-redhat.spec
@@ -1,6 +1,6 @@
 Name: foreman-bootloaders-redhat
 Version: 202506020000
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Metapackage with Grub2 and Shim TFTP bootloaders
 
 Group: Applications/System
@@ -74,6 +74,9 @@ install -Dp -m0755 %{SOURCE0} %{buildroot}%{_bindir}/foreman-generate-bootloader
 
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 202506020000-3
+- Rebuild for EL10
+
 * Sat Nov 22 2025 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 202506020000-2
 - Fix RPM build macro on non-RHEL
 

--- a/packages/foreman/foreman-obsolete-packages/foreman-obsolete-packages.spec
+++ b/packages/foreman/foreman-obsolete-packages/foreman-obsolete-packages.spec
@@ -1,6 +1,6 @@
 Name: foreman-obsolete-packages
 Version: 1.18
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: MIT
 Summary: A package to obsolete retired packages
 URL: https://github.com/theforeman/foreman-packaging
@@ -66,6 +66,9 @@ from the distribution for some reason.
 %files
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.18-2
+- Rebuild for EL10
+
 * Wed Jul 22 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.18-1
 - Re-add rubygem-colorize and rubygem-method_source (still needed)
 

--- a/packages/foreman/python-websockify/python-websockify.spec
+++ b/packages/foreman/python-websockify/python-websockify.spec
@@ -2,7 +2,7 @@
 %global summary WSGI based adapter for the Websockets protocol
 Name:           python-%{pkgname}
 Version:        0.10.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        %{summary}
 
 License:        LGPLv3
@@ -60,6 +60,9 @@ install -m 444 docs/websockify.1 %{buildroot}%{_mandir}/man1/
 %doc docs
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.10.0-4
+- Rebuild for EL10
+
 * Fri Jul 22 2022 Fedora Release Engineering <releng@fedoraproject.org> - 0.10.0-3
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_37_Mass_Rebuild
 

--- a/packages/foreman/rubygem-actiontext/rubygem-actiontext.spec
+++ b/packages/foreman/rubygem-actiontext/rubygem-actiontext.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Rich text framework
 License: MIT
 URL: https://rubyonrails.org
@@ -60,6 +60,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.0.10-2
+- Rebuild for EL10
+
 * Wed Oct 29 2025 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.10-1
 - Update to 7.0.10
 

--- a/packages/foreman/rubygem-hammer_cli/rubygem-hammer_cli.spec
+++ b/packages/foreman/rubygem-hammer_cli/rubygem-hammer_cli.spec
@@ -3,7 +3,7 @@
 
 %global hammer_confdir %{_sysconfdir}/hammer
 
-%global release 1
+%global release 2
 %global prereleasesource pre.develop
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
 
@@ -97,6 +97,9 @@ install -m 0644 .%{gem_instdir}/config/cli_config.template.yml \
 %{gem_instdir}/test
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.2.pre.develop
+- Rebuild for EL10
+
 * Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.pre.develop
 - Bump version to 5.0-develop
 

--- a/packages/foreman/rubygem-hammer_cli_foreman/rubygem-hammer_cli_foreman.spec
+++ b/packages/foreman/rubygem-hammer_cli_foreman/rubygem-hammer_cli_foreman.spec
@@ -2,7 +2,7 @@
 %global gem_name hammer_cli_foreman
 %global plugin_name foreman
 
-%global release 1
+%global release 2
 %global prereleasesource pre.develop
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
 
@@ -74,6 +74,9 @@ install -m 0644 .%{gem_instdir}/config/%{plugin_name}.yml \
 %{gem_instdir}/test
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.2.pre.develop
+- Rebuild for EL10
+
 * Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.pre.develop
 - Bump version to 5.0-develop
 

--- a/packages/foreman/rubygem-rails/rubygem-rails.spec
+++ b/packages/foreman/rubygem-rails/rubygem-rails.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Full-stack web application framework
 License: MIT
 URL: https://rubyonrails.org
@@ -58,6 +58,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.0.10-2
+- Rebuild for EL10
+
 * Wed Oct 29 2025 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.10-1
 - Update to 7.0.10
 

--- a/packages/foreman/rubygem-railties/rubygem-railties.spec
+++ b/packages/foreman/rubygem-railties/rubygem-railties.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Tools for creating, working with, and running Rails applications
 License: MIT
 URL: https://rubyonrails.org
@@ -67,6 +67,9 @@ find %{buildroot}%{gem_instdir}/exe -type f | xargs chmod a+x
 %doc %{gem_instdir}/README.rdoc
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.0.10-2
+- Rebuild for EL10
+
 * Wed Oct 29 2025 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.10-1
 - Update to 7.0.10
 


### PR DESCRIPTION
## EL10 Rebuild — frameworks

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (9)

- [ ] rubygem-actiontext
- [ ] rubygem-railties
- [ ] rubygem-rails
- [ ] rubygem-hammer_cli
- [ ] rubygem-hammer_cli_foreman
- [ ] dynflow-utils
- [ ] foreman-bootloaders-redhat
- [ ] foreman-obsolete-packages
- [ ] python-websockify

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
