### PR TITLE
EL10 rebuild: ansible-core, ansible-runner

### DIFF
--- a/packages/plugins/ansible-core/ansible-core.spec
+++ b/packages/plugins/ansible-core/ansible-core.spec
@@ -28,7 +28,7 @@ Name: ansible-core
 Summary: SSH-based configuration management, deployment, and task execution system
 Version: 2.16.14
 %global uversion %{version_no_tilde %{quote:%nil}}
-Release: 3%{?dist}
+Release: 4%{?dist}
 Epoch:   1
 
 Group: Development/Libraries
@@ -56,7 +56,6 @@ BuildRequires: python%{python3_pkgversion}-wheel
 BuildRequires: python%{python3_pkgversion}-docutils
 BuildRequires: python%{python3_pkgversion}-jinja2 >= 3.0.0
 BuildRequires: python%{python3_pkgversion}-pyyaml
-BuildRequires: python%{python3_pkgversion}-rpm-macros
 BuildRequires: python%{python3_pkgversion}-setuptools
 
 Requires: git-core
@@ -170,6 +169,11 @@ cp -p lib/ansible_core.egg-info/PKG-INFO .
 %{python3_sitelib}/ansible_test
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 1:2.16.14-4
+- Rebuild for EL10
+- Drop redundant python3.12-rpm-macros BuildRequires; not available on EL10 and
+  already satisfied transitively via python3.12-devel/pyproject-rpm-macros
+
 * Mon Feb 03 2025 Odilon Sousa <osousa@redhat.com> - 1:2.16.14-3
 - Rebuild against python 3.12
 

--- a/packages/plugins/ansible-runner/ansible-runner.spec
+++ b/packages/plugins/ansible-runner/ansible-runner.spec
@@ -4,7 +4,7 @@
 
 Name:           %{pypi_name}
 Version:        2.3.6
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A tool and python library to interface with Ansible
 
 License:        ASL 2.0
@@ -16,7 +16,6 @@ BuildArch:      noarch
 BuildRequires: python%{python3_pkgversion}-devel
 BuildRequires: python%{python3_pkgversion}-setuptools
 BuildRequires: python%{python3_pkgversion}-pbr
-BuildRequires: python%{python3_pkgversion}-rpm-macros
 Requires:      python%{python3_pkgversion}-%{pypi_name} = %{version}-%{release}
 Obsoletes:     python3-%{pypi_name} < %{version}
 Obsoletes:     python38-%{pypi_name} < %{version}
@@ -73,6 +72,11 @@ ln -s %{_bindir}/ansible-runner-%{python3_version} %{buildroot}/%{_bindir}/ansib
 %{python3_sitelib}/*
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 2.3.6-3
+- Rebuild for EL10
+- Drop redundant python3.12-rpm-macros BuildRequires; not available on EL10 and
+  already satisfied transitively via python3.12-devel
+
 * Wed Jan 29 2025 Odilon Sousa <osousa@redhat.com> - 2.3.6-2
 - Rebuild against python 3.12
 


### PR DESCRIPTION
Wave 6 (final) of the `ansible-core`/`ansible-runner` Python dependency chain (theforeman/el10_rebuild#24) — bumps release to trigger a build/install verification on rhel-10-x86_64.

All prerequisites are merged: python-docutils, python-jinja2, python-pyyaml, python-pbr (waves 0-2), python-cryptography, python-packaging, python-resolvelib, python-daemon, python-six (waves 1-5). Both packages also drop a redundant `python3.12-rpm-macros` BuildRequires that doesn't exist on EL10 (same fix already applied to python-jinja2/python-resolvelib/python-setuptools-scm earlier in this chain).

This is the last wave — closes out theforeman/el10_rebuild#24 and gets `rubygem-smart_proxy_ansible`'s Ansible dependency building on EL10.

Ref: theforeman/el10_rebuild#24