### PR TITLE
EL10 rebuild: katello (hammer_cli_katello, hammer_cli_foreman_rh_cloud, hammer_cli_foreman_scc_manager)

### DIFF
--- a/packages/katello/rubygem-hammer_cli_foreman_rh_cloud/rubygem-hammer_cli_foreman_rh_cloud.spec
+++ b/packages/katello/rubygem-hammer_cli_foreman_rh_cloud/rubygem-hammer_cli_foreman_rh_cloud.spec
@@ -6,7 +6,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 5.0.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman Rh Cloud plugin for Hammer CLI
 License: GPLv3+
 URL: https://github.com/theforeman/hammer-cli-foreman-rh-cloud
@@ -70,6 +70,9 @@ install -m 0644 .%{gem_instdir}/config/%{plugin_name}.yml \
 %{gem_instdir}/test
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-2
+- Rebuild for EL10
+
 * Mon Jul 06 2026 Chris Roberts <chrobert@redhat.com> - 5.0.0-1
 - Update to 5.0.0
 

--- a/packages/katello/rubygem-hammer_cli_foreman_scc_manager/rubygem-hammer_cli_foreman_scc_manager.spec
+++ b/packages/katello/rubygem-hammer_cli_foreman_scc_manager/rubygem-hammer_cli_foreman_scc_manager.spec
@@ -6,7 +6,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.7.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Foreman SCC Manager plugin for Hammer CLI
 License: GPLv3
 URL: https://github.com/ATIX-AG/hammer-cli-foreman-scc-manager
@@ -70,6 +70,9 @@ install -m 0644 .%{gem_instdir}/config/%{plugin_name}.yml \
 %{gem_instdir}/test
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.7.0-2
+- Rebuild for EL10
+
 * Sun May 24 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.7.0-1
 - Update to 0.7.0
 

--- a/packages/katello/rubygem-hammer_cli_katello/rubygem-hammer_cli_katello.spec
+++ b/packages/katello/rubygem-hammer_cli_katello/rubygem-hammer_cli_katello.spec
@@ -2,7 +2,7 @@
 %global gem_name hammer_cli_katello
 %global plugin_name katello
 
-%global release 1
+%global release 2
 %global prereleasesource pre.main
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
 
@@ -73,6 +73,9 @@ install -m 0644 .%{gem_instdir}/config/%{plugin_name}.yml \
 %{gem_instdir}/test
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.2.pre.main
+- Rebuild for EL10
+
 * Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.pre.main
 - Bump version to 5.0.0
 


### PR DESCRIPTION
## EL10 Rebuild — katello

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (3)

- [ ] rubygem-hammer_cli_katello
- [ ] rubygem-hammer_cli_foreman_rh_cloud
- [ ] rubygem-hammer_cli_foreman_scc_manager

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).