### PR TITLE
Add openssh-clients dependency to foreman

### DIFF
--- a/packages/foreman/foreman/foreman.spec
+++ b/packages/foreman/foreman/foreman.spec
@@ -6,7 +6,7 @@
 %global dynflow_sidekiq_service_name dynflow-sidekiq@
 %global rake /usr/bin/rake
 
-%global release 1
+%global release 2
 %global prereleasesource develop
 %global prerelease %{?prereleasesource}
 
@@ -41,6 +41,7 @@ Requires: wget
 Requires: /etc/cron.d
 Requires: gawk
 Requires: /usr/sbin/sendmail
+Requires: openssh-clients
 Requires: sshpass
 
 Requires(pre):  shadow-utils
@@ -859,6 +860,9 @@ exit 0
 %endif
 
 %changelog
+* Tue Sep 01 2026 Lukas Zapletal - 5.1.0-0.2.develop
+- Add openssh-clients dependency (ssh client invoked by sshpass)
+
 * Wed Aug 12 2026 Ondřej Gajdušek <ogajduse@redhat.com> - 5.1.0-0.1.develop
 - Bump version to 5.1-develop
 


### PR DESCRIPTION
### What

Add an explicit `Requires: openssh-clients` to the foreman package.

### Why

The foreman package already requires `sshpass`, which shells out to the `ssh` client binary at runtime. Without an explicit dependency, `/usr/bin/ssh` is not guaranteed to be present on the host. This adds `openssh-clients` (the package that provides the ssh client) so the pair is complete.

Note: `sshpass` is already present in the spec, so only the ssh client is added here. `openssh-clients` (not the bare `ssh`, which does not exist as a package on EL/Fedora) is the correct package providing `/usr/bin/ssh`.

The release is bumped and a changelog entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)