### PR TITLE
EL10 rebuild: core-apps (redfish_client..webrick, 5 packages)

### DIFF
--- a/packages/foreman/rubygem-redfish_client/rubygem-redfish_client.spec
+++ b/packages/foreman/rubygem-redfish_client/rubygem-redfish_client.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.9.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Simple Redfish client library
 License: Apache-2.0
 URL: https://github.com/xlab-steampunk/redfish-client-ruby
@@ -67,6 +67,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/redfish_client.gemspec
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.9.0-2
+- Rebuild for EL10
+
 * Sun Jul 19 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.9.0-1
 - Update to 0.9.0
 

--- a/packages/foreman/rubygem-rsec/rubygem-rsec.spec
+++ b/packages/foreman/rubygem-rsec/rubygem-rsec.spec
@@ -6,7 +6,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.4.3
-Release: 5%{?dist}
+Release: 6%{?dist}
 Summary: Extreme Fast Parser Combinator for Ruby
 Group: Development/Languages
 License: Ruby or BSD
@@ -80,6 +80,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.4.3-6
+- Rebuild for EL10
+
 * Thu Mar 11 2021 Eric D. Helms <ericdhelms@gmail.com> - 0.4.3-5
 - Rebuild against rh-ruby27
 

--- a/packages/foreman/rubygem-rubyipmi/rubygem-rubyipmi.spec
+++ b/packages/foreman/rubygem-rubyipmi/rubygem-rubyipmi.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.13.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: A ruby wrapper for ipmi command line tools that supports ipmitool and freeipmi
 License: LGPLv2.1
 URL: https://github.com/logicminds/rubyipmi
@@ -72,6 +72,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/rubyipmi.gemspec
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.13.0-3
+- Rebuild for EL10
+
 * Thu Apr 30 2026 Arvind Jangir <ajangir@redhat.com> 0.13.0-2
 - Add which as dependency
 

--- a/packages/foreman/rubygem-server_sent_events/rubygem-server_sent_events.spec
+++ b/packages/foreman/rubygem-server_sent_events/rubygem-server_sent_events.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.1.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Library for dealing with server-sent events
 License: Apache-2.0
 URL: https://github.com/xlab-si/server-sent-events-ruby
@@ -66,6 +66,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/server_sent_events.gemspec
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.1.3-2
+- Rebuild for EL10
+
 * Tue Aug 16 2022 Foreman Packaging Automation <packaging@theforeman.org> 0.1.3-1
 - Update to 0.1.3
 

--- a/packages/foreman/rubygem-webrick/rubygem-webrick.spec
+++ b/packages/foreman/rubygem-webrick/rubygem-webrick.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.9.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: HTTP server toolkit
 License: Ruby and BSD-2-Clause
 URL: https://github.com/ruby/webrick
@@ -61,6 +61,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/webrick.gemspec
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.9.2-2
+- Rebuild for EL10
+
 * Wed Dec 03 2025 Foreman Packaging Automation <packaging@theforeman.org> - 1.9.2-1
 - Update to 1.9.2
 


### PR DESCRIPTION
## EL10 Rebuild — core-apps

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (5)

- [ ] rubygem-redfish_client
- [ ] rubygem-rsec
- [ ] rubygem-rubyipmi
- [ ] rubygem-server_sent_events
- [ ] rubygem-webrick

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
