### PR TITLE
Fix rubygem-foreman_theme_satellite to use Satellite assets for el10sat builds

### DIFF
--- a/packages/satellite/rubygem-foreman_theme_satellite/rubygem-foreman_theme_satellite.spec
+++ b/packages/satellite/rubygem-foreman_theme_satellite/rubygem-foreman_theme_satellite.spec
@@ -3,11 +3,11 @@
 %global plugin_name theme_satellite
 %global foreman_min_version 3.15.0
 
-%global downstream_build ("%{?dist}" == ".el8sat" || "%{?dist}" == ".el9sat")
+%global downstream_build ("%{?dist}" == ".el8sat" || "%{?dist}" == ".el9sat" || "%{?dist}" == ".el10sat")
 
 Name: rubygem-%{gem_name}
 Version: 16.4.0
-Release: 1%{?foremandist}%{?dist}
+Release: 2%{?foremandist}%{?dist}
 Summary: This is a plugin that enables building a theme for Foreman
 License: GPLv3
 URL: https://github.com/RedHatSatellite/foreman_theme_satellite
@@ -104,6 +104,9 @@ cp -a .%{gem_dir}/* \
 %{foreman_plugin_log}
 
 %changelog
+* Thu Aug 27 2026 Zach Huntington-Meath <zhunting@redhat.com> - 16.4.0-2
+- Include el10sat in downstream_build condition to use Satellite-branded assets
+
 * Mon Aug 03 2026 Foreman Packaging Automation <packaging@theforeman.org> - 16.4.0-1
 - Update to 16.4.0
 


### PR DESCRIPTION
The `downstream_build` condition was missing `el10sat`, causing el10sat builds to use the upstream gem's Foreman-branded assets instead of the Satellite-branded assets from `foreman_theme_satellite_assets`.

This resulted in the Foreman helmet logo appearing on the login screen instead of the Red Hat Satellite logo.

**Root cause:** The spec file only checked for `.el8sat` and `.el9sat` when deciding whether to replace the upstream assets with Satellite-branded ones.

**Fix:** Add `.el10sat` to the downstream_build condition.

**Impact:** After this fix and a rebuild, el10sat packages will show the correct Red Hat Satellite logo on the login page.

Fixes: Login page shows Foreman logo instead of Satellite logo on el10sat