### PR TITLE
Exclude ansible-core and ansible-test from el10 appstream repoclosure

### DIFF
--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -22,6 +22,7 @@ enabled=1
 name=CentOS Stream 10 - AppStream
 metalink=https://mirrors.centos.org/metalink?repo=centos-appstream-10-stream&arch=x86_64&protocol=https,http
 enabled=1
+excludepkgs=ansible-core,ansible-test
 
 [el10-crb]
 name=CentOS Stream 10 - CRB


### PR DESCRIPTION
## Summary

- Exclude `ansible-core` and `ansible-test` from el10-appstream in the repoclosure yum.conf

CentOS Stream 10 appstream ships `ansible-core-1:2.16.18`, which is newer than foreman-packaging's `1:2.16.14`. With `--newest`, dnf only considers the appstream version during repoclosure, leaving `ansible-test`'s exact version dependency (`= 1:2.16.14-4.el10`) unresolved.

This is the same pattern used for ruby packages in el8-appstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)