### PR TITLE
Add rubygem-colorize and rubygem-method_source to EL10 comps

### DIFF
--- a/comps/comps-foreman-el10.xml
+++ b/comps/comps-foreman-el10.xml
@@ -196,6 +196,7 @@
       <packagereq type="default">rubygem-builder</packagereq>
       <packagereq type="default">rubygem-bundler_ext</packagereq>
       <packagereq type="default">rubygem-clamp</packagereq>
+      <packagereq type="default">rubygem-colorize</packagereq>
       <packagereq type="default">rubygem-concurrent-ruby</packagereq>
       <packagereq type="default">rubygem-concurrent-ruby-edge</packagereq>
       <packagereq type="default">rubygem-connection_pool</packagereq>
@@ -275,6 +276,7 @@
       <packagereq type="default">rubygem-mail</packagereq>
       <packagereq type="default">rubygem-marcel</packagereq>
       <packagereq type="default">rubygem-memoist</packagereq>
+      <packagereq type="default">rubygem-method_source</packagereq>
       <packagereq type="default">rubygem-mime-types</packagereq>
       <packagereq type="default">rubygem-mime-types-data</packagereq>
       <packagereq type="default">rubygem-mini_mime</packagereq>
@@ -404,6 +406,7 @@
       <packagereq type="default">rubygem-builder-doc</packagereq>
       <packagereq type="default">rubygem-bundler_ext-doc</packagereq>
       <packagereq type="default">rubygem-clamp-doc</packagereq>
+      <packagereq type="default">rubygem-colorize-doc</packagereq>
       <packagereq type="default">rubygem-concurrent-ruby-doc</packagereq>
       <packagereq type="default">rubygem-concurrent-ruby-edge-doc</packagereq>
       <packagereq type="default">rubygem-connection_pool-doc</packagereq>
@@ -483,6 +486,7 @@
       <packagereq type="default">rubygem-mail-doc</packagereq>
       <packagereq type="default">rubygem-marcel-doc</packagereq>
       <packagereq type="default">rubygem-memoist-doc</packagereq>
+      <packagereq type="default">rubygem-method_source-doc</packagereq>
       <packagereq type="default">rubygem-mime-types-data-doc</packagereq>
       <packagereq type="default">rubygem-mime-types-doc</packagereq>
       <packagereq type="default">rubygem-mini_mime-doc</packagereq>


### PR DESCRIPTION
## Summary
- Adds `rubygem-colorize` and `rubygem-method_source` (plus their `-doc` subpackages) to `comps/comps-foreman-el10.xml`
- These packages were present in the EL9 comps but missing from EL10, causing repoclosure failures for `rubygem-puma-status` (needs `rubygem(colorize)`) and `rubygem-railties` (needs `rubygem(method_source)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)