### PR TITLE
Add missing el10 repoclosure definitions

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -926,6 +926,7 @@ repoclosures:
         el10:
           - el10-baseos
           - el10-appstream
+          - "el10-openvox-{{ puppet_version }}"
     foreman-staging-repoclosure-el9:
       repoclosure_target_repos:
         el9:
@@ -947,6 +948,8 @@ repoclosures:
         el10:
           - el10-baseos
           - el10-appstream
+          - el10-configmanagement-salt
+          - "el10-foreman-{{ foreman_version }}-staging"
     plugins-staging-repoclosure-el9:
       repoclosure_target_repos:
         el9:

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -47,9 +47,28 @@ enabled=1
 name=el9-openvox-8
 baseurl=https://yum.voxpupuli.org/openvox8/el/9/x86_64/
 
+[el10-openvox-8]
+name=el10-openvox-8
+baseurl=https://yum.voxpupuli.org/openvox8/el/10/x86_64/
+
 [el10-foreman-client-nightly-staging]
 name=Foreman Client nightly EL10
 baseurl=https://stagingyum.theforeman.org/client/nightly/el10/x86_64/
+
+[el10-foreman-nightly-staging]
+name=Foreman nightly staging EL10
+baseurl=https://stagingyum.theforeman.org/foreman/nightly/el10/x86_64/
+module_hotfixes=1
+
+[el10-foreman-plugins-nightly-staging]
+name=Foreman Plugins nightly staging EL10
+baseurl=https://stagingyum.theforeman.org/plugins/nightly/el10/x86_64/
+module_hotfixes=1
+
+[el10-katello-nightly-staging]
+name=Katello nightly staging EL10
+baseurl=https://stagingyum.theforeman.org/katello/nightly/el10/x86_64/
+module_hotfixes=1
 
 [el9-foreman-client-nightly-staging]
 name=Foreman Client nightly EL9
@@ -64,6 +83,10 @@ name=AlmaLinux 8 - AppStream
 mirrorlist=https://mirrors.almalinux.org/mirrorlist/8/appstream
 module_hotfixes=1
 excludepkgs=ruby-3*,ruby-default-gems-3*,ruby-devel-3*,ruby-libs-3*,rubygem-rdoc-6.4*,rubygem-rdoc-6.6*
+
+[el10-configmanagement-salt]
+name=SaltStack configmanagement
+baseurl=https://packages.broadcom.com/artifactory/saltproject-rpm/
 
 [el9-configmanagement-salt]
 name=SaltStack configmanagement


### PR DESCRIPTION
## Summary

`foreman-nightly-rpm-pipeline` [#3227](https://ci.theforeman.org/blue/organizations/jenkins/foreman-nightly-rpm-pipeline/detail/foreman-nightly-rpm-pipeline/3227/pipeline) failed with:

```
Error: Unknown repo: 'el10-foreman-nightly-staging'
```

`repoclosure/yum.conf` only defined `el10-baseos`/`el10-appstream`/`el10-crb` and `el10-foreman-client-nightly-staging`. It was missing the el10 equivalents of several el9 staging/lookaside repos that `package_manifest.yaml`'s `repoclosures` section already references.

## Changes

- `repoclosure/yum.conf`: add `el10-foreman-nightly-staging`, `el10-foreman-plugins-nightly-staging`, `el10-katello-nightly-staging`, `el10-openvox-8`, `el10-configmanagement-salt` (mirrors the existing el9 definitions).
- `package_manifest.yaml`: wire the new repos into `repoclosure_lookaside_repos` for `foreman-staging-repoclosure-el10` (openvox, for puppet ruby) and `plugins-staging-repoclosure-el10` (foreman-nightly-staging + salt, for foreman-proxy/salt-master deps), matching the el9 group structure.

Verified locally with `obal repoclosure <group>-el10` for the foreman, plugins, katello, and foreman-client groups — the "Unknown repo" failure is gone and repoclosure runs to completion.

## Known gaps surfaced (out of scope for this PR)

Running repoclosure for real now surfaces genuine el10 packaging gaps, not repoclosure-definition issues:

- **foreman group**: `rubygem-railties` needs `rubygem(method_source)`, which isn't present in `el10-foreman-nightly-staging` yet. The package exists in this repo (`packages/foreman/rubygem-method_source`) but doesn't appear to be built/published for el10.
- **plugins group**: `rubygem-foreman_bootdisk` requires `/usr/bin/genisoimage`, which CentOS Stream 10 no longer ships in BaseOS/AppStream/CRB (dropped in favor of `xorriso`). The spec hardcodes this requirement with no el10 conditional.
- **plugins group**: `ansible-test` unresolved against `ansible-core = 1:2.16.14-4.el10` in one run, but checking the actual repo metadata shows both packages present with matching NEVRA — possibly mirror flakiness during that particular repoclosure run rather than a real issue. Worth re-checking on a subsequent nightly run.

- katello el10 nightly staging (`stagingyum.theforeman.org/katello/nightly/el10/`) isn't published yet, so `katello-staging-repoclosure-el10` currently no-ops rather than failing — once katello starts building for el10, its lookaside repos (candlepin included) will need the same treatment.

## Test plan

- [x] `obal repoclosure foreman-staging-repoclosure-el10` — unknown-repo error gone, resolves to a real (separate) gap
- [x] `obal repoclosure plugins-staging-repoclosure-el10` — unknown-repo error gone, resolves to real (separate) gaps
- [x] `obal repoclosure katello-staging-repoclosure-el10` — passes (repo not yet published)
- [x] `obal repoclosure foreman-client-staging-repoclosure-el10` — passes clean