### PR TITLE
Pass conflict detail to bump_rpm.sh

### DIFF
--- a/.github/workflows/bump_packages.yml
+++ b/.github/workflows/bump_packages.yml
@@ -67,6 +67,7 @@ jobs:
       run: ./bump_rpm.sh "${{ matrix.directory }}" "${{ matrix.new_version }}"
       env:
         SKIP_GIT_COMMIT: 1
+        DETAIL: ${{ matrix.detail }}
     - name: Open a PR
       uses: peter-evans/create-pull-request@v7
       with:


### PR DESCRIPTION
Companion to #14002, which restores `merge_specs()`'s leaf-vs-pin agreement handling and starts propagating the actual conflicting versions/projects into the matrix entry as `matrix.detail`. This PR wires that field through to `bump_rpm.sh` so a genuine `CONFLICT` job prints something actionable, e.g.:

```
rubygem-concurrent-ruby: requested with a conflict.
This means multiple packages requested different versions:
  1.1.10 (foreman) != 1.3.8 (smart-proxy)
```

instead of just:

```
rubygem-concurrent-ruby: requested with a conflict.
This means multiple packages requested different versions
```

Passed via `env:` rather than inline in `run:`, since `detail` strings embed lockfile-derived text that never passes `bump_rpm.sh`'s own version validation.

Needs #14002 merged first for `matrix.detail` to actually be populated.
