### PR TITLE
Rebuild rubygem-foreman_openbolt for EL10

### DIFF
--- a/packages/plugins/rubygem-foreman_openbolt/rubygem-foreman_openbolt.spec
+++ b/packages/plugins/rubygem-foreman_openbolt/rubygem-foreman_openbolt.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.2.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman OpenBolt integration
 License: GPL-3.0-only
 URL: https://github.com/overlookinfra/foreman_openbolt
@@ -94,6 +94,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.2.1-2
+- Rebuild for EL10
+
 * Wed Jun 24 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.2.1-1
 - Update to 1.2.1
 


### PR DESCRIPTION
## EL10 Rebuild — plugins-tier2

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (1)

- [ ] rubygem-foreman_openbolt

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
