### PR TITLE
EL10 rebuild: ruby-tier2 (rkerberos..foreman_theme_satellite, 6 packages)

### DIFF
--- a/packages/foreman/rubygem-rkerberos/rubygem-rkerberos.spec
+++ b/packages/foreman/rubygem-rkerberos/rubygem-rkerberos.spec
@@ -4,7 +4,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.2.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A Ruby interface for the the Kerberos library
 License: Artistic-2.0
 URL: https://github.com/domcleal/rkerberos
@@ -90,6 +90,9 @@ rm -rf gem_ext_test
 %{gem_instdir}/spec
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.2.3-2
+- Rebuild for EL10
+
 * Wed Mar 11 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.2.3-1
 - Update to 0.2.3
 

--- a/packages/plugins/foreman-discovery-image-service/foreman-discovery-image-service.spec
+++ b/packages/plugins/foreman-discovery-image-service/foreman-discovery-image-service.spec
@@ -1,6 +1,6 @@
 Name: foreman-discovery-image-service
 Version: 1.0.0
-Release: 5%{?dist}
+Release: 6%{?dist}
 Summary: Metapackage with dependencies for FDI
 
 Group: Applications/System
@@ -39,6 +39,9 @@ Metapackage with dependencies for FDI text-user interface
 %files tui
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.0-6
+- Rebuild for EL10
+
 * Wed Sep 25 2024 Leos Stejskal <lstejska@redhat.com - 1.0.0-5
 - Update spec file
 

--- a/packages/plugins/rubygem-newt/rubygem-newt.spec
+++ b/packages/plugins/rubygem-newt/rubygem-newt.spec
@@ -4,7 +4,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.0.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Ruby bindings for newt
 License: MIT
 URL: https://github.com/theforeman/ruby-newt
@@ -79,6 +79,9 @@ rm -rf gem_ext_test
 %{gem_instdir}/examples
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.0.1-2
+- Rebuild for EL10
+
 * Tue Sep 24 2024 Leos Stejskal <lstejska@redhat.com> - 1.0.1-1
 - Update to 1.0.1
 

--- a/packages/plugins/rubygem-radcli/rubygem-radcli.spec
+++ b/packages/plugins/rubygem-radcli/rubygem-radcli.spec
@@ -4,7 +4,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 1.1.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A Ruby interface for the adcli library
 License: Artistic-2.0
 URL: https://github.com/martencassel/radcli
@@ -94,6 +94,9 @@ rm -rf gem_ext_test
 %{gem_instdir}/test
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.1.0-2
+- Rebuild for EL10
+
 * Wed Jul 24 2024 Evgeni Golov - 1.1.0-1
 - Update to 1.1.0
 

--- a/packages/plugins/rubygem-smart_proxy_realm_ad_plugin/rubygem-smart_proxy_realm_ad_plugin.spec
+++ b/packages/plugins/rubygem-smart_proxy_realm_ad_plugin/rubygem-smart_proxy_realm_ad_plugin.spec
@@ -17,7 +17,7 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.1
-Release: 10%{?foremandist}%{?dist}
+Release: 11%{?foremandist}%{?dist}
 Summary: A realm ad provider plugin for Foreman's smart proxy
 Group: Applications/Internet
 License: GPLv3
@@ -110,6 +110,9 @@ mv %{buildroot}%{gem_instdir}/config/realm_ad.yml.example \
 %{gem_instdir}/test
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.1-11
+- Rebuild for EL10
+
 * Mon May 09 2022 Eric D. Helms <ericdhelms@gmail.com> - 0.1-10
 - Drop unused smart_proxy_dynflow_core_bundlerd_dir macro
 

--- a/packages/satellite/rubygem-foreman_theme_satellite/rubygem-foreman_theme_satellite.spec
+++ b/packages/satellite/rubygem-foreman_theme_satellite/rubygem-foreman_theme_satellite.spec
@@ -7,7 +7,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 16.3.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: This is a plugin that enables building a theme for Foreman
 License: GPLv3
 URL: https://github.com/RedHatSatellite/foreman_theme_satellite
@@ -104,6 +104,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 16.3.0-2
+- Rebuild for EL10
+
 * Wed Jun 03 2026 Foreman Packaging Automation <packaging@theforeman.org> - 16.3.0-1
 - Update to 16.3.0
 


### PR DESCRIPTION
## EL10 Rebuild — ruby-tier2

Bump release for EL10 rebuild. CI will scratch build these for the `rhel-10-x86_64` chroot.

### Packages (6)

- [ ] rubygem-rkerberos
- [ ] rubygem-newt
- [ ] rubygem-radcli
- [ ] rubygem-smart_proxy_realm_ad_plugin
- [ ] foreman-discovery-image-service
- [ ] rubygem-foreman_theme_satellite

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).
