### PR TITLE
Rebuild rubygem-foreman_leapp for EL10

### DIFF
--- a/packages/plugins/rubygem-foreman_leapp/rubygem-foreman_leapp.spec
+++ b/packages/plugins/rubygem-foreman_leapp/rubygem-foreman_leapp.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 4.1.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: A Foreman plugin for Leapp utility
 License: GPLv3
 URL: https://github.com/theforeman/foreman_leapp
@@ -91,6 +91,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 4.1.0-2
+- Rebuild for EL10
+
 * Mon Jul 13 2026 Foreman Packaging Automation <packaging@theforeman.org> - 4.1.0-1
 - Update to 4.1.0
 


### PR DESCRIPTION
Bump release for EL10 rebuild.

Packages:
- rubygem-foreman_leapp

Note: This will fail CI — needs rubygem-foreman_ansible (Ruby 3.3 blocker) and rubygem-foreman_remote_execution (PR #13894) merged first.