### PR TITLE
Remove module_hotfixes from el10 repoclosure repos

### DIFF
--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -58,22 +58,18 @@ baseurl=https://stagingyum.theforeman.org/client/nightly/el10/x86_64/
 [el10-foreman-nightly-staging]
 name=Foreman nightly staging EL10
 baseurl=https://stagingyum.theforeman.org/foreman/nightly/el10/x86_64/
-module_hotfixes=1
 
 [el10-foreman-plugins-nightly-staging]
 name=Foreman Plugins nightly staging EL10
 baseurl=https://stagingyum.theforeman.org/plugins/nightly/el10/x86_64/
-module_hotfixes=1
 
 [el10-katello-nightly-staging]
 name=Katello nightly staging EL10
 baseurl=https://stagingyum.theforeman.org/katello/nightly/el10/x86_64/
-module_hotfixes=1
 
 [el10-candlepin-5.0-staging]
 name=Candlepin 5.0 staging EL10
 baseurl=https://stagingyum.theforeman.org/candlepin/5.0/el10/x86_64/
-module_hotfixes=1
 
 [el9-foreman-client-nightly-staging]
 name=Foreman Client nightly EL9


### PR DESCRIPTION
## Summary

`module_hotfixes` exists to make a non-modular package visible when a repo of the same name also ships modular content (relevant on el8/el9 AppStream). el10 dropped modularity entirely, so the flag is a no-op on the el10 staging repos in `repoclosure/yum.conf`. Removing it for clarity — no functional change.

## Changes

- `repoclosure/yum.conf`: drop `module_hotfixes=1` from `el10-foreman-nightly-staging`, `el10-foreman-plugins-nightly-staging`, `el10-katello-nightly-staging`, `el10-candlepin-5.0-staging`.

## Test plan

- [x] `obal repoclosure foreman-staging-repoclosure-el10` — passes, same as before
- [x] `obal repoclosure plugins-staging-repoclosure-el10` — same 2 known unresolved deps as before (ansible-core, genisoimage — unrelated pre-existing gaps), unaffected by this change
- [x] `obal repoclosure katello-staging-repoclosure-el10` — passes, same as before