### PR TITLE
EL10 rebuild: katello (pulpcore_client..pulp_rpm_client, 9 packages)

### DIFF
--- a/packages/katello/rubygem-pulp_ansible_client/rubygem-pulp_ansible_client.spec
+++ b/packages/katello/rubygem-pulp_ansible_client/rubygem-pulp_ansible_client.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.29.9
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Pulp 3 API Ruby Gem
 License: GPLv2+
 URL: https://github.com/pulp/pulp_ansible
@@ -61,6 +61,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.29.9-2
+- Rebuild for EL10
+
 * Sun Jul 19 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.29.9-1
 - Update to 0.29.9
 

--- a/packages/katello/rubygem-pulp_certguard_client/rubygem-pulp_certguard_client.spec
+++ b/packages/katello/rubygem-pulp_certguard_client/rubygem-pulp_certguard_client.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.105.15
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Pulp 3 API Ruby Gem
 License: GPLv2+
 URL: https://github.com/pulp/pulp-certguard
@@ -61,6 +61,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.105.15-2
+- Rebuild for EL10
+
 * Wed Jul 29 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.105.15-1
 - Update to 3.105.15
 

--- a/packages/katello/rubygem-pulp_container_client/rubygem-pulp_container_client.spec
+++ b/packages/katello/rubygem-pulp_container_client/rubygem-pulp_container_client.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.27.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 Epoch: 1
 Summary: Pulp container plugin for Pulp3 API Ruby Gem
 License: GPLv2+
@@ -62,6 +62,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1:2.27.10-2
+- Rebuild for EL10
+
 * Wed Jun 17 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1:2.27.10-1
 - Update to 2.27.10
 

--- a/packages/katello/rubygem-pulp_deb_client/rubygem-pulp_deb_client.spec
+++ b/packages/katello/rubygem-pulp_deb_client/rubygem-pulp_deb_client.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.8.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Pulp 3 DEB plugin API Ruby Gem
 License: GPLv2+
 URL: https://github.com/pulp/pulp_deb
@@ -61,6 +61,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.8.2-2
+- Rebuild for EL10
+
 * Sun Jun 07 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.8.2-1
 - Update to 3.8.2
 

--- a/packages/katello/rubygem-pulp_file_client/rubygem-pulp_file_client.spec
+++ b/packages/katello/rubygem-pulp_file_client/rubygem-pulp_file_client.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.105.15
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Pulp 3 API Ruby Gem
 License: GPLv2+
 URL: https://github.com/pulp/pulp_file
@@ -61,6 +61,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.105.15-2
+- Rebuild for EL10
+
 * Wed Jul 29 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.105.15-1
 - Update to 3.105.15
 

--- a/packages/katello/rubygem-pulp_ostree_client/rubygem-pulp_ostree_client.spec
+++ b/packages/katello/rubygem-pulp_ostree_client/rubygem-pulp_ostree_client.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 2.6.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Epoch: 1
 Summary: Pulp 3 API Ruby Gem
 License: GPL-2.0+
@@ -61,6 +61,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1:2.6.1-2
+- Rebuild for EL10
+
 * Wed Jul 29 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1:2.6.1-1
 - Update to 2.6.1
 

--- a/packages/katello/rubygem-pulp_python_client/rubygem-pulp_python_client.spec
+++ b/packages/katello/rubygem-pulp_python_client/rubygem-pulp_python_client.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.27.6
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Pulp 3 API Ruby Gem
 License: GPLv2+
 URL: https://github.com/pulp/pulp_python
@@ -60,6 +60,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.27.6-2
+- Rebuild for EL10
+
 * Sun Jul 19 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.27.6-1
 - Update to 3.27.6
 

--- a/packages/katello/rubygem-pulp_rpm_client/rubygem-pulp_rpm_client.spec
+++ b/packages/katello/rubygem-pulp_rpm_client/rubygem-pulp_rpm_client.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.35.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Pulp 3 RPM plugin API Ruby Gem
 License: GPLv2+
 URL: https://github.com/pulp/pulp_rpm
@@ -61,6 +61,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.35.3-2
+- Rebuild for EL10
+
 * Wed Jun 17 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.35.3-1
 - Update to 3.35.3
 

--- a/packages/katello/rubygem-pulpcore_client/rubygem-pulpcore_client.spec
+++ b/packages/katello/rubygem-pulpcore_client/rubygem-pulpcore_client.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.105.15
-Release: 1%{?dist}
+Release: 2%{?dist}
 Epoch: 1
 Summary: Pulp 3 API Ruby Gem
 License: GPLv2+
@@ -62,6 +62,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/spec
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1:3.105.15-2
+- Rebuild for EL10
+
 * Wed Jul 29 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1:3.105.15-1
 - Update to 3.105.15
 


### PR DESCRIPTION
## EL10 Rebuild — katello

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (9)

- [ ] rubygem-pulpcore_client
- [ ] rubygem-pulp_ansible_client
- [ ] rubygem-pulp_certguard_client
- [ ] rubygem-pulp_container_client
- [ ] rubygem-pulp_deb_client
- [ ] rubygem-pulp_file_client
- [ ] rubygem-pulp_ostree_client
- [ ] rubygem-pulp_python_client
- [ ] rubygem-pulp_rpm_client

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
