### PR TITLE
Remove foreman-installer from el10 comps

### DIFF
--- a/comps/comps-foreman-el10.xml
+++ b/comps/comps-foreman-el10.xml
@@ -20,8 +20,6 @@
       <packagereq type="default">foreman-dynflow-sidekiq</packagereq>
       <packagereq type="default">foreman-ec2</packagereq>
       <packagereq type="default">foreman-fapolicyd</packagereq>
-      <packagereq type="default">foreman-installer</packagereq>
-      <packagereq type="default">foreman-installer-katello</packagereq>
       <packagereq type="default">foreman-journald</packagereq>
       <packagereq type="default">foreman-libvirt</packagereq>
       <packagereq type="default">foreman-obsolete-packages</packagereq>


### PR DESCRIPTION
Foreman 5.0 ships everything for el10 except `foreman-installer` and `foreman-installer-katello`, which aren't ready for that dist yet. Dropping them from comps keeps them out of the staged/production el10 repo, per discussion on theforeman/theforeman-rel-eng#603.

