### PR TITLE
Rebuild rubygem-foreman_monitoring for EL10

### DIFF
--- a/packages/plugins/rubygem-foreman_monitoring/rubygem-foreman_monitoring.spec
+++ b/packages/plugins/rubygem-foreman_monitoring/rubygem-foreman_monitoring.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.4.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman plugin for monitoring system integration
 License: GPLv3
 URL: https://github.com/theforeman/foreman_monitoring
@@ -75,6 +75,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.4.0-2
+- Rebuild for EL10
+
 * Tue Aug 19 2025 Foreman Packaging Automation <packaging@theforeman.org> - 3.4.0-1
 - Update to 3.4.0
 


### PR DESCRIPTION
## EL10 Rebuild — plugins-tier2

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (1)

- [ ] rubygem-foreman_monitoring

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
