### PR TITLE
Rebuild foreman for EL10

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -6,7 +6,7 @@
 %global dynflow_sidekiq_service_name dynflow-sidekiq@
 %global rake /usr/bin/rake
 
-%global release 2
+%global release 3
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -860,6 +860,9 @@ exit 0
 %endif
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.3.develop
+- Rebuild for EL10
+
 * Thu May 28 2026 Oleh Fedorenko <ofedoren@redhat.com> - 5.0.0-0.2.develop
 - Bump safemode to 2.0.0
 


### PR DESCRIPTION
## EL10 Rebuild — core-apps

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (1)

- [ ] foreman

### Scratch Builds

- EL10: https://copr.fedorainfracloud.org/coprs/build/10798496
- EL9: https://copr.fedorainfracloud.org/coprs/build/10798497

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).