### PR TITLE
Rebuild ansible packages for EL10

### DIFF
--- a/packages/plugins/ansible-collection-theforeman-foreman/ansible-collection-theforeman-foreman.spec
+++ b/packages/plugins/ansible-collection-theforeman-foreman/ansible-collection-theforeman-foreman.spec
@@ -4,7 +4,7 @@
 %global collection_name foreman
 %global collection_directory %{_datadir}/ansible/collections/ansible_collections/%{collection_namespace}/%{collection_name}
 
-%global release 1
+%global release 2
 
 Name:       ansible-collection-%{collection_namespace}-%{collection_name}
 Version:    5.11.0
@@ -51,6 +51,9 @@ cp -a ./* %{buildroot}%{collection_directory}
 
 
 %changelog
+* Mon Aug 03 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.11.0-2
+- Rebuild for EL10
+
 * Fri Apr 17 2026 Evgeni Golov - 5.11.0-1
 - Release ansible-collection-theforeman-foreman 5.11.0
 

--- a/packages/plugins/ansible-collection-theforeman-operations/ansible-collection-theforeman-operations.spec
+++ b/packages/plugins/ansible-collection-theforeman-operations/ansible-collection-theforeman-operations.spec
@@ -4,7 +4,7 @@
 %global collection_name operations
 %global collection_directory %{_datadir}/ansible/collections/ansible_collections/%{collection_namespace}/%{collection_name}
 
-%global release 1
+%global release 2
 
 Name:       ansible-collection-%{collection_namespace}-%{collection_name}
 Version:    4.0.1
@@ -43,6 +43,9 @@ cp -a ./* %{buildroot}%{collection_directory}
 %doc %{collection_directory}/README.md
 
 %changelog
+* Mon Aug 03 2026 Zach Huntington-Meath <zhunting@redhat.com> - 4.0.1-2
+- Rebuild for EL10
+
 * Tue Jun 16 2026 Evgeni Golov - 4.0.1-1
 - Release ansible-collection-theforeman-operations 4.0.1
 

--- a/packages/plugins/ansiblerole-foreman_scap_client/ansiblerole-foreman_scap_client.spec
+++ b/packages/plugins/ansiblerole-foreman_scap_client/ansiblerole-foreman_scap_client.spec
@@ -7,7 +7,7 @@
 Name: ansiblerole-foreman_scap_client
 Summary: Packaging of the foreman_scap_client Ansible role
 Version: 0.5.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPLv3
 
 Source0: https://github.com/%{repo_orgname}/%{repo_name}/archive/%{version}.tar.gz#/%{role_name}-%{version}.tar.gz
@@ -40,6 +40,9 @@ cp -pR %{repo_name}-%{version} %{buildroot}%{_datadir}/ansible/roles/%{role_orgn
 %doc %{repo_name}-%{version}/README.md
 
 %changelog
+* Mon Aug 03 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.5.0-2
+- Rebuild for EL10
+
 * Tue Oct 07 2025 Adam Ruzicka <aruzicka@redhat.com> - 0.5.0-1
 - Update to 0.5.0
 

--- a/packages/plugins/ansiblerole-insights-client/ansiblerole-insights-client.spec
+++ b/packages/plugins/ansiblerole-insights-client/ansiblerole-insights-client.spec
@@ -7,7 +7,7 @@
 Name: ansiblerole-insights-client
 Summary: Packaging of the insights-client Ansible role
 Version: 1.7.1
-Release: 3%{?dist}
+Release: 4%{?dist}
 License: ASL 2.0
 
 Source0: https://github.com/%{repo_orgname}/%{repo_name}/archive/v%{version}.tar.gz#/%{role_name}-%{version}.tar.gz
@@ -42,6 +42,9 @@ cp -pR %{repo_name}-%{version} %{buildroot}%{_datadir}/ansible/roles/%{role_orgn
 %license %{repo_name}-%{version}/LICENSE
 
 %changelog
+* Mon Aug 03 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.7.1-4
+- Rebuild for EL10
+
 * Fri Sep 12 2025 Maximilian Kolb - 1.7.1-3
 - Fix typo in package description
 

--- a/packages/satellite/ansible-collection-redhat-satellite/ansible-collection-redhat-satellite.spec
+++ b/packages/satellite/ansible-collection-redhat-satellite/ansible-collection-redhat-satellite.spec
@@ -4,7 +4,7 @@
 %global collection_name satellite
 %global collection_directory %{_datadir}/ansible/collections/ansible_collections/%{collection_namespace}/%{collection_name}
 
-%global release 1
+%global release 2
 
 Name:       ansible-collection-%{collection_namespace}-%{collection_name}
 Version:    5.11.0
@@ -51,6 +51,9 @@ cp -a ./* %{buildroot}%{collection_directory}
 
 
 %changelog
+* Mon Aug 03 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.11.0-2
+- Rebuild for EL10
+
 * Fri Apr 17 2026 Evgeni Golov - 5.11.0-1
 - Release ansible-collection-redhat-satellite 5.11.0
 

--- a/packages/satellite/ansible-collection-redhat-satellite_operations/ansible-collection-redhat-satellite_operations.spec
+++ b/packages/satellite/ansible-collection-redhat-satellite_operations/ansible-collection-redhat-satellite_operations.spec
@@ -4,7 +4,7 @@
 %global collection_name satellite_operations
 %global collection_directory %{_datadir}/ansible/collections/ansible_collections/%{collection_namespace}/%{collection_name}
 
-%global release 1
+%global release 2
 
 Name:       ansible-collection-%{collection_namespace}-%{collection_name}
 Version:    4.0.0
@@ -37,6 +37,9 @@ cp -a ./* %{buildroot}%{collection_directory}
 %doc %{collection_directory}/README.md
 
 %changelog
+* Mon Aug 03 2026 Zach Huntington-Meath <zhunting@redhat.com> - 4.0.0-2
+- Rebuild for EL10
+
 * Wed Mar 25 2026 Evgeni Golov - 4.0.0-1
 - Release ansible-collection-redhat-satellite_operations 4.0.0
 


### PR DESCRIPTION
## Summary
- Bump release on the remaining 6 ansible/ansiblerole packages for EL10 builds
- All are noarch packages with no spec changes needed beyond the release bump
- Packages: ansible-collection-theforeman-foreman, ansible-collection-theforeman-operations, ansiblerole-foreman_scap_client, ansiblerole-insights-client, ansible-collection-redhat-satellite, ansible-collection-redhat-satellite_operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)