### PR TITLE
Add the lockfile instead of the npm cache tarball

### DIFF
--- a/add_npm_package.sh
+++ b/add_npm_package.sh
@@ -75,8 +75,8 @@ generate_npm_package() {
   echo "FINISHED"
 
   if [ "$STRATEGY" = "bundle" ]; then
-    echo -e "Adding npmjs cache binary... - "
-    git add $PACKAGE_DIR/*-registry.npmjs.org.tgz
+    echo -e "Adding lockfile... - "
+    git add $PACKAGE_DIR/*-package-lock.json
     echo "FINISHED"
   fi
   echo -e "Adding spec to git... - "


### PR DESCRIPTION
Depends on theforeman/npm2rpm#100, which replaces the generated npm cache tarball with a committed `package-lock.json`.

Without this the bundle branch aborts: the `*-registry.npmjs.org.tgz` glob matches nothing, `git add` errors on the pathspec, and the script runs under `bash -e`. The lockfile also needs adding as a plain file — the annex step only globs `*.tgz`.

Draft until npm2rpm#100 lands.