### PR TITLE
Rebuild rubygem-foreman_expire_hosts for EL10

### DIFF
--- a/packages/plugins/rubygem-foreman_expire_hosts/rubygem-foreman_expire_hosts.spec
+++ b/packages/plugins/rubygem-foreman_expire_hosts/rubygem-foreman_expire_hosts.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 9.1.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman plugin for limiting host lifetime
 License: GPLv3
 URL: https://github.com/theforeman/foreman_expire_hosts
@@ -72,6 +72,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 9.1.0-2
+- Rebuild for EL10
+
 * Mon Mar 02 2026 Foreman Packaging Automation <packaging@theforeman.org> - 9.1.0-1
 - Update to 9.1.0
 


### PR DESCRIPTION
## EL10 Rebuild — plugins-tier2

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (1)

- [ ] rubygem-foreman_expire_hosts

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
