### PR TITLE
Rebuild rubygem-foreman_resource_quota for EL10

### DIFF
--- a/packages/plugins/rubygem-foreman_resource_quota/rubygem-foreman_resource_quota.spec
+++ b/packages/plugins/rubygem-foreman_resource_quota/rubygem-foreman_resource_quota.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.6.4
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman Plug-in for resource quota
 License: GPLv3
 URL: https://github.com/ATIX-AG/foreman_resource_quota
@@ -89,6 +89,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.6.4-2
+- Rebuild for EL10
+
 * Wed Jun 24 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.6.4-1
 - Update to 0.6.4
 


### PR DESCRIPTION
## EL10 Rebuild — plugins-tier2

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (1)

- [ ] rubygem-foreman_resource_quota

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
