### PR TITLE
Add scoped_search team to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -96,6 +96,9 @@
 # salt
 /packages/plugins/*_salt/ @theforeman/packaging @theforeman/salt
 
+# scoped_search
+/packages/foreman/rubygem-scoped_search/ @theforeman/packaging @theforeman/scoped_search
+
 # webhooks
 /packages/plugins/*_webhooks/ @theforeman/packaging @theforeman/webhooks
 /packages/plugins/rubygem-smart_proxy_shellhooks/ @theforeman/packaging @theforeman/webhooks


### PR DESCRIPTION
Add @theforeman/scoped_search as CODEOWNERS for packages/foreman/rubygem-scoped_search/, same pattern as other team-owned plugins (e.g. foreman_theme_satellite).