### PR TITLE
foreman: add libcap-dev to Build-Depends for cap2

### DIFF
--- a/debian/bookworm/foreman/changelog
+++ b/debian/bookworm/foreman/changelog
@@ -1,3 +1,10 @@
+foreman (5.0.0-3) stable; urgency=low
+
+  * Add libcap-dev to Build-Depends (needed to compile the cap2 gem
+    pulled in by net-ping >= 2.1.0)
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Tue, 11 Aug 2026 09:24:00 +0200
+
 foreman (5.0.0-2) stable; urgency=low
 
   * Pin i18n gem to a compatible version

--- a/debian/bookworm/foreman/control
+++ b/debian/bookworm/foreman/control
@@ -4,7 +4,7 @@ Section: web
 Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 9.20160709), ruby-dev (>= 1:2.7), git,
-               zlib1g-dev, libpq-dev, pkg-config, libvirt-dev, libyaml-dev,
+               zlib1g-dev, libpq-dev, pkg-config, libvirt-dev, libyaml-dev, libcap-dev,
                build-essential, curl, nodejs (>= 22.0), npm, libffi-dev,
                python3, libsystemd-dev, libcurl4-openssl-dev, libxml2-dev, tzdata,
                libfontconfig1, libfreetype6

--- a/debian/jammy/foreman/changelog
+++ b/debian/jammy/foreman/changelog
@@ -1,3 +1,10 @@
+foreman (5.0.0-3) stable; urgency=low
+
+  * Add libcap-dev to Build-Depends (needed to compile the cap2 gem
+    pulled in by net-ping >= 2.1.0)
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Tue, 11 Aug 2026 09:24:00 +0200
+
 foreman (5.0.0-2) stable; urgency=low
 
   * Pin i18n gem to a compatible version

--- a/debian/jammy/foreman/control
+++ b/debian/jammy/foreman/control
@@ -4,7 +4,7 @@ Section: web
 Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 9.20160709), ruby-dev (>= 1:2.7), git,
-               zlib1g-dev, libpq-dev, pkg-config, libvirt-dev,
+               zlib1g-dev, libpq-dev, pkg-config, libvirt-dev, libcap-dev,
                build-essential, curl, nodejs (>= 22.0), libffi-dev,
                python3, libsystemd-dev, libcurl4-openssl-dev, libxml2-dev, tzdata,
                libfontconfig1, libfreetype6

--- a/debian/noble/foreman/changelog
+++ b/debian/noble/foreman/changelog
@@ -1,3 +1,10 @@
+foreman (5.0.0-3) stable; urgency=low
+
+  * Add libcap-dev to Build-Depends (needed to compile the cap2 gem
+    pulled in by net-ping >= 2.1.0)
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Tue, 11 Aug 2026 09:24:00 +0200
+
 foreman (5.0.0-2) stable; urgency=low
 
   * Pin i18n gem to a compatible version

--- a/debian/noble/foreman/control
+++ b/debian/noble/foreman/control
@@ -4,7 +4,7 @@ Section: web
 Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 9.20160709), ruby-dev (>= 1:2.7), git,
-               zlib1g-dev, libpq-dev, pkg-config, libvirt-dev, libyaml-dev,
+               zlib1g-dev, libpq-dev, pkg-config, libvirt-dev, libyaml-dev, libcap-dev,
                build-essential, curl, nodejs (>= 22.0), npm, libffi-dev,
                python3, libsystemd-dev, libcurl4-openssl-dev, libxml2-dev, tzdata,
                libfontconfig1, libfreetype6

--- a/debian/trixie/foreman/changelog
+++ b/debian/trixie/foreman/changelog
@@ -1,3 +1,10 @@
+foreman (5.0.0-3) stable; urgency=low
+
+  * Add libcap-dev to Build-Depends (needed to compile the cap2 gem
+    pulled in by net-ping >= 2.1.0)
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Tue, 11 Aug 2026 09:24:00 +0200
+
 foreman (5.0.0-2) stable; urgency=low
 
   * Pin i18n gem to a compatible version

--- a/debian/trixie/foreman/control
+++ b/debian/trixie/foreman/control
@@ -4,7 +4,7 @@ Section: web
 Priority: extra
 Standards-Version: 3.9.1
 Build-Depends: debhelper (>= 9.20160709), ruby-dev (>= 1:2.7), git,
-               zlib1g-dev, libpq-dev, pkg-config, libvirt-dev, libyaml-dev,
+               zlib1g-dev, libpq-dev, pkg-config, libvirt-dev, libyaml-dev, libcap-dev,
                build-essential, curl, nodejs (>= 22.0), npm, libffi-dev,
                python3, libsystemd-dev, libcurl4-openssl-dev, libxml2-dev, tzdata,
                libfontconfig1, libfreetype6


### PR DESCRIPTION
net-ping 2.1.0 pulls in the cap2 gem, which needs libcap headers to compile. Fixes foreman-develop-package-release failing on jammy/bookworm/noble/trixie.

Refs theforeman/foreman-infra#2455, theforeman/actions#96, Foreman#39600