### PR TITLE
Rebuild rubygem-foreman_omaha for EL10

### DIFF
--- a/packages/plugins/rubygem-foreman_omaha/rubygem-foreman_omaha.spec
+++ b/packages/plugins/rubygem-foreman_omaha/rubygem-foreman_omaha.spec
@@ -8,7 +8,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 5.0.1
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Summary: This plug-in adds support for the Omaha procotol to The Foreman
 Group: Applications/Systems
 License: GPLv3
@@ -102,6 +102,9 @@ cp -pa .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.1-3
+- Rebuild for EL10
+
 * Wed Aug 24 2022 Evgeni Golov - 5.0.1-2
 - Refs #35409 - Include sprockets assets
 


### PR DESCRIPTION
## EL10 Rebuild — plugins-tier2

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (1)

- [ ] rubygem-foreman_omaha

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
