### PR TITLE
Handle DOWNGRADE sentinel in bump_rpm.sh

### DIFF
--- a/bump_rpm.sh
+++ b/bump_rpm.sh
@@ -79,6 +79,12 @@ else
 		fi
 		exit 1
 	fi
+
+	if [[ $NEW_VERSION == "DOWNGRADE" ]] ; then
+		echo "${PACKAGE_NAME}: requested version would be a downgrade."
+		echo "This means the detected version is older than what is currently packaged."
+		exit 1
+	fi
 fi
 
 if [[ $CURRENT_VERSION != "$NEW_VERSION" ]] ; then


### PR DESCRIPTION
Fixes the ENOENT crash seen in [this run](https://github.com/theforeman/foreman-packaging/actions/runs/32367036717/job/96418838135): `bump_rpm.sh` handled the `CONFLICT` sentinel from `list_updatable_packages` but not `DOWNGRADE`, so it fell through to a normal bump and crashed npm2rpm trying to download a bogus version. Now it exits cleanly with a message, like `CONFLICT` does.

Related upstream npm2rpm issue (crashes with a stack trace instead of a clear error on invalid registry responses): theforeman/npm2rpm#103