### PR TITLE
Fix false CONFLICT for leaf packages also pinned by a lockfile

### DIFF
--- a/bump_rpm.sh
+++ b/bump_rpm.sh
@@ -71,7 +71,12 @@ else
 
 	if [[ $NEW_VERSION == "CONFLICT" ]] ; then
 		echo "${PACKAGE_NAME}: requested with a conflict."
-		echo "This means multiple packages requested different versions"
+		echo "This means multiple packages requested different versions:"
+		if [[ -n $DETAIL ]] ; then
+			echo "  ${DETAIL}"
+		else
+			echo "  (no details available)"
+		fi
 		exit 1
 	fi
 fi

--- a/list_updatable_packages
+++ b/list_updatable_packages
@@ -209,10 +209,11 @@ def merge_specs(specs: Iterable[Tuple[Spec, Optional[str], Optional[str]]]) -> M
     result: Dict[Spec, Dict[Optional[str], Optional[str]]] = {}
     for spec, new_version, project in specs:
         existing_spec = result.get(spec)
-        if existing_spec and existing_spec['new_version'] != new_version:
+        if existing_spec and existing_spec['new_version'] not in (None, new_version):
             # TODO: GH annotation?
-            print(f'Found conflict for {spec.package_name}: {result[spec]["new_version"]} ({result[spec]["project"]}) != {new_version} ({project})', file=sys.stderr)
-            result[spec] = {'new_version': 'CONFLICT', 'project': project}
+            detail = f'{result[spec]["new_version"]} ({result[spec]["project"]}) != {new_version} ({project})'
+            print(f'Found conflict for {spec.package_name}: {detail}', file=sys.stderr)
+            result[spec] = {'new_version': 'CONFLICT', 'project': project, 'detail': detail}
         else:
             result[spec] = {'new_version': new_version, 'project': project}
     return result
@@ -246,6 +247,8 @@ def build_matrix(specs: Mapping[Spec, Dict[Optional[str], Optional[str]]], packa
                     'current_version': current_version,
                     'new_version': new_version,
                 }
+                if new_version == 'CONFLICT':
+                    entry['detail'] = metadata.get('detail', '')
                 yield entry
 
 


### PR DESCRIPTION
`list_updatable_packages` was permanently flagging some packages `CONFLICT` even when every version source actually agreed — e.g. `rubygem-foreman-tasks` and `rubygem-foreman_remote_execution`, both stuck failing every run: https://github.com/theforeman/foreman-packaging/actions/runs/32013508243/job/95338069508

```
Run ./bump_rpm.sh "packages/plugins/rubygem-foreman_remote_execution" "CONFLICT"
rubygem-foreman_remote_execution: requested with a conflict.
This means multiple packages requested different versions
##[error]Process completed with exit code 1.
```

**Cause:** `merge_specs()` treats "supported leaf" packages (tracked via `find_packaged_specs()`, which yields no explicit version — just "check latest upstream") as a source equal to any real `Gemfile.lock` pin. #9470 restructured the comparison for better conflict messages, but the rewrite dropped the original `not in (None, new_version)` tolerance that let a leaf's placeholder be safely overwritten by a real pin — leaving the docstring ("will take the more specific constraint") describing behavior the code no longer had. This stayed unnoticed until #13674 widened the glob that discovers Gemfile.lock-pinned specs, which is what started catching these plugin packages.

**Fix:** restore the original comparison (`not in (None, new_version)`), so a leaf placeholder yields to a real pin instead of being compared against it. Also propagate the actual conflicting versions/projects into the matrix entry, and have `bump_rpm.sh` print that detail on a genuine `CONFLICT` (via the new `DETAIL` env var, wired up in the companion workflow PR below), so the failing job is self-explanatory instead of requiring a cross-reference against the separate `Gather RPMs` job's log. For a genuine conflict (e.g. two projects pinning different versions of a shared dependency), the job now prints:

```
rubygem-concurrent-ruby: requested with a conflict.
This means multiple packages requested different versions:
  1.1.10 (foreman) != 1.3.8 (smart-proxy)
```

instead of just the generic message shown above.

Companion workflow change (to actually wire the new detail through in CI): #14003
