### PR TITLE
EL10 rebuild: python packages (markupsafe..pexpect, 10 packages)

### DIFF
--- a/packages/plugins/python-docutils/python-docutils.spec
+++ b/packages/plugins/python-docutils/python-docutils.spec
@@ -8,7 +8,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.19
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Docutils -- Python Documentation Utilities
 
 License:        public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt)
@@ -78,6 +78,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.19-4
+- Rebuild for EL10
+
 * Wed Jan 29 2025 Odilon Sousa <osousa@redhat.com> - 0.19-3
 - Rebuild against python 3.12
 

--- a/packages/plugins/python-markupsafe/python-markupsafe.spec
+++ b/packages/plugins/python-markupsafe/python-markupsafe.spec
@@ -16,7 +16,7 @@
 
 Name:           python-%{srcname}
 Version:        3.0.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Safely add untrusted strings to HTML/XML markup
 
 License:        BSD-3-Clause
@@ -89,6 +89,9 @@ CFLAGS="${CFLAGS:-${RPM_OPT_FLAGS}}" LDFLAGS="${LDFLAGS:-${RPM_LD_FLAGS}}"\
 %endif
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.0.2-3
+- Rebuild for EL10
+
 * Mon Feb 03 2025 Odilon Sousa <osousa@redhat.com> - 3.0.2-2
 - Rebuild against python 3.12
 

--- a/packages/plugins/python-packaging/python-packaging.spec
+++ b/packages/plugins/python-packaging/python-packaging.spec
@@ -8,7 +8,7 @@
 
 Name:           python-%{pypi_name}
 Version:        21.3
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Core utilities for Python packages
 
 License:        BSD-2-Clause or Apache-2.0
@@ -65,6 +65,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 21.3-5
+- Rebuild for EL10
+
 * Wed Jan 29 2025 Odilon Sousa <osousa@redhat.com> - 21.3-4
 - Rebuild against python 3.12
 

--- a/packages/plugins/python-pbr/python-pbr.spec
+++ b/packages/plugins/python-pbr/python-pbr.spec
@@ -6,7 +6,7 @@
 
 Name:           python-%{pypi_name}
 Version:        5.8.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Python Build Reasonableness
 
 License:        None
@@ -58,6 +58,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.8.0-7
+- Rebuild for EL10
+
 * Wed Jan 29 2025 Odilon Sousa <osousa@redhat.com> - 5.8.0-6
 - Rebuild against python 3.12
 

--- a/packages/plugins/python-pexpect/python-pexpect.spec
+++ b/packages/plugins/python-pexpect/python-pexpect.spec
@@ -8,7 +8,7 @@
 
 Name:           python-%{pypi_name}
 Version:        4.8.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Pexpect allows easy control of interactive console applications
 
 License:        ISC license
@@ -64,6 +64,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 4.8.0-5
+- Rebuild for EL10
+
 * Wed Jan 29 2025 Odilon Sousa <osousa@redhat.com> - 4.8.0-4
 - Rebuild against python 3.12
 

--- a/packages/plugins/python-ptyprocess/python-ptyprocess.spec
+++ b/packages/plugins/python-ptyprocess/python-ptyprocess.spec
@@ -8,7 +8,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.7.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Run a subprocess in a pseudo terminal
 
 License:        None
@@ -62,6 +62,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.7.0-5
+- Rebuild for EL10
+
 * Wed Jan 29 2025 Odilon Sousa <osousa@redhat.com> - 0.7.0-4
 - Add python3.12 macro
 

--- a/packages/plugins/python-pyparsing/python-pyparsing.spec
+++ b/packages/plugins/python-pyparsing/python-pyparsing.spec
@@ -8,7 +8,7 @@
 
 Name:           python-%{pypi_name}
 Version:        2.4.7
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Python parsing module
 
 License:        MIT License
@@ -65,6 +65,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.4.7-6
+- Rebuild for EL10
+
 * Wed Jan 29 2025 Odilon Sousa <osousa@redhat.com> - 2.4.7-5
 - Rebuild against python 3.12
 

--- a/packages/plugins/python-resolvelib/python-resolvelib.spec
+++ b/packages/plugins/python-resolvelib/python-resolvelib.spec
@@ -6,7 +6,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.0.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Resolve abstract dependencies into concrete ones
 
 License:        ISC License
@@ -16,7 +16,6 @@ BuildArch:      noarch
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python%{python3_pkgversion}-devel
-BuildRequires:  python%{python3_pkgversion}-rpm-macros
 BuildRequires:  python%{python3_pkgversion}-setuptools
 BuildRequires:  python%{python3_pkgversion}-wheel
 BuildRequires:  python%{python3_pkgversion}-pip
@@ -51,6 +50,11 @@ Summary:        %{summary}
 
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.1-4
+- Rebuild for EL10
+- Drop redundant python3.12-rpm-macros BuildRequires; not available on EL10 and
+  already satisfied transitively via python3.12-devel/pyproject-rpm-macros
+
 * Mon Feb 03 2025 Odilon Sousa <osousa@redhat.com> - 1.0.1-3
 - Provides python3.12-resolvelib
 

--- a/packages/plugins/python-semantic-version/python-semantic-version.spec
+++ b/packages/plugins/python-semantic-version/python-semantic-version.spec
@@ -6,7 +6,7 @@
 
 Name:           python-%{pypi_name}
 Version:        2.10.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        A library implementing the 'SemVer' scheme
 
 License:        BSD
@@ -57,6 +57,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.10.0-7
+- Rebuild for EL10
+
 * Fri Jan 31 2025 Odilon Sousa <osousa@redhat.com> - 2.10.0-6
 - Rebuild against python 3.12
 

--- a/packages/plugins/python-six/python-six.spec
+++ b/packages/plugins/python-six/python-six.spec
@@ -6,7 +6,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.17.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python 2 and 3 compatibility utilities
 
 License:        MIT
@@ -57,6 +57,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.17.0-2
+- Rebuild for EL10
+
 * Wed Dec 11 2024 Foreman Packaging Automation <packaging@theforeman.org> - 1.17.0-1
 - Update to 1.17.0
 


### PR DESCRIPTION
## EL10 Rebuild — Python packages

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (10)

- [ ] python-markupsafe
- [ ] python-ptyprocess
- [ ] python-pyparsing
- [ ] python-six
- [ ] python-pbr
- [ ] python-docutils
- [ ] python-resolvelib
- [ ] python-semantic-version
- [ ] python-packaging
- [ ] python-pexpect

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).