### PR TITLE
foreman: add libcap-dev to Depends for cap2

### DIFF
--- a/debian/bookworm/foreman/changelog
+++ b/debian/bookworm/foreman/changelog
@@ -1,3 +1,10 @@
+foreman (5.0.0-4) stable; urgency=low
+
+  * Add libcap-dev to Depends (postinst runs bundle update --local,
+    which recompiles the cap2 native extension on the target host)
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Tue, 11 Aug 2026 14:44:54 +0200
+
 foreman (5.0.0-3) stable; urgency=low
 
   * Add libcap-dev to Build-Depends (needed to compile the cap2 gem

--- a/debian/bookworm/foreman/control
+++ b/debian/bookworm/foreman/control
@@ -14,7 +14,7 @@ Package: foreman
 Architecture: any
 Section: web
 Priority: extra
-Depends: ruby (>= 1:2.7), ruby-dev, zlib1g-dev,
+Depends: ruby (>= 1:2.7), ruby-dev, zlib1g-dev, libcap-dev,
          build-essential, tzdata, libyaml-dev, libffi-dev,
          rake (>=0.8.4), gawk, ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug (= ${binary:Version})

--- a/debian/jammy/foreman/changelog
+++ b/debian/jammy/foreman/changelog
@@ -1,3 +1,10 @@
+foreman (5.0.0-4) stable; urgency=low
+
+  * Add libcap-dev to Depends (postinst runs bundle update --local,
+    which recompiles the cap2 native extension on the target host)
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Tue, 11 Aug 2026 14:44:54 +0200
+
 foreman (5.0.0-3) stable; urgency=low
 
   * Add libcap-dev to Build-Depends (needed to compile the cap2 gem

--- a/debian/jammy/foreman/control
+++ b/debian/jammy/foreman/control
@@ -14,7 +14,7 @@ Package: foreman
 Architecture: any
 Section: web
 Priority: extra
-Depends: ruby (>= 1:2.7), ruby-dev, zlib1g-dev,
+Depends: ruby (>= 1:2.7), ruby-dev, zlib1g-dev, libcap-dev,
          build-essential, tzdata, libffi-dev,
          rake (>=0.8.4), gawk, ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug (= ${binary:Version})

--- a/debian/noble/foreman/changelog
+++ b/debian/noble/foreman/changelog
@@ -1,3 +1,10 @@
+foreman (5.0.0-4) stable; urgency=low
+
+  * Add libcap-dev to Depends (postinst runs bundle update --local,
+    which recompiles the cap2 native extension on the target host)
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Tue, 11 Aug 2026 14:44:54 +0200
+
 foreman (5.0.0-3) stable; urgency=low
 
   * Add libcap-dev to Build-Depends (needed to compile the cap2 gem

--- a/debian/noble/foreman/control
+++ b/debian/noble/foreman/control
@@ -14,7 +14,7 @@ Package: foreman
 Architecture: any
 Section: web
 Priority: extra
-Depends: ruby (>= 1:2.7), ruby-dev, zlib1g-dev,
+Depends: ruby (>= 1:2.7), ruby-dev, zlib1g-dev, libcap-dev,
          build-essential, tzdata, libyaml-dev, libffi-dev,
          rake (>=0.8.4), gawk, ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug (= ${binary:Version})

--- a/debian/trixie/foreman/changelog
+++ b/debian/trixie/foreman/changelog
@@ -1,3 +1,10 @@
+foreman (5.0.0-4) stable; urgency=low
+
+  * Add libcap-dev to Depends (postinst runs bundle update --local,
+    which recompiles the cap2 native extension on the target host)
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Tue, 11 Aug 2026 14:44:54 +0200
+
 foreman (5.0.0-3) stable; urgency=low
 
   * Add libcap-dev to Build-Depends (needed to compile the cap2 gem

--- a/debian/trixie/foreman/control
+++ b/debian/trixie/foreman/control
@@ -14,7 +14,7 @@ Package: foreman
 Architecture: any
 Section: web
 Priority: extra
-Depends: ruby (>= 1:2.7), ruby-dev, zlib1g-dev,
+Depends: ruby (>= 1:2.7), ruby-dev, zlib1g-dev, libcap-dev,
          build-essential, tzdata, libyaml-dev, libffi-dev,
          rake (>=0.8.4), gawk, ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug (= ${binary:Version})


### PR DESCRIPTION
Follow-up to #13953. That PR fixed the *build*, but postinst runs `bundle update --local` on the target host too, so cap2 needs libcap-dev at install time as well — fails foreman-pipeline-foreman-deb-nightly on debian12/ubuntu2204. Same two-step pattern as libyaml-dev/psych (3.11.0-3 → 3.11.0-4).

Refs theforeman/foreman-infra#2455, theforeman/actions#96, Foreman#39600