### PR TITLE
Do not require foreman-installer-katello on EL10

### DIFF
--- a/packages/katello/katello/katello.spec
+++ b/packages/katello/katello/katello.spec
@@ -5,7 +5,7 @@
 %global confdir common
 %global prereleasesource rc1
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 1
+%global release 2
 
 Name:       katello
 Version:    5.0.0
@@ -27,7 +27,9 @@ BuildRequires: util-linux
 
 Requires: %{name}-common = %{version}-%{release}
 
+%if 0%{?rhel} < 10
 Requires: foreman-installer-%{name}
+%endif
 
 Requires: %{?scl_prefix}rubygem-katello
 
@@ -112,7 +114,9 @@ Useful utilities for debug info collecting
 Summary: Provides a federation of katello services
 BuildArch: noarch
 Requires: findutils
+%if 0%{?rhel} < 10
 Requires: foreman-installer-%{name}
+%endif
 Requires: rubygem-foreman_maintain >= 0.2.2
 Requires: %{name}-common = %{version}-%{release}
 
@@ -123,6 +127,9 @@ Provides a federation of katello services
 # the files section is empty, but without it no RPM will be generated
 
 %changelog
+* Thu Aug 13 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.2.rc1
+- Do not require foreman-installer-katello on EL10
+
 * Tue Aug 11 2026 Zach Huntington-Meath <zhunting@redhat.com> - 5.0.0-0.1.rc1
 - Release katello 5.0.0rc1
 


### PR DESCRIPTION
## Summary
- `foreman-installer-katello` is not built for EL10, so make the dependency conditional on `rhel < 10` for both `katello` and `foreman-proxy-content` subpackages
- Fixes repoclosure failure on EL10

🤖 Generated with [Claude Code](https://claude.com/claude-code)