### PR TITLE
EL10 rebuild: plugins-tier2 (foreman_azure_rm..foreman_dlm, 9 packages)

### DIFF
--- a/packages/plugins/rubygem-foreman_azure_rm/rubygem-foreman_azure_rm.spec
+++ b/packages/plugins/rubygem-foreman_azure_rm/rubygem-foreman_azure_rm.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.0.4
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Azure Resource Manager as a compute resource for The Foreman
 License: GPLv3
 URL: https://github.com/theforeman/foreman_azure_rm
@@ -82,6 +82,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.0.4-2
+- Rebuild for EL10
+
 * Wed May 28 2025 Chris Roberts <chrobert@redhat.com> - 3.0.4-1
 - Update to 3.0.4
 

--- a/packages/plugins/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
+++ b/packages/plugins/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 23.2.4
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Create boot disks to provision hosts with Foreman
 License: GPLv3
 URL: https://github.com/theforeman/foreman_bootdisk
@@ -99,6 +99,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 23.2.4-2
+- Rebuild for EL10
+
 * Sun May 17 2026 Foreman Packaging Automation <packaging@theforeman.org> - 23.2.4-1
 - Update to 23.2.4
 

--- a/packages/plugins/rubygem-foreman_concrete/rubygem-foreman_concrete.spec
+++ b/packages/plugins/rubygem-foreman_concrete/rubygem-foreman_concrete.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.0.0
-Release: 4%{?foremandist}%{?dist}
+Release: 5%{?foremandist}%{?dist}
 Summary: Foreman plug-in to send exceptions to sentry
 License: GPLv3
 URL: https://github.com/timogoebel/foreman_concrete
@@ -74,6 +74,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.0-5
+- Rebuild for EL10
+
 * Thu Jul 14 2022 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.0.0-4
 - Regenerate spec
 - Allow a newer sentry-raven

--- a/packages/plugins/rubygem-foreman_cve_scanner/rubygem-foreman_cve_scanner.spec
+++ b/packages/plugins/rubygem-foreman_cve_scanner/rubygem-foreman_cve_scanner.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.6.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Run CVE scan on host and collect report
 License: GPLv3
 URL: https://github.com/ATIX-AG/foreman_cve_scanner
@@ -91,6 +91,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.6.0-2
+- Rebuild for EL10
+
 * Wed Jun 03 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.6.0-1
 - Update to 0.6.0
 

--- a/packages/plugins/rubygem-foreman_datacenter/rubygem-foreman_datacenter.spec
+++ b/packages/plugins/rubygem-foreman_datacenter/rubygem-foreman_datacenter.spec
@@ -9,7 +9,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 2.3.0
-Release: 6%{?foremandist}%{?dist}
+Release: 7%{?foremandist}%{?dist}
 Summary: A plugin that lets you document your servers in a datacenter
 Group: Applications/Systems
 License: GPLv3
@@ -107,6 +107,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.3.0-7
+- Rebuild for EL10
+
 * Wed Aug 24 2022 Evgeni Golov - 2.3.0-6
 - Refs #35409 - Include sprockets assets
 

--- a/packages/plugins/rubygem-foreman_default_hostgroup/rubygem-foreman_default_hostgroup.spec
+++ b/packages/plugins/rubygem-foreman_default_hostgroup/rubygem-foreman_default_hostgroup.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 7.1.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Default Hostgroup Plugin for Foreman
 License: GPLv3
 URL: https://github.com/theforeman/foreman_default_hostgroup
@@ -73,6 +73,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 7.1.0-2
+- Rebuild for EL10
+
 * Thu Apr 03 2025 Foreman Packaging Automation <packaging@theforeman.org> - 7.1.0-1
 - Update to 7.1.0
 

--- a/packages/plugins/rubygem-foreman_dhcp_browser/rubygem-foreman_dhcp_browser.spec
+++ b/packages/plugins/rubygem-foreman_dhcp_browser/rubygem-foreman_dhcp_browser.spec
@@ -6,7 +6,7 @@
 Summary:    DHCP browser plugin for Foreman
 Name:       rubygem-%{gem_name}
 Version:    0.1.2
-Release:    1%{?foremandist}%{?dist}
+Release:    2%{?foremandist}%{?dist}
 Group:      Applications/Systems
 License:    GPLv3
 URL:        https://github.com/theforeman/foreman_dhcp_browser
@@ -78,6 +78,9 @@ cp -pa .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.1.2-2
+- Rebuild for EL10
+
 * Mon Jan 27 2025 Foreman Packaging Automation <packaging@theforeman.org> - 0.1.2-1
 - Update to 0.1.2
 

--- a/packages/plugins/rubygem-foreman_discovery/rubygem-foreman_discovery.spec
+++ b/packages/plugins/rubygem-foreman_discovery/rubygem-foreman_discovery.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 26.1.3
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: MaaS Discovery Plugin for Foreman
 License: GPLv3
 URL: https://github.com/theforeman/foreman_discovery
@@ -89,6 +89,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 26.1.3-2
+- Rebuild for EL10
+
 * Tue Mar 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 26.1.3-1
 - Update to 26.1.3
 

--- a/packages/plugins/rubygem-foreman_dlm/rubygem-foreman_dlm.spec
+++ b/packages/plugins/rubygem-foreman_dlm/rubygem-foreman_dlm.spec
@@ -8,7 +8,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 4.0.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Distributed Lock Manager for Foreman
 License: GPLv3
 URL: https://github.com/dm-drogeriemarkt/foreman_dlm
@@ -100,6 +100,9 @@ install -Dp -m0644 %{buildroot}%{gem_instdir}/contrib/systemd/%{service_name}.ti
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 4.0.0-2
+- Rebuild for EL10
+
 * Sun May 18 2025 Foreman Packaging Automation <packaging@theforeman.org> - 4.0.0-1
 - Update to 4.0.0
 


### PR DESCRIPTION
## EL10 Rebuild — plugins-tier2

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (9)

- [ ] rubygem-foreman_azure_rm
- [ ] rubygem-foreman_bootdisk
- [ ] rubygem-foreman_concrete
- [ ] rubygem-foreman_cve_scanner
- [ ] rubygem-foreman_datacenter
- [ ] rubygem-foreman_default_hostgroup
- [ ] rubygem-foreman_dhcp_browser
- [ ] rubygem-foreman_discovery
- [ ] rubygem-foreman_dlm

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
