### PR TITLE
EL10 rebuild: python-daemon, python-lockfile, python-setuptools-scm

### DIFF
--- a/packages/plugins/python-daemon/python-daemon.spec
+++ b/packages/plugins/python-daemon/python-daemon.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        2.3.1
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Library to implement a well-behaved Unix daemon process
 
 License:        Apache-2
@@ -56,6 +56,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 2.3.1-6
+- Rebuild for EL10
+
 * Wed Apr 30 2025 Odilon Sousa <osousa@redhat.com> - 2.3.1-5
 - Obsolete python3.11 package for better upgrade
 

--- a/packages/plugins/python-lockfile/python-lockfile.spec
+++ b/packages/plugins/python-lockfile/python-lockfile.spec
@@ -8,7 +8,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.12.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Platform-independent file locking module
 
 License:        None
@@ -65,6 +65,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 0.12.2-4
+- Rebuild for EL10
+
 * Wed Jan 29 2025 Odilon Sousa <osousa@redhat.com> - 0.12.2-3
 - Rebuild against python 3.12
 

--- a/packages/plugins/python-setuptools-scm/python-setuptools-scm.spec
+++ b/packages/plugins/python-setuptools-scm/python-setuptools-scm.spec
@@ -6,7 +6,7 @@
 
 Name:           python-%{pypi_name}
 Version:        8.1.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        the blessed package to manage your versions by scm tags
 
 License:        MIT
@@ -16,7 +16,6 @@ BuildArch:      noarch
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python%{python3_pkgversion}-devel
-BuildRequires:  python%{python3_pkgversion}-rpm-macros
 BuildRequires:  python%{python3_pkgversion}-setuptools
 BuildRequires:  python%{python3_pkgversion}-packaging >= 20.0
 BuildRequires:  python%{python3_pkgversion}-wheel
@@ -72,6 +71,11 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 8.1.0-2
+- Rebuild for EL10
+- Drop redundant python3.12-rpm-macros BuildRequires; not available on EL10 and
+  already satisfied transitively via python3.12-devel/pyproject-rpm-macros
+
 * Fri Jan 31 2025 Odilon Sousa <osousa@redhat.com> - 8.1.0-1
 - Release python-setuptools-scm 8.1.0
 


### PR DESCRIPTION
Wave 2 of the `ansible-core`/`ansible-runner` Python dependency chain (theforeman/el10_rebuild#24) — bumps release to trigger a build/install verification on rhel-10-x86_64.

Wave 1 (python-jinja2 #13862, and the 10-package batch #13863) is merged. This wave covers the three packages that depend only on wave 1 packages:

- python-daemon → docutils
- python-lockfile → pbr
- python-setuptools-scm → packaging (also drops a redundant `python3.12-rpm-macros` BuildRequires that doesn't exist on EL10 — same fix already applied to python-jinja2/python-resolvelib in wave 1)

None of these three packages depend on each other, so they're safe to bundle in one PR.

Ref: theforeman/el10_rebuild#24