### PR TITLE
Rebuild rubygem-foreman-tasks for EL10

### DIFF
--- a/packages/plugins/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
+++ b/packages/plugins/rubygem-foreman-tasks/rubygem-foreman-tasks.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 13.1.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman plugin for showing tasks information for resources and users
 License: GPLv3
 URL: https://github.com/theforeman/foreman-tasks
@@ -154,6 +154,9 @@ type foreman-selinux-relabel >/dev/null 2>&1 && foreman-selinux-relabel 2>&1 >/d
 %{foreman_plugin_log}
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 13.1.0-2
+- Rebuild for EL10
+
 * Mon Jul 13 2026 Adam Lazík <alazik@redhat.com> - 13.1.0-1
 - Update to 13.1.0
 


### PR DESCRIPTION
## EL10 Rebuild — rubygem-foreman-tasks

Bump release for EL10 rebuild.

**Note:** This will fail CI until foreman core (foreman-assets, foreman-plugin) and npm packages (npm(@theforeman/builder)) are rebuilt for EL10.

### Packages (1)

- [ ] rubygem-foreman-tasks

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).