### PR TITLE
Rebuild rubygem-katello for EL10

### DIFF
--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -6,7 +6,7 @@
 %global prereleasesource pre.master
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
 %global mainver 5.0.0
-%global release 1
+%global release 2
 
 Name: rubygem-%{gem_name}
 Version: %{mainver}
@@ -165,6 +165,9 @@ done
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.2.pre.master
+- Rebuild for EL10
+
 * Wed May 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.pre.master
 - Bump version to 5.0.0
 

--- a/packages/katello/rubygem-katello/rubygem-katello.spec
+++ b/packages/katello/rubygem-katello/rubygem-katello.spec
@@ -25,9 +25,9 @@ Requires: foreman >= %{foreman_min_version}
 BuildRequires: foreman-assets >= %{foreman_min_version}
 BuildRequires: foreman-plugin >= %{foreman_min_version}
 Requires: ruby >= 2.7
-Requires: ruby < 3.1
+Requires: ruby < 4
 BuildRequires: ruby >= 2.7
-BuildRequires: ruby < 3.1
+BuildRequires: ruby < 4
 BuildRequires: rubygems-devel > 1.3.1
 BuildRequires: rubygem(rails)
 BuildRequires: rubygem(json)


### PR DESCRIPTION
## EL10 Rebuild — rubygem-katello

Fix ruby version constraint and bump release for EL10 rebuild.

The upstream gemspec specifies `ruby >= 3.0, < 4` but the RPM spec had a stale `ruby < 3.1` constraint which prevents building on EL10 (Ruby 3.3). Updated to `ruby < 4` to match upstream.

**Note:** This will fail CI until foreman_remote_execution, spidr, and the pulp clients are merged and released to nightly-staging.

### Packages (1)

- [ ] rubygem-katello

Tracked in [el10_rebuild](https://github.com/theforeman/el10_rebuild).