### PR TITLE
EL10 rebuild: plugins-tier2 (foreman_fog_proxmox..foreman_kubevirt, 7 packages)

### DIFF
--- a/packages/plugins/rubygem-foreman_fog_proxmox/rubygem-foreman_fog_proxmox.spec
+++ b/packages/plugins/rubygem-foreman_fog_proxmox/rubygem-foreman_fog_proxmox.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.24.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman plugin that adds Proxmox VE compute resource using fog-proxmox
 License: GPLv3
 URL: https://github.com/theforeman/foreman_fog_proxmox
@@ -104,6 +104,9 @@ fi
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.24.0-2
+- Rebuild for EL10
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.24.0-1
 - Update to 0.24.0
 

--- a/packages/plugins/rubygem-foreman_git_templates/rubygem-foreman_git_templates.spec
+++ b/packages/plugins/rubygem-foreman_git_templates/rubygem-foreman_git_templates.spec
@@ -10,7 +10,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 2.0.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Adds support for using templates from Git repositories
 Group: Applications/Systems
 License: GPLv3
@@ -103,6 +103,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.0.0-2
+- Rebuild for EL10
+
 * Tue May 14 2024 Manuel Laug <laugmanuel@gmail.com> - 2.0.0-1
 - Update foreman_git_templates to 2.0.0
 

--- a/packages/plugins/rubygem-foreman_google/rubygem-foreman_google.spec
+++ b/packages/plugins/rubygem-foreman_google/rubygem-foreman_google.spec
@@ -6,7 +6,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.0.8
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Google Compute Engine plugin for the Foreman
 License: GPLv3
 URL: https://github.com/theforeman/foreman_google
@@ -99,6 +99,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.0.8-2
+- Rebuild for EL10
+
 * Sun May 17 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.0.8-1
 - Update to 3.0.8
 

--- a/packages/plugins/rubygem-foreman_graphite/rubygem-foreman_graphite.spec
+++ b/packages/plugins/rubygem-foreman_graphite/rubygem-foreman_graphite.spec
@@ -9,7 +9,7 @@
 Summary:    Adds graphite integration to Foreman
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    0.0.3
-Release:    10%{?foremandist}%{?dist}
+Release:    11%{?foremandist}%{?dist}
 Group:      Applications/Systems
 License:    GPLv3
 URL:        https://github.com/theforeman/foreman_graphite
@@ -98,6 +98,9 @@ mv %{buildroot}%{gem_instdir}/%{gem_name}.yaml.example %{buildroot}%{foreman_plu
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.0.3-11
+- Rebuild for EL10
+
 * Wed May 21 2025 Zach Huntington-Meath <zhunting@redhat.com> - 0.0.3-10
 - Removed unversioned obsoletes
 

--- a/packages/plugins/rubygem-foreman_hdm/rubygem-foreman_hdm.spec
+++ b/packages/plugins/rubygem-foreman_hdm/rubygem-foreman_hdm.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.1.0
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Summary: Display hiera data in Foreman using HDM
 License: GPLv3
 URL: https://github.com/betadots/foreman_hdm
@@ -90,6 +90,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.1.0-3
+- Rebuild for EL10
+
 * Tue Jul 15 2025 Evgeni Golov - 1.1.0-2
 - Rebuild for removal of theforeman/vendor
 

--- a/packages/plugins/rubygem-foreman_host_extra_validator/rubygem-foreman_host_extra_validator.spec
+++ b/packages/plugins/rubygem-foreman_host_extra_validator/rubygem-foreman_host_extra_validator.spec
@@ -9,7 +9,7 @@
 Summary:    This plugin adds extra validations to a host
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    0.2.2
-Release:    2%{?foremandist}%{?dist}
+Release:    3%{?foremandist}%{?dist}
 Group:      Applications/Systems
 License:    GPLv3
 URL:        https://github.com/theforeman/foreman_host_extra_validator
@@ -89,6 +89,9 @@ cp -pa .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.2.2-3
+- Rebuild for EL10
+
 * Wed May 21 2025 Zach Huntington-Meath <zhunting@redhat.com> - 0.2.2-2
 - Removed unversioned obsoletes
 

--- a/packages/plugins/rubygem-foreman_kubevirt/rubygem-foreman_kubevirt.spec
+++ b/packages/plugins/rubygem-foreman_kubevirt/rubygem-foreman_kubevirt.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.6.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Provision and manage Kubevirt Virtual Machines from Foreman
 License: GPLv3
 URL: https://github.com/theforeman/foreman_kubevirt
@@ -79,6 +79,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.6.0-2
+- Rebuild for EL10
+
 * Tue Mar 17 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.6.0-1
 - Update to 0.6.0
 


### PR DESCRIPTION
Bump release for EL10 rebuild.

Packages:
- rubygem-foreman_fog_proxmox
- rubygem-foreman_git_templates
- rubygem-foreman_google
- rubygem-foreman_graphite
- rubygem-foreman_hdm
- rubygem-foreman_host_extra_validator
- rubygem-foreman_kubevirt