### PR TITLE
EL10 rebuild: plugins-tier2 (foreman_salt, foreman_wreckingball)

### DIFF
--- a/packages/plugins/rubygem-foreman_salt/rubygem-foreman_salt.spec
+++ b/packages/plugins/rubygem-foreman_salt/rubygem-foreman_salt.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 17.0.5
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman Plug-in for Salt
 License: GPLv3
 URL: https://github.com/theforeman/foreman_salt
@@ -80,6 +80,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 17.0.5-2
+- Rebuild for EL10
+
 * Sun Mar 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 17.0.5-1
 - Update to 17.0.5
 

--- a/packages/plugins/rubygem-foreman_wreckingball/rubygem-foreman_wreckingball.spec
+++ b/packages/plugins/rubygem-foreman_wreckingball/rubygem-foreman_wreckingball.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 6.0.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Adds status checks of the VMWare VMs to Foreman
 License: GPLv3
 URL: https://github.com/dm-drogeriemarkt/foreman_wreckingball
@@ -81,6 +81,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 6.0.0-2
+- Rebuild for EL10
+
 * Sun May 18 2025 Foreman Packaging Automation <packaging@theforeman.org> - 6.0.0-1
 - Update to 6.0.0
 


### PR DESCRIPTION
## EL10 Rebuild — plugins-tier2

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (2)

- [ ] rubygem-foreman_salt
- [ ] rubygem-foreman_wreckingball

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
