### PR TITLE
Update requirements for packages that are not present on EL10 like it was on EL9

### DIFF
--- a/packages/plugins/ansible-collection-theforeman-foreman/ansible-collection-theforeman-foreman.spec
+++ b/packages/plugins/ansible-collection-theforeman-foreman/ansible-collection-theforeman-foreman.spec
@@ -4,7 +4,7 @@
 %global collection_name foreman
 %global collection_directory %{_datadir}/ansible/collections/ansible_collections/%{collection_namespace}/%{collection_name}
 
-%global release 2
+%global release 3
 
 Name:       ansible-collection-%{collection_namespace}-%{collection_name}
 Version:    5.11.0
@@ -20,13 +20,19 @@ Provides: ansible-collection(%{collection_namespace}.%{collection_name}) = %{ver
 Provides: bundled(python-apypie) = 0.7.0
 
 Requires: ansible-core
+%if 0%{?rhel} == 9
 Requires: (python3-requests if (ansible-core >= 1:2.14.7 and ansible-core < 1:2.16.14-3))
 Requires: (python3-pyyaml if (ansible-core >= 1:2.14.7 and ansible-core < 1:2.16.14-3))
 Requires: (python3.11-requests if (ansible-core >= 2.14.2-3 and ansible-core < 1:2.14.7))
 Requires: (python3.11-pyyaml if (ansible-core >= 2.14.2-3 and ansible-core < 1:2.14.7))
 Requires: (python3.12-requests if ansible-core >= 1:2.16.14-3)
 Requires: (python3.12-pyyaml if ansible-core >= 1:2.16.14-3)
+%endif
 
+%if 0%{?rhel} == 10
+Requires: python3-requests
+Requires: python3-pyyaml
+%endif
 
 %description
 Collection of Ansible Modules to manage Foreman installations.
@@ -51,6 +57,9 @@ cp -a ./* %{buildroot}%{collection_directory}
 
 
 %changelog
+* Wed Aug 05 2026 Odilon Sousa <osousa@redhat.com> - 5.11.0-3
+- Fix conditions for ansible-core to be installed on EL10
+
 * Mon Aug 03 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.11.0-2
 - Rebuild for EL10
 

--- a/packages/plugins/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
+++ b/packages/plugins/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
@@ -16,6 +16,7 @@ Requires:   dosfstools
 Requires:   grub2-efi-x64
 Requires:   ipxe-bootimgs
 Requires:   /usr/bin/xorriso
+Requires:   /usr/bin/isohybrid
 
 # start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}

--- a/packages/plugins/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
+++ b/packages/plugins/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
@@ -5,7 +5,7 @@
 
 Name: rubygem-%{gem_name}
 Version: 23.2.4
-Release: 2%{?foremandist}%{?dist}
+Release: 3%{?foremandist}%{?dist}
 Summary: Create boot disks to provision hosts with Foreman
 License: GPLv3
 URL: https://github.com/theforeman/foreman_bootdisk
@@ -15,8 +15,7 @@ Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 Requires:   dosfstools
 Requires:   grub2-efi-x64
 Requires:   ipxe-bootimgs
-Requires:   /usr/bin/isohybrid
-Requires:   /usr/bin/genisoimage
+Requires:   /usr/bin/xorriso
 
 # start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
@@ -99,6 +98,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Wed Aug 05 2026 Odilon Sousa <osousa@redhat.com> - 23.2.4-3
+- Switch to xoriso to allow EL10 installation
+
 * Fri Jul 31 2026 Zach Huntington-Meath <zhunting@redhat.com> - 23.2.4-2
 - Rebuild for EL10
 

--- a/packages/plugins/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
+++ b/packages/plugins/rubygem-foreman_bootdisk/rubygem-foreman_bootdisk.spec
@@ -10,6 +10,7 @@ Summary: Create boot disks to provision hosts with Foreman
 License: GPLv3
 URL: https://github.com/theforeman/foreman_bootdisk
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
+Patch0:  switch-genisoimage-to-xorrisofs.patch
 
 # used in app/services/foreman_bootdisk/iso_generator.rb
 Requires:   dosfstools
@@ -54,7 +55,8 @@ BuildArch: noarch
 Documentation for %{name}.
 
 %prep
-%setup -q -n  %{gem_name}-%{version}
+%setup -q -n %{gem_name}-%{version}
+%autopatch -p1
 
 %build
 # Create the gem as gem install only works on a gem file

--- a/packages/plugins/rubygem-foreman_bootdisk/switch-genisoimage-to-xorrisofs.patch
+++ b/packages/plugins/rubygem-foreman_bootdisk/switch-genisoimage-to-xorrisofs.patch
@@ -1,0 +1,71 @@
+From 1d755bc835149cf6edbaed57f85a65d4b9cb9b80 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ond=C5=99ej=20Gajdu=C5=A1ek?= <ogajduse@redhat.com>
+Date: Wed, 5 Aug 2026 11:55:00 +0200
+Subject: [PATCH] Fixes #39589 - Default bootdisk_mkiso_command to xorrisofs
+ instead of genisoimage
+
+genisoimage/cdrkit was dropped entirely on CentOS Stream 10, so the
+default breaks ISO generation there. xorriso's mkisofs/genisoimage/
+xorrisofs personalities all dispatch to the same argument-emulation
+code path (xorriso/base_obj.c), so this is not a behavior change on
+distros that still carry genisoimage/mkisofs -- just picking the name
+that keeps working once the legacy compat aliases go away.
+---
+ README.md                                      | 4 ++--
+ app/services/foreman_bootdisk/iso_generator.rb | 2 +-
+ lib/foreman_bootdisk/engine.rb                 | 4 ++--
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/README.md b/README.md
+index 99a5a20..2035634 100644
+--- a/README.md
++++ b/README.md
+@@ -27,7 +27,7 @@ Debian users can install the "ruby-foreman-bootdisk" package.
+ 
+ * iPXE images are required
+ * syslinux is required
+-* genisoimage/mkisofs and isohybrid are required
++* xorrisofs (or genisoimage/mkisofs) and isohybrid are required
+ 
+ gPXE images are unsupported due to lack of initrd support.
+ 
+@@ -328,7 +328,7 @@ the Foreman UI.
+ * _iPXE directory_ (`bootdisk_ipxe_dir`) points to the directory containing
+   ipxe.lkrn
+ * _ISO generation command_ (`bootdisk_mkiso_command`) is the name of
+-  genisoimage/mkisofs on your OS
++  xorrisofs, genisoimage, or mkisofs on your OS
+ * _SYSLINUX directory_ (`bootdisk_syslinux_dir`) points to the directory
+   containing syslinux images
+ 
+diff --git a/app/services/foreman_bootdisk/iso_generator.rb b/app/services/foreman_bootdisk/iso_generator.rb
+index 51ae0cd..2076d9f 100644
+--- a/app/services/foreman_bootdisk/iso_generator.rb
++++ b/app/services/foreman_bootdisk/iso_generator.rb
+@@ -7,7 +7,7 @@ require 'uri'
+ 
+ # Generates an iPXE ISO hybrid image
+ #
+-# requires syslinux, ipxe/ipxe-bootimgs, genisoimage, isohybrid
++# requires syslinux, ipxe/ipxe-bootimgs, xorrisofs (or genisoimage/mkisofs), isohybrid
+ module ForemanBootdisk
+   class ISOGenerator
+     extend Foreman::HttpProxy
+diff --git a/lib/foreman_bootdisk/engine.rb b/lib/foreman_bootdisk/engine.rb
+index dac8319..bc54559 100644
+--- a/lib/foreman_bootdisk/engine.rb
++++ b/lib/foreman_bootdisk/engine.rb
+@@ -112,9 +112,9 @@ module ForemanBootdisk
+ 
+               setting "bootdisk_mkiso_command",
+                 type: :string,
+-                default: "genisoimage",
++                default: "xorrisofs",
+                 full_name: N_("ISO generation command"),
+-                description: N_("Command to generate ISO image, use genisoimage or mkisofs")
++                description: N_("Command to generate ISO image, use xorrisofs, genisoimage or mkisofs")
+ 
+               setting "bootdisk_cache_media",
+                 type: :boolean,
+-- 
+2.54.0

--- a/packages/plugins/rubygem-openscap/add-support-el10.patch
+++ b/packages/plugins/rubygem-openscap/add-support-el10.patch
@@ -1,0 +1,22 @@
+From cbfe5ba67dfd726278da6cd2bd483c1e89fdd0c8 Mon Sep 17 00:00:00 2001
+From: Odilon Sousa <osousa@redhat.com>
+Date: Wed, 5 Aug 2026 08:56:07 -0300
+Subject: [PATCH] Add support to EL10
+
+---
+ lib/openscap/openscap.rb | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/openscap/openscap.rb b/lib/openscap/openscap.rb
+index 966ea80..5806da5 100644
+--- a/lib/openscap/openscap.rb
++++ b/lib/openscap/openscap.rb
+@@ -4,7 +4,7 @@
+ 
+ module OpenSCAP
+   extend FFI::Library
+-  ffi_lib ['libopenscap.so.8', 'libopenscap.so.25', 'openscap']
++  ffi_lib ['libopenscap.so.8', 'libopenscap.so.25', 'libopenscap.so.33', 'openscap']
+ 
+   def self.error?
+     oscap_err

--- a/packages/plugins/rubygem-openscap/rubygem-openscap.spec
+++ b/packages/plugins/rubygem-openscap/rubygem-openscap.spec
@@ -6,19 +6,26 @@
 
 Name: %{?scl_prefix}rubygem-%{gem_name}
 Version: 0.4.9
-Release: 10%{?dist}
+Release: 11%{?dist}
 Summary: A FFI wrapper around the OpenSCAP library
 Group: Development/Languages
 License: GPLv2+
 URL: https://github.com/OpenSCAP/ruby-openscap
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
+Patch0: add-support-el10.patch
 
-# CI runs rpmlint on EL7
-%if 0%{?rhel} >= 8
+
+%if 0%{?rhel} == 9
 # Loaded via FFI
 Requires: (libopenscap.so.25()(64bit) if libc.so.6()(64bit))
 Requires: (libopenscap.so.25 if libc.so.6)
 %endif
+
+%if 0%{?rhel} == 10
+# Loaded via FFI
+Requires: (libopenscap.so.33()(64bit) if libc.so.6()(64bit))
+%endif
+
 
 # start specfile generated dependencies
 Requires: %{?scl_prefix_ruby}ruby(release)
@@ -52,6 +59,7 @@ gem unpack %{SOURCE0}
 %{?scl:EOF}
 
 %setup -q -D -T -n  %{gem_name}-%{version}
+%autopatch -p1
 
 %{?scl:scl enable %{scl} - << \EOF}
 gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
@@ -88,6 +96,9 @@ cp -a .%{gem_dir}/* \
 %{gem_instdir}/test
 
 %changelog
+* Wed Aug 05 2026 Odilon Sousa <osousa@redhat.com> - 0.4.9-11
+- Update libopenscap.so requirement to match EL10 released version
+
 * Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 0.4.9-10
 - Rebuild for EL10
 


### PR DESCRIPTION
<!--
If your package needs to be released within one or more release streams, and/or distributions, please open PRs to each of those branches respectively. The easiest way to do this is to make the initial commit for the mainline branch (e.g. rpm/develop or deb/develop) and then cherry pick the commit hash onto each subsequent branch.

The Foreman Community supports the `develop` branch for active development and the latest two releases.
You can view the currently supported versions on [theforeman.org](https://theforeman.org/).
 
RPM Example:

    git checkout -b rpm/develop-foreman-tasks-1.0.1 rpm/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b rpm/1.20-foreman-tasks-1.0.1-1.20 rpm/1.20
    git cherry-pick -x $COMMIT

DEB Example:

    git checkout -b deb/develop-foreman-tasks-1.0.1 deb/develop

    # Make changes to update package

    git commit -a -m 'Release foreman-tasks-1.0.1'
    COMMIT=`git rev-parse HEAD`

    git checkout -b deb/1.20-foreman-tasks-1.0.1-1.20 deb/1.20
    git cherry-pick -x $COMMIT

See Foreman's [plugin maintainer documentation](https://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Release-strategies) for more information.
-->

Plugins are failing with

```
[2026-08-05T01:18:51.651Z] fatal: [plugins-staging-repoclosure-el10]: FAILED! => 
[2026-08-05T01:18:51.651Z]     changed: false
[2026-08-05T01:18:51.651Z]     command: dnf repoclosure --refresh --newest --best --config /tmp/ansible.i0zi_9zzrepoclosure/yum.conf
[2026-08-05T01:18:51.651Z]         --arch noarch --arch x86_64 --check el10-foreman-plugins-nightly-staging --repo
[2026-08-05T01:18:51.651Z]         el10-foreman-plugins-nightly-staging --repo el10-baseos --repo el10-appstream
[2026-08-05T01:18:51.651Z]         --repo el10-configmanagement-salt --repo el10-openvox-8 --repo el10-foreman-nightly-staging
[2026-08-05T01:18:51.651Z]     msg: Repoclosure failed
[2026-08-05T01:18:51.651Z]     output: |-
[2026-08-05T01:18:51.651Z]         Unable to detect release version (use '--releasever' to specify release version)
[2026-08-05T01:18:51.651Z]         Last metadata expiration check: 0:00:01 ago on Wed 05 Aug 2026 01:18:49 AM UTC.
[2026-08-05T01:18:51.651Z]         Error: Repoclosure ended with unresolved dependencies (6) across 4 packages.
[2026-08-05T01:18:51.651Z]         package: ansible-collection-theforeman-foreman-5.11.0-2.el10.noarch from el10-foreman-plugins-nightly-staging
[2026-08-05T01:18:51.651Z]           unresolved deps (2):
[2026-08-05T01:18:51.651Z]             (python3.11-pyyaml if (ansible-core >= 2.14.2-3 and ansible-core < 1:2.14.7))
[2026-08-05T01:18:51.651Z]             (python3.11-requests if (ansible-core >= 2.14.2-3 and ansible-core < 1:2.14.7))
[2026-08-05T01:18:51.651Z]         package: ansible-test-1:2.16.14-4.el10.noarch from el10-foreman-plugins-nightly-staging
[2026-08-05T01:18:51.651Z]           unresolved deps (1):
[2026-08-05T01:18:51.651Z]             ansible-core = 1:2.16.14-4.el10
[2026-08-05T01:18:51.651Z]         package: rubygem-foreman_bootdisk-23.2.4-2.el10.noarch from el10-foreman-plugins-nightly-staging
[2026-08-05T01:18:51.651Z]           unresolved deps (1):
[2026-08-05T01:18:51.651Z]             /usr/bin/genisoimage
[2026-08-05T01:18:51.651Z]         package: rubygem-openscap-0.4.9-10.el10.noarch from el10-foreman-plugins-nightly-staging
[2026-08-05T01:18:51.651Z]           unresolved deps (2):
[2026-08-05T01:18:51.651Z]             (libopenscap.so.25 if libc.so.6)
[2026-08-05T01:18:51.651Z]             (libopenscap.so.25()(64bit) if libc.so.6()(64bit))
[2026-08-05T01:18:52.052Z] 
```

Ansible-core needs python3- on EL10 since it's system python with 3.12
Foreman Bootdisk needs xorriso, genisoimage and isohybrid are not present on CS10, only in EPEL
Openscap changed also on EL10