### PR TITLE
EL10 rebuild: katello (foreman_rh_cloud, foreman_scc_manager, foreman_virt_who_configure)

### DIFF
--- a/packages/katello/rubygem-foreman_kernel_care/rubygem-foreman_kernel_care.spec
+++ b/packages/katello/rubygem-foreman_kernel_care/rubygem-foreman_kernel_care.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 3.0.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Plugin for KernelCare
 License: GPLv3
 URL: https://github.com/maccelf/foreman_kernel_care
@@ -72,6 +72,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.0.0-2
+- Rebuild for EL10
+
 * Thu Jul 31 2025 Foreman Packaging Automation <packaging@theforeman.org> - 3.0.0-1
 - Update to 3.0.0
 

--- a/packages/katello/rubygem-foreman_rh_cloud/rubygem-foreman_rh_cloud.spec
+++ b/packages/katello/rubygem-foreman_rh_cloud/rubygem-foreman_rh_cloud.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 14.3.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Connects Foreman with Red Hat Cloud services
 License: GPLv3
 URL: https://github.com/theforeman/foreman_rh_cloud
@@ -97,6 +97,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 14.3.0-2
+- Rebuild for EL10
+
 * Thu Jul 16 2026 Foreman Packaging Automation <packaging@theforeman.org> - 14.3.0-1
 - Update to 14.3.0
 

--- a/packages/katello/rubygem-foreman_scc_manager/rubygem-foreman_scc_manager.spec
+++ b/packages/katello/rubygem-foreman_scc_manager/rubygem-foreman_scc_manager.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 5.3.1
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: Suse Customer Center plugin for Foreman
 License: GPLv3
 URL: https://www.orcharhino.com/
@@ -91,6 +91,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.3.1-2
+- Rebuild for EL10
+
 * Fri Jul 17 2026 Foreman Packaging Automation <packaging@theforeman.org> - 5.3.1-1
 - Update to 5.3.1
 

--- a/packages/katello/rubygem-foreman_virt_who_configure/rubygem-foreman_virt_who_configure.spec
+++ b/packages/katello/rubygem-foreman_virt_who_configure/rubygem-foreman_virt_who_configure.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 5.0.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: A plugin to make virt-who configuration easy
 License: GPLv3
 URL: https://github.com/theforeman/foreman_virt_who_configure
@@ -78,6 +78,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-2
+- Rebuild for EL10
+
 * Mon Jul 06 2026 Foreman Packaging Automation <packaging@theforeman.org> - 5.0.0-1
 - Update to 5.0.0
 


### PR DESCRIPTION
## EL10 Rebuild — katello

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (3)

- [ ] rubygem-foreman_rh_cloud
- [ ] rubygem-foreman_scc_manager
- [ ] rubygem-foreman_virt_who_configure

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
