### PR TITLE
EL10 rebuild: core-apps (foreman-fapolicyd..rb-inotify, 20 packages)

### DIFF
--- a/packages/foreman/foreman-fapolicyd/foreman-fapolicyd.spec
+++ b/packages/foreman/foreman-fapolicyd/foreman-fapolicyd.spec
@@ -1,6 +1,6 @@
 Name:     foreman-fapolicyd
 Version:  1.1.0
-Release:  1%{?dist}
+Release:  2%{?dist}
 Summary:  Foreman fapolicyd rules
 
 Group:    System Environment/Base
@@ -69,6 +69,9 @@ Foreman Proxy fapolicyd rules
 %attr(0644,root,fapolicyd) %{_sysconfdir}/fapolicyd/rules.d/61-foreman-proxy.rules
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.1.0-2
+- Rebuild for EL10
+
 * Wed Sep 24 2025 Eric D. Helms <ericdhelms@gmail.com> - 1.1.0-1
 - Release foreman-fapolicyd 1.1.0
 

--- a/packages/foreman/foreman-installer/foreman-installer.spec
+++ b/packages/foreman/foreman-installer/foreman-installer.spec
@@ -1,4 +1,4 @@
-%global release 1
+%global release 2
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -126,6 +126,9 @@ foreman-installer --scenario katello --migrations-only > /dev/null
 %{_sbindir}/foreman-proxy-certs-generate
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1:5.0.0-0.2.develop
+- Rebuild for EL10
+
 * Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1:5.0.0-0.1.develop
 - Bump version to 5.0-develop
 

--- a/packages/foreman/foreman-proxy/foreman-proxy.spec
+++ b/packages/foreman/foreman-proxy/foreman-proxy.spec
@@ -1,7 +1,7 @@
 %global homedir %{_datadir}/%{name}
 %global confdir config
 
-%global release 1
+%global release 2
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -239,6 +239,9 @@ exit 0
 
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.2.develop
+- Rebuild for EL10
+
 * Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.develop
 - Bump version to 5.0-develop
 

--- a/packages/foreman/foreman-selinux/foreman-selinux.spec
+++ b/packages/foreman/foreman-selinux/foreman-selinux.spec
@@ -21,7 +21,7 @@
 
 %define moduletype apps
 
-%global release 1
+%global release 2
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -173,6 +173,9 @@ fi
 %{_mandir}/man8/foreman-proxy-selinux-relabel.8.gz
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.2.develop
+- Rebuild for EL10
+
 * Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.develop
 - Bump version to 5.0-develop
 

--- a/packages/foreman/foremanctl/foremanctl.spec
+++ b/packages/foreman/foremanctl/foremanctl.spec
@@ -2,7 +2,7 @@
 
 Name:      foremanctl
 Version:   2.3.0
-Release:   3%{?dist}
+Release:   4%{?dist}
 Summary:   Install Foreman using containers
 
 License:   GPL-2-only
@@ -67,6 +67,9 @@ cp -r build/collections/%{name} %{buildroot}%{_datadir}/%{name}/collections
 
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.3.0-4
+- Rebuild for EL10
+
 * Wed Jul 22 2026 Arvind Jangir <ajangir@redhat.com> 2.3.0-3
 - Add proxy inventory group
 

--- a/packages/foreman/katello-certs-tools/katello-certs-tools.spec
+++ b/packages/foreman/katello-certs-tools/katello-certs-tools.spec
@@ -3,7 +3,7 @@ Summary:   Katello SSL Key/Cert Tool
 Group:     Applications/Internet
 License:   GPLv2
 Version:   2.10.0
-Release:   1%{?dist}
+Release:   2%{?dist}
 URL:       https://github.com/katello/katello-certs-tools
 Source0:   https://codeload.github.com/Katello/%{name}/tar.gz/%{version}#/%{name}-%{version}.tar.gz
 BuildArch: noarch
@@ -45,6 +45,9 @@ mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/pki/%{name}/private
 %license LICENSE
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.10.0-2
+- Rebuild for EL10
+
 * Wed Apr 17 2024 Eric D. Helms <ericdhelms@gmail.com> - 2.10.0-1
 - Release 2.10.0
 

--- a/packages/foreman/puppet-agent-oauth/puppet-agent-oauth.spec
+++ b/packages/foreman/puppet-agent-oauth/puppet-agent-oauth.spec
@@ -4,7 +4,7 @@
 Summary: OAuth Core Ruby implementation for Puppet Agent
 Name: puppet-agent-%{gem_name}
 Version: 0.5.10
-Release: 2%{?dist}
+Release: 3%{?dist}
 Group: Development/Languages
 License: MIT
 URL: http://rubydoc.info/gems/oauth
@@ -50,6 +50,9 @@ if ! /opt/puppetlabs/puppet/bin/gem list %{gem_name} | grep %{gem_name} | grep -
 fi
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.5.10-3
+- Rebuild for EL10
+
 * Tue Sep 30 2025 Bernhard Suttner - 0.5.10-2
 - Build with openvox-agent
 

--- a/packages/foreman/puppet-agent-puppet-strings/puppet-agent-puppet-strings.spec
+++ b/packages/foreman/puppet-agent-puppet-strings/puppet-agent-puppet-strings.spec
@@ -4,7 +4,7 @@
 Summary: Puppet documentation via YARD
 Name: puppet-agent-%{gem_name}
 Version: 4.1.2
-Release: 2%{?dist}
+Release: 3%{?dist}
 Group: Development/Languages
 License: ASL-2.0
 URL: https://github.com/puppetlabs/puppetlabs-strings
@@ -49,6 +49,9 @@ else  # upgrade
 fi
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 4.1.2-3
+- Rebuild for EL10
+
 * Tue Sep 30 2025 Bernhard Suttner <suttner@atix.de> - 4.1.2-2
 - Build with openvox-agent
 

--- a/packages/foreman/puppet-agent-rgen/puppet-agent-rgen.spec
+++ b/packages/foreman/puppet-agent-rgen/puppet-agent-rgen.spec
@@ -4,7 +4,7 @@
 Summary: OAuth Core Ruby implementation for Puppet Agent
 Name: puppet-agent-%{gem_name}
 Version: 0.9.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Group: Development/Languages
 License: MIT
 URL: http://rubydoc.info/gems/rgen
@@ -50,6 +50,9 @@ if ! /opt/puppetlabs/puppet/bin/gem list %{gem_name} | grep %{gem_name} | grep -
 fi
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.9.0-3
+- Rebuild for EL10
+
 * Tue Sep 30 2025 Bernhard Suttner <suttner@atix.de> - 0.9.0-2
 - Build with openvox-agent
 

--- a/packages/foreman/puppet-agent-yard/puppet-agent-yard.spec
+++ b/packages/foreman/puppet-agent-yard/puppet-agent-yard.spec
@@ -4,7 +4,7 @@
 Summary: Documentation generation tool for Ruby
 Name: puppet-agent-%{gem_name}
 Version: 0.9.36
-Release: 2%{?dist}
+Release: 3%{?dist}
 Group: Development/Languages
 License: MIT
 URL: http://yardoc.org/
@@ -46,6 +46,9 @@ else  # upgrade
 fi
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.9.36-3
+- Rebuild for EL10
+
 * Tue Sep 30 2025 Bernhard Suttner <suttner@atix.de> - 0.9.36-2
 - Build with openvox-agent
 

--- a/packages/foreman/python-obsah/python-obsah.spec
+++ b/packages/foreman/python-obsah/python-obsah.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.10.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        easily build CLI applications using ansible playbooks
 
 License:        None
@@ -44,6 +44,9 @@ rm -rf %{pypi_name}.egg-info
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.10.0-2
+- Rebuild for EL10
+
 * Fri Jul 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.10.0-1
 - Update to 1.10.0
 

--- a/packages/foreman/rubygem-ansi/rubygem-ansi.spec
+++ b/packages/foreman/rubygem-ansi/rubygem-ansi.spec
@@ -6,7 +6,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.5.0
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: ANSI at your fingertips!
 Group: Development/Languages
 License: BSD-2-Clause
@@ -87,6 +87,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.5.0-4
+- Rebuild for EL10
+
 * Tue Apr 06 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.5.0-3
 - Rebuild for Ruby 2.7
 

--- a/packages/foreman/rubygem-auth-sanitizer/rubygem-auth-sanitizer.spec
+++ b/packages/foreman/rubygem-auth-sanitizer/rubygem-auth-sanitizer.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.2.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Configurable KV output redaction
 License: MIT
 URL: https://github.com/ruby-oauth/auth-sanitizer
@@ -66,6 +66,9 @@ cp -a .%{gem_dir}/* \
 %doc %{gem_instdir}/SECURITY.md
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.2.3-2
+- Rebuild for EL10
+
 * Sun Jul 19 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.2.3-1
 - Update to 0.2.3
 

--- a/packages/foreman/rubygem-concurrent-ruby/rubygem-concurrent-ruby.spec
+++ b/packages/foreman/rubygem-concurrent-ruby/rubygem-concurrent-ruby.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.1.10
-Release: 2%{?dist}
+Release: 3%{?dist}
 Epoch: 1
 Summary: Modern concurrency tools for Ruby
 License: MIT
@@ -63,6 +63,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/Rakefile
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1:1.1.10-3
+- Rebuild for EL10
+
 * Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1:1.1.10-2
 - Rebuild for EL10
 

--- a/packages/foreman/rubygem-gssapi/rubygem-gssapi.spec
+++ b/packages/foreman/rubygem-gssapi/rubygem-gssapi.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.3.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A FFI wrapper around the system GSSAPI library
 License: MIT
 URL: https://github.com/zenchild/gssapi
@@ -70,6 +70,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.3.1-2
+- Rebuild for EL10
+
 * Sun Aug 28 2022 Foreman Packaging Automation <packaging@theforeman.org> 1.3.1-1
 - Update to 1.3.1
 

--- a/packages/foreman/rubygem-kafo/rubygem-kafo.spec
+++ b/packages/foreman/rubygem-kafo/rubygem-kafo.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.8.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A gem for making installations based on puppet user friendly
 License: GPLv3+
 URL: https://github.com/theforeman/kafo
@@ -71,6 +71,9 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 %doc %{gem_instdir}/doc
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.8.0-2
+- Rebuild for EL10
+
 * Tue Jul 14 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 7.8.0-1
 - Release rubygem-kafo 7.8.0
 

--- a/packages/foreman/rubygem-kafo_parsers/rubygem-kafo_parsers.spec
+++ b/packages/foreman/rubygem-kafo_parsers/rubygem-kafo_parsers.spec
@@ -7,7 +7,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.2.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Puppet module parsers
 Group: Development/Languages
 License: GPLv3+
@@ -84,6 +84,9 @@ cp -pa .%{gem_dir}/* \
 %{gem_instdir}/Rakefile
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.2.1-2
+- Rebuild for EL10
+
 * Mon Jul 26 2021 Eric D. Helms <ericdhelms@gmail.com> - 1.2.1-1
 - Release rubygem-kafo_parsers 1.2.1
 

--- a/packages/foreman/rubygem-kafo_wizards/rubygem-kafo_wizards.spec
+++ b/packages/foreman/rubygem-kafo_wizards/rubygem-kafo_wizards.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.0.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Wizard like interfaces in terminal
 License: GPLv3+
 URL: https://github.com/theforeman/kafo_wizards
@@ -62,6 +62,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/Rakefile
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.0-2
+- Rebuild for EL10
+
 * Tue Feb 17 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 1.0.0-1
 - Update to 1.0.0
 

--- a/packages/foreman/rubygem-rake-compiler/rubygem-rake-compiler.spec
+++ b/packages/foreman/rubygem-rake-compiler/rubygem-rake-compiler.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.3.1
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Rake-based Ruby Extension (C, Java) task generator
 License: MIT
 URL: https://github.com/rake-compiler/rake-compiler
@@ -72,6 +72,9 @@ find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x
 %{gem_instdir}/features
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.3.1-3
+- Rebuild for EL10
+
 * Mon Jul 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.3.1-2
 - rebuilt
 

--- a/packages/foreman/rubygem-rb-inotify/rubygem-rb-inotify.spec
+++ b/packages/foreman/rubygem-rb-inotify/rubygem-rb-inotify.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.11.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A Ruby wrapper for Linux inotify, using FFI
 License: MIT
 URL: https://github.com/guard/rb-inotify
@@ -62,6 +62,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.11.1-2
+- Rebuild for EL10
+
 * Sun Jul 07 2024 Foreman Packaging Automation <packaging@theforeman.org> - 0.11.1-1
 - Update to 0.11.1
 


### PR DESCRIPTION
## EL10 Rebuild — core-apps

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (20)

- [ ] foreman-fapolicyd
- [ ] foreman-installer
- [ ] foreman-proxy
- [ ] foreman-selinux
- [ ] foremanctl
- [ ] katello-certs-tools
- [ ] puppet-agent-oauth
- [ ] puppet-agent-puppet-strings
- [ ] puppet-agent-rgen
- [ ] puppet-agent-yard
- [ ] python-obsah
- [ ] rubygem-ansi
- [ ] rubygem-auth-sanitizer
- [ ] rubygem-concurrent-ruby
- [ ] rubygem-gssapi
- [ ] rubygem-kafo
- [ ] rubygem-kafo_parsers
- [ ] rubygem-kafo_wizards
- [ ] rubygem-rake-compiler
- [ ] rubygem-rb-inotify

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
