### PR TITLE
Re-enable EL10 repoclosure checks

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -125,9 +125,12 @@ foreman_packages:
     copr_projects:
       - "{{ hostvars['foreman-copr'] }}"
     repoclosure_target_repos:
+      el10:
+        - "el10-foreman-{{ foreman_version }}-staging"
       el9:
         - "el9-foreman-{{ foreman_version }}-staging"
     repoclosure_lookaside_repos:
+      el10: "{{ hostvars['foreman-staging-repoclosure-el10']['repoclosure_lookaside_repos']['el10'] }}"
       el9: "{{ hostvars['foreman-staging-repoclosure-el9']['repoclosure_lookaside_repos']['el9'] }}"
   children:
     foreman_core_packages: {}
@@ -141,9 +144,12 @@ plugin_packages:
       - "{{ hostvars['plugins-copr'] }}"
     package_base_dir: 'packages/plugins/'
     repoclosure_target_repos:
+      el10:
+        - "el10-foreman-plugins-{{ foreman_version }}-staging"
       el9:
         - "el9-foreman-plugins-{{ foreman_version }}-staging"
     repoclosure_lookaside_repos:
+      el10: "{{ hostvars['plugins-staging-repoclosure-el10']['repoclosure_lookaside_repos']['el10'] }}"
       el9: "{{ hostvars['plugins-staging-repoclosure-el9']['repoclosure_lookaside_repos']['el9'] }}"
   children:
     foreman_plugin_packages: {}
@@ -564,11 +570,14 @@ foreman_client_packages:
       - "{{ hostvars['client-copr'] }}"
     package_base_dir: 'packages/client/'
     repoclosure_target_repos:
+      el10:
+        - "el10-foreman-client-{{ foreman_version }}-staging"
       el9:
         - "el9-foreman-client-{{ foreman_version }}-staging"
       el8:
         - "el8-foreman-client-{{ foreman_version }}-staging"
     repoclosure_lookaside_repos:
+      el10: "{{ hostvars['foreman-client-staging-repoclosure-el10']['repoclosure_lookaside_repos']['el10'] }}"
       el9: "{{ hostvars['foreman-client-staging-repoclosure-el9']['repoclosure_lookaside_repos']['el9'] }}"
       el8: "{{ hostvars['foreman-client-staging-repoclosure-el8']['repoclosure_lookaside_repos']['el8'] }}"
       leap156:
@@ -592,9 +601,12 @@ katello_packages:
       - "{{ hostvars['katello-copr'] }}"
     package_base_dir: 'packages/katello/'
     repoclosure_target_repos:
+      el10:
+        - "el10-katello-{{ katello_version }}-staging"
       el9:
         - "el9-katello-{{ katello_version }}-staging"
     repoclosure_lookaside_repos:
+      el10: "{{ hostvars['katello-staging-repoclosure-el10']['repoclosure_lookaside_repos']['el10'] }}"
       el9: "{{ hostvars['katello-staging-repoclosure-el9']['repoclosure_lookaside_repos']['el9'] }}"
   children:
     satellite_packages: {}
@@ -905,6 +917,15 @@ foreman_proxy_other_plugin_packages_tier2:
 
 repoclosures:
   hosts:
+    foreman-staging-repoclosure-el10:
+      repoclosure_target_repos:
+        el10:
+          - "el10-foreman-{{ foreman_version }}-staging"
+      repoclosure_target_dist: el10
+      repoclosure_lookaside_repos:
+        el10:
+          - el10-baseos
+          - el10-appstream
     foreman-staging-repoclosure-el9:
       repoclosure_target_repos:
         el9:
@@ -917,6 +938,15 @@ repoclosures:
           - "el9-openvox-{{ puppet_version }}"
           - "el9-candlepin-{{ candlepin_version }}-staging"
           - "el9-foreman-plugins-{{ foreman_version }}-staging"
+    plugins-staging-repoclosure-el10:
+      repoclosure_target_repos:
+        el10:
+          - "el10-foreman-plugins-{{ foreman_version }}-staging"
+      repoclosure_target_dist: el10
+      repoclosure_lookaside_repos:
+        el10:
+          - el10-baseos
+          - el10-appstream
     plugins-staging-repoclosure-el9:
       repoclosure_target_repos:
         el9:
@@ -929,6 +959,15 @@ repoclosures:
           - el9-configmanagement-salt
           - "el9-openvox-{{ puppet_version }}"
           - "el9-foreman-{{ foreman_version }}-staging"
+    katello-staging-repoclosure-el10:
+      repoclosure_target_repos:
+        el10:
+          - "el10-katello-{{ katello_version }}-staging"
+      repoclosure_target_dist: el10
+      repoclosure_lookaside_repos:
+        el10:
+          - el10-baseos
+          - el10-appstream
     katello-staging-repoclosure-el9:
       repoclosure_target_repos:
         el9:
@@ -942,6 +981,15 @@ repoclosures:
           - "el9-foreman-{{ foreman_version }}-staging"
           - "el9-foreman-plugins-{{ foreman_version }}-staging"
           - "el9-candlepin-{{ candlepin_version }}-staging"
+    foreman-client-staging-repoclosure-el10:
+      repoclosure_target_repos:
+        el10:
+          - "el10-foreman-client-{{ foreman_version }}-staging"
+      repoclosure_target_dist: el10
+      repoclosure_lookaside_repos:
+        el10:
+          - el10-baseos
+          - el10-appstream
     foreman-client-staging-repoclosure-el9:
       repoclosure_target_repos:
         el9:
@@ -973,11 +1021,14 @@ foreman_release_packages:
       - "{{ hostvars['client-copr'] }}"
     package_base_dir: 'packages/foreman/'
     repoclosure_target_repos:
+      el10:
+        - "el10-foreman-client-{{ foreman_version }}-staging"
       el9:
         - "el9-foreman-client-{{ foreman_version }}-staging"
       el8:
         - "el8-foreman-client-{{ foreman_version }}-staging"
     repoclosure_lookaside_repos:
+      el10: "{{ hostvars['foreman-client-staging-repoclosure-el10']['repoclosure_lookaside_repos']['el10'] }}"
       el9: "{{ hostvars['foreman-client-staging-repoclosure-el9']['repoclosure_lookaside_repos']['el9'] }}"
       el8: "{{ hostvars['foreman-client-staging-repoclosure-el8']['repoclosure_lookaside_repos']['el8'] }}"
   hosts:


### PR DESCRIPTION
## Summary
- Reverts 6c3834efc which temporarily disabled EL10 repoclosure during the initial rebuild
- The EL10 repos are now populated enough for repoclosure to pass
- Re-enables repoclosure for foreman, plugins, katello, and client EL10 staging repos

Fixes the `foreman-client-nightly-rpm-pipeline` failure where `obal repoclosure foreman-client-staging-repoclosure-el10` failed with "invalid choice" because the target was removed from the inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)