### PR TITLE
EL10 rebuild: katello (katello..nodejs-react-json-tree, 10 packages)

### DIFF
--- a/packages/katello/katello-client-bootstrap/katello-client-bootstrap.spec
+++ b/packages/katello/katello-client-bootstrap/katello-client-bootstrap.spec
@@ -18,7 +18,7 @@
 
 Name:           katello-client-bootstrap
 Version:        1.7.9
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Client bootstrap utility for Foreman and Katello
 
 Group:          System Environment/Base
@@ -47,6 +47,9 @@ install -m644 -D bootstrap.py %{buildroot}%{_var}/www/html/pub/bootstrap.py
 %{_var}/www/html/pub/bootstrap.py
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.7.9-3
+- Rebuild for EL10
+
 * Thu Mar 09 2023 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.7.9-2
 - Make files owned by root
 

--- a/packages/katello/katello-repos/katello-repos.spec
+++ b/packages/katello/katello-repos/katello-repos.spec
@@ -6,7 +6,7 @@
 
 %global prereleasesource nightly
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 2
+%global release 3
 
 Name:           katello-repos
 Version:        5.0
@@ -73,6 +73,9 @@ rm -rf %{buildroot}
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-candlepin
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0-0.3.nightly
+- Rebuild for EL10
+
 * Wed Jun 24 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0-0.2.nightly
 - Update Candlepin to 4.8
 

--- a/packages/katello/katello-selinux/katello-selinux.spec
+++ b/packages/katello/katello-selinux/katello-selinux.spec
@@ -24,7 +24,7 @@
 
 Name:           katello-selinux
 Version:        5.2.0
-Release:        1%{?dotalphatag}%{?dist}
+Release:        2%{?dotalphatag}%{?dist}
 Summary:        SELinux policy module for katello
 
 Group:          System Environment/Base
@@ -117,6 +117,9 @@ fi
 %{_mandir}/man8/%{name}-relabel.8.gz
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.2.0-2
+- Rebuild for EL10
+
 * Thu Feb 06 2025 Evgeni Golov - 5.2.0-1
 - Release katello-selinux 5.2.0
 

--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,7 +5,7 @@
 %global confdir common
 %global prereleasesource master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 1
+%global release 2
 
 Name:       katello
 Version:    5.0.0
@@ -123,6 +123,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.2.master
+- Rebuild for EL10
+
 * Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.master
 - Bump version to 5.0.0
 

--- a/packages/katello/rhel8-kickstart-setup/rhel8-kickstart-setup.spec
+++ b/packages/katello/rhel8-kickstart-setup/rhel8-kickstart-setup.spec
@@ -1,6 +1,6 @@
 Name:     rhel8-kickstart-setup
 Version:  0.0.2
-Release:  3%{?dist}
+Release:  4%{?dist}
 Summary:  Adjust RHEL8 Kickstart ISOs for Katello/Satellite
 
 Group:    Applications/System
@@ -29,6 +29,9 @@ install -D %{name}.py %{buildroot}%{_bindir}/%{name}
 %license LICENSE
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.0.2-4
+- Rebuild for EL10
+
 * Wed Mar 22 2023 Evgeni Golov - 0.0.2-3
 - Use Python3 explicitly
 

--- a/packages/katello/rubygem-robotex/rubygem-robotex.spec
+++ b/packages/katello/rubygem-robotex/rubygem-robotex.spec
@@ -8,7 +8,7 @@
 Summary:    Ruby library to obey robots.txt
 Name:       %{?scl_prefix}rubygem-%{gem_name}
 Version:    1.0.0
-Release:    23%{?dist}
+Release:    24%{?dist}
 License:    MIT
 Group:      Development/Languages
 URL:        https://www.github.com/chriskite/robotex
@@ -77,6 +77,9 @@ popd
 %{gem_instdir}/spec/
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.0-24
+- Rebuild for EL10
+
 * Wed May 21 2025 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.0-23
 - Removed unversioned obsoletes
 

--- a/packages/katello/rubygem-spidr/rubygem-spidr.spec
+++ b/packages/katello/rubygem-spidr/rubygem-spidr.spec
@@ -3,7 +3,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.7.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A versatile Ruby web spidering library
 License: MIT
 URL: https://github.com/postmodern/spidr#readme
@@ -72,6 +72,9 @@ cp -a .%{gem_dir}/* \
 %exclude %{gem_instdir}/spidr.gemspec
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.7.2-2
+- Rebuild for EL10
+
 * Tue Feb 25 2025 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 0.7.2-1
 - Update to 0.7.2
 

--- a/packages/plugins/mosquitto/mosquitto.spec
+++ b/packages/plugins/mosquitto/mosquitto.spec
@@ -3,7 +3,7 @@
 
 Name:           mosquitto
 Version:        2.0.19
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Open Source MQTT v5/v3.1.x Broker
 
 License:        EPL-2.0
@@ -120,6 +120,9 @@ exit 0
 %{_mandir}/man3/libmosquitto.3.*
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.0.19-2
+- Rebuild for EL10
+
 * Mon Oct 14 2024 Eric D. Helms <ericdhelms@gmail.com> - 2.0.19-1
 - Build 2.0.19
 

--- a/packages/plugins/nodejs-react-json-tree/nodejs-react-json-tree.spec
+++ b/packages/plugins/nodejs-react-json-tree/nodejs-react-json-tree.spec
@@ -2,7 +2,7 @@
 
 Name: nodejs-react-json-tree
 Version: 0.18.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: React JSON Viewer Component, Extracted from redux-devtools
 License: MIT
 Group: Development/Libraries
@@ -101,6 +101,9 @@ rm -rf %{buildroot} %{npm_cache_dir}
 %doc node_modules/%{npm_name}/README.md
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.18.0-2
+- Rebuild for EL10
+
 * Thu Jul 30 2026 Zach Huntington-Meath <zhunting@redhat.com> 0.18.0-1
 - Update to 0.18.0
 

--- a/packages/plugins/puppet-foreman_scap_client/puppet-foreman_scap_client.spec
+++ b/packages/plugins/puppet-foreman_scap_client/puppet-foreman_scap_client.spec
@@ -4,7 +4,7 @@
 
 Name:       puppet-%{puppet_module}
 Version:    1.0.0
-Release:    2%{?dist}
+Release:    3%{?dist}
 Summary:    Puppet module to configure foreman_scap_client
 License:    GPLv2
 URL:        https://github.com/theforeman/%{name}
@@ -41,6 +41,9 @@ cp -rp . %{buildroot}/%{puppet_foreman_scap_client_dir}/
 %{puppet_foreman_scap_client_dir}/templates
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.0-3
+- Rebuild for EL10
+
 * Wed Nov 08 2023 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 1.0.0-2
 - Correctly identify license file
 


### PR DESCRIPTION
## EL10 Rebuild — katello

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (10)

- [ ] katello
- [ ] katello-client-bootstrap
- [ ] katello-repos
- [ ] katello-selinux
- [ ] rhel8-kickstart-setup
- [ ] rubygem-robotex
- [ ] rubygem-spidr
- [ ] puppet-foreman_scap_client
- [ ] mosquitto
- [ ] nodejs-react-json-tree

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
