### PR TITLE
EL10 rebuild: python-cryptography

### DIFF
--- a/packages/plugins/python-cryptography/python-cryptography.spec
+++ b/packages/plugins/python-cryptography/python-cryptography.spec
@@ -8,7 +8,7 @@
 
 Name:           python-%{pypi_name}
 Version:        43.0.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        cryptography is a package which provides cryptographic recipes and primitives to Python developers
 
 License:        BSD or Apache License, Version 2.0
@@ -66,6 +66,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 43.0.1-3
+- Rebuild for EL10
+
 * Mon Feb 03 2025 Odilon Sousa <osousa@redhat.com> - 43.0.1-2
 - Rebuild against python 3.12
 


### PR DESCRIPTION
Wave 5 of the `ansible-core`/`ansible-runner` Python dependency chain (theforeman/el10_rebuild#24) — bumps release to trigger a build/install verification on rhel-10-x86_64.

Single-package wave: python-cryptography BuildRequires python-setuptools-rust (wave 3, merged) and python-maturin (wave 4, merged) — final link in the Rust-toolchain chain.

This is also the last dependency ansible-core needs before wave 6 (ansible-core + ansible-runner) can be opened.

Ref: theforeman/el10_rebuild#24