### PR TITLE
Fix stale npm bundle/single strategy detection in bump_rpm.sh

### DIFF
--- a/bump_rpm.sh
+++ b/bump_rpm.sh
@@ -130,9 +130,8 @@ if [[ $CURRENT_VERSION != "$NEW_VERSION" ]] ; then
 
 		echo "Bumping NPM package"
 		SKIP_GIT_COMMIT=1
-		SOURCES=$(spectool --list-files "$1"/$SPEC_FILE)
 
-		if [[ $SOURCES == *registry.npmjs.org.tgz* ]]; then
+		if grep -q 'bundled(npm(' "$1"/$SPEC_FILE; then
 			NPM_STRATEGY='bundle'
 		else
 			NPM_STRATEGY='single'


### PR DESCRIPTION
## Summary

`bump_rpm.sh` decides whether to regenerate a `nodejs-*` package with the
`bundle` or `single` npm2rpm strategy by checking `spectool --list-files`
output for the literal substring `registry.npmjs.org.tgz`. That substring
only ever matched because older npm2rpm versions named the npm-cache stub
lockfile source `PACKAGE-VERSION-registry.npmjs.org.tgz`. npm2rpm 8.0.0
dropped that naming in favor of `PACKAGE-VERSION-package-lock.json` sources
and `Provides: bundled(npm(...))` lines, so the check silently stopped
matching for every bundle-strategy package.

As a result, the next bot bump of any such package falls through to
`NPM_STRATEGY=single`, and `add_npm_package.sh` regenerates the whole
package directory from scratch as a `single`-strategy package — wiping the
vendored dependency tarballs and the lockfile instead of regenerating them.
This is what happened to `nodejs-webpack` in #13905.

`add_npm_package.sh`'s rewrite-in-place path hit the exact same bug and was
fixed in #13702 by checking `grep -q 'bundled(npm(' "$SPEC_FILE"` instead of
the stale substring. This PR applies the same fix to `bump_rpm.sh`, since
that's the code path actual version bumps (including bot bumps) go through.

## Test plan

- [x] `bash -n bump_rpm.sh` — syntax OK
- [x] Verified the new check correctly classifies existing bundle-strategy
      packages (`nodejs-webpack`, `nodejs-babel-core`, `nodejs-react`, ...)
      as `bundle`, and existing single-source packages (`nodejs-axios`,
      `nodejs-argv-parse`, ...) as `single`
- [x] Re-run the `nodejs-webpack` bump with this fix and confirm the bundle
      sources and lockfile are regenerated instead of dropped