### PR TITLE
EL10 rebuild: plugins-tier2 (smart_proxy_discovery..smart_proxy_shellhooks, 17 packages)

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_discovery/rubygem-smart_proxy_discovery.spec
+++ b/packages/plugins/rubygem-smart_proxy_discovery/rubygem-smart_proxy_discovery.spec
@@ -10,7 +10,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.0.5
-Release: 10%{?foremandist}%{?dist}
+Release: 11%{?foremandist}%{?dist}
 Summary: Discovery plugin for Foreman's smart proxy
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_discovery
@@ -81,6 +81,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/discovery.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.5-11
+- Rebuild for EL10
+
 * Thu Mar 07 2024 nofaralfasi <nalfassi@redhat.com> 1.0.5-10
 - Regenerate spec file based on the latest template
 

--- a/packages/plugins/rubygem-smart_proxy_discovery_image/rubygem-smart_proxy_discovery_image.spec
+++ b/packages/plugins/rubygem-smart_proxy_discovery_image/rubygem-smart_proxy_discovery_image.spec
@@ -17,7 +17,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.6.0
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Summary: FDI API for Foreman Smart-Proxy
 Group: Applications/Internet
 License: GPLv3
@@ -109,6 +109,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/discovery_image.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.6.0-3
+- Rebuild for EL10
+
 * Mon May 09 2022 Eric D. Helms <ericdhelms@gmail.com> - 1.6.0-2
 - Drop unused smart_proxy_dynflow_core_bundlerd_dir macro
 

--- a/packages/plugins/rubygem-smart_proxy_dns_dnsmasq/rubygem-smart_proxy_dns_dnsmasq.spec
+++ b/packages/plugins/rubygem-smart_proxy_dns_dnsmasq/rubygem-smart_proxy_dns_dnsmasq.spec
@@ -17,7 +17,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.6
-Release: 3%{?foremandist}%{?dist}
+Release: 4%{?foremandist}%{?dist}
 Summary: dnsmasq DNS provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -108,6 +108,9 @@ mv %{buildroot}%{gem_instdir}/config/dns_dnsmasq.yml \
 %{gem_instdir}/test
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.6-4
+- Rebuild for EL10
+
 * Mon Jan 10 2022 Evgeni Golov - 0.6-3
 - use versioned obsoletes for proxy plugins
 

--- a/packages/plugins/rubygem-smart_proxy_dns_infoblox/rubygem-smart_proxy_dns_infoblox.spec
+++ b/packages/plugins/rubygem-smart_proxy_dns_infoblox/rubygem-smart_proxy_dns_infoblox.spec
@@ -17,7 +17,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.2.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Infoblox DNS provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -104,6 +104,9 @@ mv %{buildroot}%{gem_instdir}/config/dns_infoblox.yml.example \
 %{gem_instdir}/test
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.2.0-2
+- Rebuild for EL10
+
 * Tue Jul 02 2024 Foreman Packaging Automation <packaging@theforeman.org> - 1.2.0-1
 - Update to 1.2.0
 

--- a/packages/plugins/rubygem-smart_proxy_dns_powerdns/rubygem-smart_proxy_dns_powerdns.spec
+++ b/packages/plugins/rubygem-smart_proxy_dns_powerdns/rubygem-smart_proxy_dns_powerdns.spec
@@ -17,7 +17,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.0
-Release: 8%{?foremandist}%{?dist}
+Release: 9%{?foremandist}%{?dist}
 Summary: PowerDNS DNS provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -108,6 +108,9 @@ mv %{buildroot}%{gem_instdir}/config/dns_powerdns.yml \
 %{gem_instdir}/test
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.0-9
+- Rebuild for EL10
+
 * Mon May 09 2022 Eric D. Helms <ericdhelms@gmail.com> - 1.0.0-8
 - Drop unused smart_proxy_dynflow_core_bundlerd_dir macro
 

--- a/packages/plugins/rubygem-smart_proxy_dns_route53/rubygem-smart_proxy_dns_route53.spec
+++ b/packages/plugins/rubygem-smart_proxy_dns_route53/rubygem-smart_proxy_dns_route53.spec
@@ -17,7 +17,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 3.0.1
-Release: 9%{?foremandist}%{?dist}
+Release: 10%{?foremandist}%{?dist}
 Summary: Route 53 DNS provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -109,6 +109,9 @@ mv %{buildroot}%{gem_instdir}/config/dns_route53.yml \
 %{gem_instdir}/test
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.0.1-10
+- Rebuild for EL10
+
 * Mon May 09 2022 Eric D. Helms <ericdhelms@gmail.com> - 3.0.1-9
 - Drop unused smart_proxy_dynflow_core_bundlerd_dir macro
 

--- a/packages/plugins/rubygem-smart_proxy_dynflow/rubygem-smart_proxy_dynflow.spec
+++ b/packages/plugins/rubygem-smart_proxy_dynflow/rubygem-smart_proxy_dynflow.spec
@@ -10,7 +10,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.0.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Dynflow runtime for Foreman smart proxy
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_dynflow
@@ -84,6 +84,9 @@ mkdir -p %{buildroot}%{foreman_proxy_statedir}/dynflow
 %{gem_instdir}/Gemfile
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.0-2
+- Rebuild for EL10
+
 * Tue Jan 06 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.0.0-1
 - Update to 1.0.0
 

--- a/packages/plugins/rubygem-smart_proxy_hdm/rubygem-smart_proxy_hdm.spec
+++ b/packages/plugins/rubygem-smart_proxy_hdm/rubygem-smart_proxy_hdm.spec
@@ -10,7 +10,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.0.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: An HDM Plugin for Foreman's smart proxy
 License: GPLv3
 URL: https://github.com/betadots/smart_proxy_hdm
@@ -80,6 +80,9 @@ mv %{buildroot}%{gem_instdir}/config/hdm.yml \
 %{gem_instdir}/test
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.0-2
+- Rebuild for EL10
+
 * Sun May 18 2025 Foreman Packaging Automation <packaging@theforeman.org> - 1.0.0-1
 - Update to 1.0.0
 

--- a/packages/plugins/rubygem-smart_proxy_monitoring/rubygem-smart_proxy_monitoring.spec
+++ b/packages/plugins/rubygem-smart_proxy_monitoring/rubygem-smart_proxy_monitoring.spec
@@ -10,7 +10,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.4.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Monitoring plug-in for Foreman's smart proxy
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_monitoring
@@ -91,6 +91,9 @@ mkdir -p %{buildroot}%{_sysconfdir}/foreman-proxy/monitoring
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.4.0-2
+- Rebuild for EL10
+
 * Tue Dec 03 2024 Foreman Packaging Automation <packaging@theforeman.org> - 0.4.0-1
 - Update to 0.4.0
 

--- a/packages/plugins/rubygem-smart_proxy_omaha/rubygem-smart_proxy_omaha.spec
+++ b/packages/plugins/rubygem-smart_proxy_omaha/rubygem-smart_proxy_omaha.spec
@@ -21,7 +21,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.1.0
-Release: 7%{?foremandist}%{?dist}
+Release: 8%{?foremandist}%{?dist}
 Summary: Omaha protocol support for smart-proxy
 Group: Applications/Internet
 License: GPLv3
@@ -133,6 +133,9 @@ mkdir -p %{buildroot}%{content_dir}
 %{gem_instdir}/test
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.1.0-8
+- Rebuild for EL10
+
 * Mon May 09 2022 Eric D. Helms <ericdhelms@gmail.com> - 0.1.0-7
 - Drop unused smart_proxy_dynflow_core_bundlerd_dir macro
 

--- a/packages/plugins/rubygem-smart_proxy_openbolt/rubygem-smart_proxy_openbolt.spec
+++ b/packages/plugins/rubygem-smart_proxy_openbolt/rubygem-smart_proxy_openbolt.spec
@@ -10,7 +10,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.2.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Smart Proxy plugin for OpenBolt integration
 License: GPL-3.0-only
 URL: https://github.com/overlookinfra/smart_proxy_openbolt
@@ -79,6 +79,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/openbolt.yml \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.2.0-2
+- Rebuild for EL10
+
 * Fri May 01 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.2.0-1
 - Update to 1.2.0
 

--- a/packages/plugins/rubygem-smart_proxy_openscap/rubygem-smart_proxy_openscap.spec
+++ b/packages/plugins/rubygem-smart_proxy_openscap/rubygem-smart_proxy_openscap.spec
@@ -22,7 +22,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.12.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: OpenSCAP plug-in for Foreman's smart-proxy
 Group: Applications/Internet
 License: GPLv3+
@@ -148,6 +148,9 @@ ln -sv %{content_dir} %{buildroot}%{foreman_proxy_dir}/openscap
 %{gem_instdir}/test
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.12.1-2
+- Rebuild for EL10
+
 * Mon Apr 14 2025 Adam Ruzicka <aruzicka@redhat.com> - 0.12.1-1
 - Update to 0.12.1
 

--- a/packages/plugins/rubygem-smart_proxy_pulp/rubygem-smart_proxy_pulp.spec
+++ b/packages/plugins/rubygem-smart_proxy_pulp/rubygem-smart_proxy_pulp.spec
@@ -10,7 +10,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.4.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Basic Pulp support for Foreman Smart-Proxy
 License: GPLv3
 URL: https://github.com/theforeman/smart-proxy-pulp-plugin
@@ -81,6 +81,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/pulpcore.yml.example \
 %{gem_instdir}/Gemfile
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.4.0-2
+- Rebuild for EL10
+
 * Mon Oct 14 2024 Foreman Packaging Automation <packaging@theforeman.org> - 3.4.0-1
 - Update to 3.4.0
 

--- a/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
+++ b/packages/plugins/rubygem-smart_proxy_remote_execution_ssh/rubygem-smart_proxy_remote_execution_ssh.spec
@@ -10,7 +10,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 1.0.3
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Ssh remote execution provider for Foreman Smart-Proxy
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_remote_execution_ssh
@@ -90,6 +90,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/remote_execution_ssh.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.3-2
+- Rebuild for EL10
+
 * Wed May 20 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.0.3-1
 - Update to 1.0.3
 

--- a/packages/plugins/rubygem-smart_proxy_request_forwarder/rubygem-smart_proxy_request_forwarder.spec
+++ b/packages/plugins/rubygem-smart_proxy_request_forwarder/rubygem-smart_proxy_request_forwarder.spec
@@ -10,7 +10,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.0.3
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Request forwarder for Foreman smart proxy
 License: GPL-3.0-only
 URL: https://github.com/ATIX-AG/smart_proxy_request_forwarder
@@ -82,6 +82,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/request_forwarder.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.0.3-2
+- Rebuild for EL10
+
 * Mon Jul 07 2025 Nadja Heitmann <nadjah@atix.de> - 0.0.3-1
 - Update to 0.0.3
 

--- a/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
+++ b/packages/plugins/rubygem-smart_proxy_salt/rubygem-smart_proxy_salt.spec
@@ -15,7 +15,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.0.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: SaltStack Plug-In for Foreman's Smart Proxy
 License: GPLv3
 URL: https://github.com/theforeman/smart_proxy_salt
@@ -142,6 +142,9 @@ if [ ! -f %{salt_state_grains_dir}/autosign_key ] ; then
 fi
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.0.0-2
+- Rebuild for EL10
+
 * Thu Jan 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.0-1
 - Update to 7.0.0
 

--- a/packages/plugins/rubygem-smart_proxy_shellhooks/rubygem-smart_proxy_shellhooks.spec
+++ b/packages/plugins/rubygem-smart_proxy_shellhooks/rubygem-smart_proxy_shellhooks.spec
@@ -17,7 +17,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.9.3
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Execute scripts via REST API from Foreman Webhooks plugin
 Group: Applications/Internet
 License: GPLv3
@@ -109,6 +109,9 @@ mv %{buildroot}%{gem_instdir}/examples/* %{buildroot}%{foreman_proxy_statedir}/%
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.9.3-2
+- Rebuild for EL10
+
 * Wed May 15 2024 Adam Ruzicka <aruzicka@redhat.com> - 0.9.3-1
 - Release rubygem-smart_proxy_shellhooks 0.9.3
 


### PR DESCRIPTION
## EL10 Rebuild — plugins-tier2

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (17)

- [ ] rubygem-smart_proxy_discovery
- [ ] rubygem-smart_proxy_discovery_image
- [ ] rubygem-smart_proxy_dns_dnsmasq
- [ ] rubygem-smart_proxy_dns_infoblox
- [ ] rubygem-smart_proxy_dns_powerdns
- [ ] rubygem-smart_proxy_dns_route53
- [ ] rubygem-smart_proxy_dynflow
- [ ] rubygem-smart_proxy_hdm
- [ ] rubygem-smart_proxy_monitoring
- [ ] rubygem-smart_proxy_omaha
- [ ] rubygem-smart_proxy_openbolt
- [ ] rubygem-smart_proxy_openscap
- [ ] rubygem-smart_proxy_pulp
- [ ] rubygem-smart_proxy_remote_execution_ssh
- [ ] rubygem-smart_proxy_request_forwarder
- [ ] rubygem-smart_proxy_salt
- [ ] rubygem-smart_proxy_shellhooks

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
