### PR TITLE
Release rubygem-smart_proxy_container_gateway-4.0.0

### DIFF
--- a/packages/plugins/rubygem-smart_proxy_container_gateway/rubygem-smart_proxy_container_gateway.spec
+++ b/packages/plugins/rubygem-smart_proxy_container_gateway/rubygem-smart_proxy_container_gateway.spec
@@ -9,8 +9,8 @@
 %global foreman_proxy_settingsd_dir %{_sysconfdir}/foreman-proxy/settings.d
 
 Name: rubygem-%{gem_name}
-Version: 3.5.0
-Release: 2%{?foremandist}%{?dist}
+Version: 4.0.0
+Release: 1%{?foremandist}%{?dist}
 Summary: Pulp 3 container registry support for Foreman/Katello Smart-Proxy
 License: GPLv3
 URL: https://github.com/ianballou/smart_proxy_container_gateway
@@ -79,6 +79,9 @@ mv %{buildroot}%{gem_instdir}/settings.d/container_gateway.yml.example \
 %doc %{gem_instdir}/README.md
 
 %changelog
+* Thu Aug 06 2026 ianballou <ianballou67@gmail.com> - 4.0.0-1
+- Update to 4.0.0
+
 * Wed Jul 29 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.5.0-2
 - Rebuild for EL10
 

--- a/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-3.5.0.gem
+++ b/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-3.5.0.gem
@@ -1,1 +1,0 @@
-../../../.git/annex/objects/VM/WQ/SHA256E-s27136--cbd31898261183f10a18752fa87cf90aba49efe5c8bfd2548f75d7133c5d19ae.0.gem/SHA256E-s27136--cbd31898261183f10a18752fa87cf90aba49efe5c8bfd2548f75d7133c5d19ae.0.gem

--- a/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-4.0.0.gem
+++ b/packages/plugins/rubygem-smart_proxy_container_gateway/smart_proxy_container_gateway-4.0.0.gem
@@ -1,0 +1,1 @@
+../../../.git/annex/objects/77/mk/SHA256E-s27136--5d1bfc9c775c3ff6d39f5b794fbacee08ea4b0beab7e4248ebeebd33730907e4.0.gem/SHA256E-s27136--5d1bfc9c775c3ff6d39f5b794fbacee08ea4b0beab7e4248ebeebd33730907e4.0.gem


### PR DESCRIPTION
Updated container gateway with no default Pulp URI for https://github.com/theforeman/foreman-oci-images/pull/53