### PR TITLE
Add openssh-client and sshpass to foreman Depends

### DIFF
--- a/debian/bookworm/foreman/changelog
+++ b/debian/bookworm/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (5.1.0-2) stable; urgency=low
+
+  * Add openssh-client and sshpass to Depends (ssh client invoked by sshpass)
+
+ -- Lukas Zapletal <lzap+git@redhat.com>  Tue, 01 Sep 2026 14:41:28 +0200
+
 foreman (5.1.0-1) stable; urgency=low
 
   * Bump changelog to 5.1.0 to match VERSION

--- a/debian/bookworm/foreman/control
+++ b/debian/bookworm/foreman/control
@@ -16,7 +16,7 @@ Section: web
 Priority: extra
 Depends: ruby (>= 1:2.7), ruby-dev, zlib1g-dev, libcap-dev,
          build-essential, tzdata, libyaml-dev, libffi-dev,
-         rake (>=0.8.4), gawk, ${misc:Depends}
+         rake (>=0.8.4), gawk, openssh-client, sshpass, ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug (= ${binary:Version})
 Conflicts: ruby-activerecord-deprecated-finders, ruby-foreman-tasks (<< 0.10.1), ruby-sequel-pg, ruby-foreman-hooks (<= 0.3.17)
 Replaces: foreman-compute, foreman-rackspace

--- a/debian/jammy/foreman/changelog
+++ b/debian/jammy/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (5.1.0-2) stable; urgency=low
+
+  * Add openssh-client and sshpass to Depends (ssh client invoked by sshpass)
+
+ -- Lukas Zapletal <lzap+git@redhat.com>  Tue, 01 Sep 2026 14:41:28 +0200
+
 foreman (5.1.0-1) stable; urgency=low
 
   * Bump changelog to 5.1.0 to match VERSION

--- a/debian/jammy/foreman/control
+++ b/debian/jammy/foreman/control
@@ -16,7 +16,7 @@ Section: web
 Priority: extra
 Depends: ruby (>= 1:2.7), ruby-dev, zlib1g-dev, libcap-dev,
          build-essential, tzdata, libffi-dev,
-         rake (>=0.8.4), gawk, ${misc:Depends}
+         rake (>=0.8.4), gawk, openssh-client, sshpass, ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug (= ${binary:Version})
 Conflicts: ruby-activerecord-deprecated-finders, ruby-foreman-tasks (<< 0.10.1), ruby-sequel-pg, ruby-foreman-hooks (<= 0.3.17)
 Replaces: foreman-compute, foreman-rackspace

--- a/debian/noble/foreman/changelog
+++ b/debian/noble/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (5.1.0-2) stable; urgency=low
+
+  * Add openssh-client and sshpass to Depends (ssh client invoked by sshpass)
+
+ -- Lukas Zapletal <lzap+git@redhat.com>  Tue, 01 Sep 2026 14:41:28 +0200
+
 foreman (5.1.0-1) stable; urgency=low
 
   * Bump changelog to 5.1.0 to match VERSION

--- a/debian/noble/foreman/control
+++ b/debian/noble/foreman/control
@@ -16,7 +16,7 @@ Section: web
 Priority: extra
 Depends: ruby (>= 1:2.7), ruby-dev, zlib1g-dev, libcap-dev,
          build-essential, tzdata, libyaml-dev, libffi-dev,
-         rake (>=0.8.4), gawk, ${misc:Depends}
+         rake (>=0.8.4), gawk, openssh-client, sshpass, ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug (= ${binary:Version})
 Conflicts: ruby-activerecord-deprecated-finders, ruby-foreman-tasks (<< 0.10.1), ruby-sequel-pg, ruby-foreman-hooks (<= 0.3.17)
 Replaces: foreman-compute, foreman-rackspace

--- a/debian/trixie/foreman/changelog
+++ b/debian/trixie/foreman/changelog
@@ -1,3 +1,9 @@
+foreman (5.1.0-2) stable; urgency=low
+
+  * Add openssh-client and sshpass to Depends (ssh client invoked by sshpass)
+
+ -- Lukas Zapletal <lzap+git@redhat.com>  Tue, 01 Sep 2026 14:41:28 +0200
+
 foreman (5.1.0-1) stable; urgency=low
 
   * Bump changelog to 5.1.0 to match VERSION

--- a/debian/trixie/foreman/control
+++ b/debian/trixie/foreman/control
@@ -16,7 +16,7 @@ Section: web
 Priority: extra
 Depends: ruby (>= 1:2.7), ruby-dev, zlib1g-dev, libcap-dev,
          build-essential, tzdata, libyaml-dev, libffi-dev,
-         rake (>=0.8.4), gawk, ${misc:Depends}
+         rake (>=0.8.4), gawk, openssh-client, sshpass, ${misc:Depends}
 Recommends: foreman-proxy, foreman-debug (= ${binary:Version})
 Conflicts: ruby-activerecord-deprecated-finders, ruby-foreman-tasks (<< 0.10.1), ruby-sequel-pg, ruby-foreman-hooks (<= 0.3.17)
 Replaces: foreman-compute, foreman-rackspace


### PR DESCRIPTION
### What

Add `openssh-client` and `sshpass` to the foreman package `Depends` across all supported releases (bookworm, jammy, noble, trixie).

### Why

The foreman package shells out to `sshpass`, which in turn invokes the `ssh` client binary at runtime. This adds explicit runtime dependencies so both are guaranteed present:

- `sshpass` — non-interactive ssh password helper
- `openssh-client` — provides `/usr/bin/ssh` that sshpass invokes (the bare `ssh` package is a metapackage that would also pull in an SSH server, which is not wanted here)

This mirrors the equivalent RPM change. Each release's changelog is bumped to `5.1.0-2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)