### PR TITLE
EL10 rebuild: plugins-tier2 (python-setuptools-scm..python-maturin, 4 packages)

### DIFF
--- a/packages/plugins/python-daemon/python-daemon.spec
+++ b/packages/plugins/python-daemon/python-daemon.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        2.3.1
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Library to implement a well-behaved Unix daemon process
 
 License:        Apache-2
@@ -56,6 +56,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.3.1-7
+- Rebuild for EL10
+
 * Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 2.3.1-6
 - Rebuild for EL10
 

--- a/packages/plugins/python-lockfile/python-lockfile.spec
+++ b/packages/plugins/python-lockfile/python-lockfile.spec
@@ -8,7 +8,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.12.2
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Platform-independent file locking module
 
 License:        None
@@ -65,6 +65,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.12.2-5
+- Rebuild for EL10
+
 * Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 0.12.2-4
 - Rebuild for EL10
 

--- a/packages/plugins/python-maturin/python-maturin.spec
+++ b/packages/plugins/python-maturin/python-maturin.spec
@@ -8,7 +8,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.7.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Build and publish crates with pyo3, cffi and uniffi bindings as well as rust binaries as python packages
 
 License:        MIT OR Apache-2.0
@@ -68,6 +68,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.7.1-4
+- Rebuild for EL10
+
 * Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 1.7.1-3
 - Rebuild for EL10
 

--- a/packages/plugins/python-setuptools-scm/python-setuptools-scm.spec
+++ b/packages/plugins/python-setuptools-scm/python-setuptools-scm.spec
@@ -6,7 +6,7 @@
 
 Name:           python-%{pypi_name}
 Version:        8.1.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        the blessed package to manage your versions by scm tags
 
 License:        MIT
@@ -71,6 +71,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 8.1.0-3
+- Rebuild for EL10
+
 * Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 8.1.0-2
 - Rebuild for EL10
 - Drop redundant python3.12-rpm-macros BuildRequires; not available on EL10 and


### PR DESCRIPTION
## EL10 Rebuild — plugins-tier2

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (4)

- [ ] python-setuptools-scm
- [ ] python-daemon
- [ ] python-lockfile
- [ ] python-maturin

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
