### PR TITLE
EL10 rebuild: python-setuptools-rust

### DIFF
--- a/packages/plugins/python-setuptools-rust/python-setuptools-rust.spec
+++ b/packages/plugins/python-setuptools-rust/python-setuptools-rust.spec
@@ -7,7 +7,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.9.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Setuptools Rust extension plugin
 
 License:        MIT
@@ -59,6 +59,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 1.9.0-3
+- Rebuild for EL10
+
 * Fri Jan 31 2025 Odilon Sousa <osousa@redhat.com> - 1.9.0-2
 - Rebuild against python 3.12
 


### PR DESCRIPTION
Wave 3 of the `ansible-core`/`ansible-runner` Python dependency chain (theforeman/el10_rebuild#24) — bumps release to trigger a build/install verification on rhel-10-x86_64.

Single-package wave: python-setuptools-rust BuildRequires python-setuptools-scm (wave 2, merged), and is itself a BuildRequires of python-maturin (wave 4) and python-cryptography (wave 5) — a linear Rust-toolchain chain that can't be bundled, same shape as pulpcore-packaging's tier2.

Ref: theforeman/el10_rebuild#24