### PR TITLE
ruby-hammer-cli-foreman-puppet: bump to 0.1.3-2 to force rebuild

### DIFF
--- a/dependencies/bookworm/hammer_cli_foreman_puppet/changelog
+++ b/dependencies/bookworm/hammer_cli_foreman_puppet/changelog
@@ -1,3 +1,10 @@
+ruby-hammer-cli-foreman-puppet (0.1.3-2) stable; urgency=low
+
+  * Rebuild to publish relaxed ruby-hammer-cli-foreman dependency (<<
+    6.0.0)
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Tue, 11 Aug 2026 19:00:25 +0200
+
 ruby-hammer-cli-foreman-puppet (0.1.3-1) stable; urgency=low
 
   * 0.1.3 released

--- a/dependencies/jammy/hammer_cli_foreman_puppet/changelog
+++ b/dependencies/jammy/hammer_cli_foreman_puppet/changelog
@@ -1,3 +1,10 @@
+ruby-hammer-cli-foreman-puppet (0.1.3-2) stable; urgency=low
+
+  * Rebuild to publish relaxed ruby-hammer-cli-foreman dependency (<<
+    6.0.0)
+
+ -- Ondřej Gajdušek <ogajduse@redhat.com>  Tue, 11 Aug 2026 19:00:25 +0200
+
 ruby-hammer-cli-foreman-puppet (0.1.3-1) stable; urgency=low
 
   * 0.1.3 released


### PR DESCRIPTION
Changelog-only bump, no source change. a01a62872 relaxed the ruby-hammer-cli-foreman dependency to << 6.0.0 in control, but only touched control, not changelog — CI never rebuilt/republished it. Confirmed the published .deb on bookworm/jammy nightly still ships << 4.0.0, conflicting with ruby-hammer-cli-foreman 5.0.0 and breaking foreman-pipeline-foreman-deb-nightly's debian12/ubuntu2204 upgrade tests.

Unrelated to the earlier libcap-dev/cap2 fixes (#13953, #13958) — different package, different bug.