### PR TITLE
EL10 rebuild: plugins-tier2 (foreman_snapshot_management..puppetdb_foreman, 8 packages)

### DIFF
--- a/packages/plugins/rubygem-foreman_snapshot_management/rubygem-foreman_snapshot_management.spec
+++ b/packages/plugins/rubygem-foreman_snapshot_management/rubygem-foreman_snapshot_management.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 4.2.2
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Snapshot Management for machines on virtualization-platforms
 License: GPLv3
 URL: https://www.orcharhino.com
@@ -88,6 +88,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 4.2.2-2
+- Rebuild for EL10
+
 * Fri Mar 27 2026 Foreman Packaging Automation <packaging@theforeman.org> - 4.2.2-1
 - Update to 4.2.2
 

--- a/packages/plugins/rubygem-foreman_statistics/rubygem-foreman_statistics.spec
+++ b/packages/plugins/rubygem-foreman_statistics/rubygem-foreman_statistics.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.1.0
-Release: 4%{?foremandist}%{?dist}
+Release: 5%{?foremandist}%{?dist}
 Summary: Add Statistics and Trends
 License: GPLv3
 URL: https://theforeman.org
@@ -93,6 +93,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.1.0-5
+- Rebuild for EL10
+
 * Tue Jul 15 2025 Evgeni Golov - 2.1.0-4
 - Rebuild for removal of theforeman/vendor
 

--- a/packages/plugins/rubygem-foreman_supervisory_authority/rubygem-foreman_supervisory_authority.spec
+++ b/packages/plugins/rubygem-foreman_supervisory_authority/rubygem-foreman_supervisory_authority.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.2.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: This Foreman plug-in integrates with Elastic APM
 License: GPLv3
 URL: https://github.com/theforeman/foreman_supervisory_authority
@@ -72,6 +72,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.2.0-2
+- Rebuild for EL10
+
 * Wed Aug 21 2024 Manuel Laug - 0.2.0-1
 - Update foreman_supervisory_authority to 0.2.0
 

--- a/packages/plugins/rubygem-foreman_templates/rubygem-foreman_templates.spec
+++ b/packages/plugins/rubygem-foreman_templates/rubygem-foreman_templates.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 11.0.2
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Template-syncing engine for Foreman
 License: GPLv3
 URL: https://github.com/theforeman/foreman_templates
@@ -93,6 +93,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 11.0.2-2
+- Rebuild for EL10
+
 * Fri May 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 11.0.2-1
 - Update to 11.0.2
 

--- a/packages/plugins/rubygem-foreman_vault/rubygem-foreman_vault.spec
+++ b/packages/plugins/rubygem-foreman_vault/rubygem-foreman_vault.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.0.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Adds support for using credentials from Hashicorp Vault
 License: GPLv3
 URL: https://github.com/dm-drogeriemarkt/foreman_vault
@@ -75,6 +75,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.0.0-2
+- Rebuild for EL10
+
 * Sun May 18 2025 Foreman Packaging Automation <packaging@theforeman.org> - 3.0.0-1
 - Update to 3.0.0
 

--- a/packages/plugins/rubygem-foreman_vmwareannotations/rubygem-foreman_vmwareannotations.spec
+++ b/packages/plugins/rubygem-foreman_vmwareannotations/rubygem-foreman_vmwareannotations.spec
@@ -8,7 +8,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.0.1
-Release: 6%{?foremandist}%{?dist}
+Release: 7%{?foremandist}%{?dist}
 Summary: This plug-in copies the host comment to VMWare annotations in The Foreman
 Group: Applications/Systems
 License: GPLv3
@@ -92,6 +92,9 @@ cp -pa .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.0.1-7
+- Rebuild for EL10
+
 * Mon May 09 2022 Evgeni Golov - 0.0.1-6
 - log plugin installation in posttrans
 

--- a/packages/plugins/rubygem-foreman_webhooks/rubygem-foreman_webhooks.spec
+++ b/packages/plugins/rubygem-foreman_webhooks/rubygem-foreman_webhooks.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 6.0.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Configure webhooks for Foreman
 License: GPLv3
 URL: https://github.com/theforeman/foreman_webhooks
@@ -92,6 +92,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 6.0.0-2
+- Rebuild for EL10
+
 * Tue Jun 16 2026 Foreman Packaging Automation <packaging@theforeman.org> - 6.0.0-1
 - Update to 6.0.0
 

--- a/packages/plugins/rubygem-puppetdb_foreman/rubygem-puppetdb_foreman.spec
+++ b/packages/plugins/rubygem-puppetdb_foreman/rubygem-puppetdb_foreman.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 6.0.2
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: This is a Foreman plugin to interact with PuppetDB
 License: GPLv3
 URL: https://www.github.com/theforeman/puppetdb_foreman
@@ -76,6 +76,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 6.0.2-2
+- Rebuild for EL10
+
 * Tue May 16 2023 Foreman Packaging Automation <packaging@theforeman.org> 6.0.2-1
 - Update to 6.0.2
 


### PR DESCRIPTION
## EL10 Rebuild — plugins-tier2

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (8)

- [ ] rubygem-foreman_snapshot_management
- [ ] rubygem-foreman_statistics
- [ ] rubygem-foreman_supervisory_authority
- [ ] rubygem-foreman_templates
- [ ] rubygem-foreman_vault
- [ ] rubygem-foreman_vmwareannotations
- [ ] rubygem-foreman_webhooks
- [ ] rubygem-puppetdb_foreman

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
